### PR TITLE
Profiling: fix disabling profiling

### DIFF
--- a/haskell-packages.nix
+++ b/haskell-packages.nix
@@ -36,7 +36,7 @@ let
       then filterOverrides.benchmark else filter;
   };
   profilingOverlay    = import ./overlays/profile.nix       {
-    inherit pkgs;
+    inherit pkgs enableProfiling;
     filter = if builtins.hasAttr "profiling" filterOverrides
       then filterOverrides.profiling else filter;
   };
@@ -60,7 +60,7 @@ let
   };
 
   activeOverlays = [ requiredOverlay' ]
-      ++ optional enableProfiling profilingOverlay
+      ++ [profilingOverlay]
       ++ optional enablePhaseMetrics metricOverlay
       ++ optional enableBenchmarks benchmarkOverlay
       ++ optional enableDebugging debugOverlay

--- a/overlays/profile.nix
+++ b/overlays/profile.nix
@@ -1,10 +1,26 @@
-{ pkgs, filter }:
+{ pkgs, filter, enableProfiling }:
 
 with pkgs.lib;
 
+# The nixpkgs defaults are to enable library profiling and disable executable profiling.
+# We would like to enable both when profiling is enabled, and disable both when it is disabled,
+# so we need this overlay unconditionally to set them both to the same, we can't leave
+# it to the defaults.
 self: super: {
-  mkDerivation = args: super.mkDerivation (args // optionalAttrs (filter args.pname) {
-    enableLibraryProfiling = true;
-    enableExecutableProfiling = true;
-  });
+  # Try and prevent rebuilds by leaving the original attribute in place: in particular, if it doesn't have the
+  # attribute set and we're not enabling profiling, don't add the attribute set to false, as this will be a rebuild
+  mkDerivation = args: super.mkDerivation (args // (optionalAttrs (args ? enableLibraryProfiling || enableProfiling) {
+    # For non-filtered packages:
+    # - Ignore executable profiling
+    # - Control library profiling, but if we were going to already build with profiling then
+    #   do that - it costs us nothing and reduces rebuilds.
+    enableLibraryProfiling = (args ? enableLibraryProfiling && args.enableLibraryProfiling) || enableProfiling;
+  }) //
+  (optionalAttrs (filter args.pname) {
+    # For filtered packages:
+    # - Control executable profiling
+    # - Control library profiling
+    enableExecutableProfiling = enableProfiling;
+    enableLibraryProfiling = enableProfiling;
+  }));
 }


### PR DESCRIPTION
The nixpkgs default is to enable library profiling, so turning off the
overlay won't disable profiling, we need to explicitly do it.

Also restructured the overlay a bit to be very careful about avoiding
rebuilds.

This fails for me with a linker error when trying to build the test
suite for `language-plutus-core` with profiling enabled, but that was
already true when profiling was enabled, so that's a separate issue.

Fixes #12.