### PR TITLE
Add pinned nixpkgs to common nix repo

### DIFF
--- a/cardano-sl/nixpkgs-src.json
+++ b/cardano-sl/nixpkgs-src.json
@@ -1,0 +1,5 @@
+{
+  "url": "https://github.com/input-output-hk/nixpkgs",
+  "rev": "d4cd290a9a1b2ee7ac67ca87d5ffc2f3941157c0",
+  "sha256": "1kxkhccvwc3m9wdk9p57bafzgplk68j5l3rh7bkg6hdrzslyw4mh"
+}

--- a/clean-source-haskell.nix
+++ b/clean-source-haskell.nix
@@ -1,9 +1,8 @@
-pkgs: src:
-  let lib = pkgs.lib;
-  in if (builtins.typeOf src) == "path"
+{ lib }: src:
+  if (builtins.typeOf src) == "path"
     then lib.cleanSourceWith {
-      filter = with pkgs.stdenv;
-        name: type: let baseName = baseNameOf (toString name); in ! (
+      filter = name: type:
+        let baseName = baseNameOf (toString name); in ! (
           # Filter out cabal build products.
           baseName == "dist" || baseName == "dist-newstyle" ||
           baseName == "cabal.project.local" ||

--- a/daedalus/nixpkgs-src.json
+++ b/daedalus/nixpkgs-src.json
@@ -1,0 +1,5 @@
+{
+  "url": "https://github.com/input-output-hk/nixpkgs",
+  "rev": "fda4b93cd4fd3775408117c380aab0f33737d30f",
+  "sha256": "0f3nnsqgr1qpy9h65ssfmwj6c5nxadk3p043qca4glzw2k5pyrpw"
+}

--- a/default.nix
+++ b/default.nix
@@ -1,10 +1,40 @@
-{
-  fetchNixpkgs = import ./fetch-nixpkgs.nix;
-  cleanSourceHaskell = import ./clean-source-haskell.nix;
-  haskellPackages = ./haskell-packages.nix;
-  maybeEnv = import ./maybe-env.nix;
-  jemallocOverlay = import ./overlays/jemalloc.nix;
-  getPackages = import ./get-packages.nix;
+{ config ? {}
+, system ? builtins.currentSystem
+}:
+
+rec {
+  commonLib = {
+    fetchNixpkgs = import ./fetch-nixpkgs.nix;
+    maybeEnv = import ./maybe-env.nix;
+  };
+
+  # Overlay which adds more functions to pkgs.lib
+  extraLib = self: super: {
+    lib = super.lib.extend (lib: _: {
+      cleanSourceHaskell = import ./clean-source-haskell.nix { inherit lib; };
+      getPackages = import ./get-packages.nix { inherit lib; };
+      commitIdFromGitRepo = import ./commit-id.nix { inherit lib; };
+    });
+  };
+
+  cardano-sl = rec {
+    pkgs = import (commonLib.fetchNixpkgs ./cardano-sl/nixpkgs-src.json) {
+      inherit config system;
+      overlays = [
+        (import ./overlays/jemalloc.nix)
+        extraLib
+      ];
+    };
+    haskellPackages = args: import ./haskell-packages.nix (args // { inherit pkgs; });
+  };
+
+  daedalus = {
+    pkgs = import (commonLib.fetchNixpkgs ./daedalus/nixpkgs-src.json) {
+      inherit config system;
+      # overlays = [ extraLib ]; # needs nixpkgs-18.09
+    };
+  };
+
   tests = {
     hlint = ./tests/hlint.nix;
     shellcheck = ./tests/shellcheck.nix;


### PR DESCRIPTION
If there are multiple cardano repos it would make sense to have `iohk-nix` provide the pinned nixpkgs set -- as well as library functions depending on nixpkgs.
