### PR TITLE
Update default-pin to current iohk-18.09 branch

### DIFF
--- a/nixpkgs-pins/default-nixpkgs-src.json
+++ b/nixpkgs-pins/default-nixpkgs-src.json
@@ -1,6 +1,6 @@
 {
   "url": "https://github.com/input-output-hk/nixpkgs",
-  "rev": "ce68b263fe25a05a1111acac8ccbe538d139d2dc",
-  "sha256": "0b0r5zz4qfbr8x5gi60lwdxpnr670mk49idldh6sh66z315hmb0p",
+  "rev": "3ff97c12fa19a197eb8ddee634ff2f3d4f02ad31",
+  "sha256": "125sy7118bmxprxlbyg1scxmjpq092xlj207xzy7l23j6arw8sbx",
   "fetchSubmodules": false
 }


### PR DESCRIPTION
Among other things, this includes GHC 8.4.4 (current has only 8.4.3), so this is needed to use newer Stackage LTS snapshots.