### PR TITLE
Add stack2nix regeneration script

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -44,6 +44,7 @@ let
     haskellPackages = import ./haskell-packages.nix;
     commitIdFromGitRepo = pkgs.callPackage ./commit-id.nix {};
   };
+
   nix-tools = rec {
     # Programs for generating nix haskell package sets from cabal and
     # stack.yaml files.
@@ -51,8 +52,14 @@ let
       pkgs = commonLib.pkgsDefault;
     };
     # Script to invoke nix-tools stack-to-nix on a repo.
-    regeneratePackages =  commonLib.pkgsDefault.callPackage ./nix-tools-regenerate.nix {
+    regeneratePackages = commonLib.pkgsDefault.callPackage ./nix-tools-regenerate.nix {
       nix-tools = package;
+    };
+  };
+
+  stack2nix = rec {
+    regeneratePackages = {hackageSnapshot}: commonLib.pkgsDefault.callPackage ./stack2nix-regenerate.nix {
+      inherit hackageSnapshot;
     };
   };
 
@@ -63,6 +70,6 @@ let
   };
 
 in {
-  inherit tests nix-tools jemallocOverlay;
+  inherit tests nix-tools stack2nix jemallocOverlay;
   inherit (commonLib) pkgs haskellPackages fetchNixpkgs maybeEnv cleanSourceHaskell getPkgs nixpkgs commitIdFromGitRepo getPackages;
 }

--- a/stack2nix-regenerate.nix
+++ b/stack2nix-regenerate.nix
@@ -1,0 +1,55 @@
+{ stdenv
+, lib
+, writeScript
+, nixStable
+, coreutils
+, git
+, findutils
+, cabal2nix
+, glibcLocales
+, stack
+, cabal-install
+, stack2nix
+, path
+# Set this to a recent enough date that include any package versions that you need from hackage.
+# Any timestamp works.
+, hackageSnapshot
+}:
+
+let
+  deps = [ nixStable coreutils git findutils cabal2nix glibcLocales stack cabal-install stack2nix ];
+in
+  writeScript "generate" ''
+    #!${stdenv.shell}
+    #
+    # Haskell package set regeneration script.
+    #
+    # stack2nix will transform the stack.yaml file into something
+    # nix can understand.
+    # 
+    # Takes one argument which is the file to write the package set into.
+
+    set -euo pipefail
+    export PATH=${lib.makeBinPath deps}
+    export HOME=$(pwd)
+    export NIX_PATH=nixpkgs=${path}
+
+    echo "Using hackage snapshot from ${hackageSnapshot}"
+
+    # Ensure that nix 1.11 (used by cabal2nix) works in multi-user mode.
+    if [ ! -w /nix/store ]; then
+        export NIX_REMOTE=''${NIX_REMOTE:-daemon}
+    fi
+
+    dest=$1
+    function cleanup {
+      rm -f "$dest.new"
+    }
+    trap cleanup EXIT
+
+    # Generate package set
+    stack2nix --platform x86_64-linux --hackage-snapshot "${hackageSnapshot}" -j8 --test --bench --no-indent ../. > "$dest.new"
+    mv "$dest.new" "$dest"
+
+    echo "Wrote $dest"
+  ''


### PR DESCRIPTION
Also tweaked to be very similar to the nix-tools version. One difference
(which might be an improvement for the nix-tools script too) is taking
the output location as an argument, since we probably don't want to be
too prescriptive about that.

The hackage snapshot remains as an argument to the nix derivation so that we can
make a pinned regeneration script in a project's `default.nix`, since I would argue
that this is a slightly more important piece of data and should appear
with the rest of the nix configuration rather than be hidden in a script
argument.