### PR TITLE
Fix isLibrary checks

### DIFF
--- a/overlays/benchmark.nix
+++ b/overlays/benchmark.nix
@@ -1,5 +1,10 @@
 let
-  isBenchmark = args: !((args.isExecutable or false) || (args.isLibrary or true));
+  # The Haskell generic builder falls back to checking 'isExecutable' if 'isLibrary' 
+  # is not provided. Tools like cabal2nix therefore often don't provide 'isLibrary', so
+  # we need to mimic that logic here.
+  isExecutable = args: args.isExecutable or false;
+  isLibrary = args: args.isLibrary or (!(isExecutable args));
+  isBenchmark = args: !((isExecutable args) || (isLibrary args));
 
 in { pkgs, filter }:
 


### PR DESCRIPTION
The Haskell generic builder falls back to checking `isExecutable` if
the `isLibrary` argument is not set. Tools like `cabal2nix` sometimes
indeed do not set `isLibrary`, so we need to mimic that logic, since we
don't have access to the "computed" answer.

Without this we incorrectly think that packages with a library but not
an executable (for which `cabal2nix` does not set `isLibrary`) are not
libraries, and thus don't Haddock them etc.