### PR TITLE
[DEVOPS-1120] Add nix-tools to common nix config

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -33,6 +33,15 @@ let
     haskellPackages = import ./haskell-packages.nix;
     commitIdFromGitRepo = pkgs.callPackage ./commit-id.nix {};
   };
+  nix-tools = rec {
+    # Programs for generating nix haskell package sets from cabal and
+    # stack.yaml files.
+    package = commonLib.pkgs.callPackage ./nix-tools.nix {};
+    # Script to invoke nix-tools stack-to-nix on a repo.
+    regeneratePackages =  commonLib.pkgs.callPackage ./nix-tools-regenerate.nix {
+      nix-tools = package;
+    };
+  };
 
   tests = {
     hlint = ./tests/hlint.nix;
@@ -41,6 +50,6 @@ let
   };
 
 in {
-  inherit tests jemallocOverlay;
+  inherit tests nix-tools jemallocOverlay;
   inherit (commonLib) pkgs haskellPackages fetchNixpkgs maybeEnv cleanSourceHaskell getPkgs nixpkgs commitIdFromGitRepo getPackages;
 }

--- a/nix-tools-regenerate.nix
+++ b/nix-tools-regenerate.nix
@@ -1,0 +1,10 @@
+# A script for generating the nix haskell package set based on stackage,
+# using the common convention for repo layout.
+
+{ nix-tools, writeScript }:
+
+writeScript "nix-tools-regenerate" ''
+  # stack-to-nix will transform the stack.yaml file into something
+  # nix can understand.
+  ${nix-tools}/bin/stack-to-nix -o nix stack.yaml > nix/.stack-pkgs.nix
+''

--- a/nix-tools-regenerate.nix
+++ b/nix-tools-regenerate.nix
@@ -1,10 +1,34 @@
 # A script for generating the nix haskell package set based on stackage,
 # using the common convention for repo layout.
 
-{ nix-tools, writeScript }:
+{ lib, stdenv, path, writeScript, nix-tools, coreutils, nix, nix-prefetch-git }:
 
-writeScript "nix-tools-regenerate" ''
-  # stack-to-nix will transform the stack.yaml file into something
-  # nix can understand.
-  ${nix-tools}/bin/stack-to-nix -o nix stack.yaml > nix/.stack-pkgs.nix
-''
+let
+  deps = [ nix-tools coreutils nix nix-prefetch-git ];
+
+in
+  writeScript "nix-tools-regenerate" ''
+    #!${stdenv.shell}
+    #
+    # Haskell package set regeneration script.
+    #
+    # stack-to-nix will transform the stack.yaml file into something
+    # nix can understand.
+    #
+
+    set -euo pipefail
+    export PATH=${lib.makeBinPath deps}
+    export NIX_PATH=nixpkgs=${path}
+
+    dest=nix/.stack-pkgs.nix
+
+    function cleanup {
+      rm -f "$dest.new"
+    }
+    trap cleanup EXIT
+
+    stack-to-nix -o nix stack.yaml > "$dest.new"
+    mv "$dest.new" "$dest"
+
+    echo "Wrote $dest"
+  ''

--- a/nix-tools.nix
+++ b/nix-tools.nix
@@ -6,8 +6,8 @@ let
   src = pkgs.fetchFromGitHub {
     owner = "angerman";
     repo = "nix-tools";
-    rev = "b7835666bcf73c3fa50f5c59bfa4cac29ea8d626";
-    sha256 = "1pnw10jvlb6gld6ja294yzf4mlnc8a0sxml3d0mhgi7ns4zr9ggy";
+    rev = "35c161984661667a44f92c57b1d7df7222ce0e86";
+    sha256 = "0bw9w733viacf32izr70rvmmrrdsjhjw7yi0hgwbjzwzilnhrks6";
     fetchSubmodules = true;
   };
   nix-tools = import src { inherit pkgs; };

--- a/nix-tools.nix
+++ b/nix-tools.nix
@@ -6,8 +6,8 @@ let
   src = pkgs.fetchFromGitHub {
     owner = "angerman";
     repo = "nix-tools";
-    rev = "9b1066f5613b35037231cf2dbb6db25cb60c4205";
-    sha256 = "0h03dv1g2ykdhdkvbzlwfyykwmvf5pqw4672x7mbx8vzm1i0s1q0";
+    rev = "b7835666bcf73c3fa50f5c59bfa4cac29ea8d626";
+    sha256 = "1pnw10jvlb6gld6ja294yzf4mlnc8a0sxml3d0mhgi7ns4zr9ggy";
   };
   nix-tools = import src { inherit pkgs; };
 in

--- a/nix-tools.nix
+++ b/nix-tools.nix
@@ -8,6 +8,7 @@ let
     repo = "nix-tools";
     rev = "b7835666bcf73c3fa50f5c59bfa4cac29ea8d626";
     sha256 = "1pnw10jvlb6gld6ja294yzf4mlnc8a0sxml3d0mhgi7ns4zr9ggy";
+    fetchSubmodules = true;
   };
   nix-tools = import src { inherit pkgs; };
 in

--- a/nix-tools.nix
+++ b/nix-tools.nix
@@ -1,0 +1,14 @@
+# Import and build nix-tools, which is used for generating haskell
+# package sets in nix.
+
+{ pkgs }:
+let
+  src = pkgs.fetchFromGitHub {
+    owner = "angerman";
+    repo = "nix-tools";
+    rev = "9b1066f5613b35037231cf2dbb6db25cb60c4205";
+    sha256 = "0h03dv1g2ykdhdkvbzlwfyykwmvf5pqw4672x7mbx8vzm1i0s1q0";
+  };
+  nix-tools = import src { inherit pkgs; };
+in
+  nix-tools.nix-tools-all-execs


### PR DESCRIPTION
This is added so that `cardano-*` repos can share the nix-tools regeneration script and all use a consistent convention for where the generated files go.
