### PR TITLE
Bump nixpkgs to include ghc-8.6.3

### DIFF
--- a/nixpkgs-pins/default-nixpkgs-src.json
+++ b/nixpkgs-pins/default-nixpkgs-src.json
@@ -1,6 +1,6 @@
 {
   "url": "https://github.com/input-output-hk/nixpkgs",
-  "rev": "ce68b263fe25a05a1111acac8ccbe538d139d2dc",
-  "sha256": "0b0r5zz4qfbr8x5gi60lwdxpnr670mk49idldh6sh66z315hmb0p",
+  "rev": "f9bd1533773e5fd3576b07cd7a39215b0cb3dad9",
+  "sha256": "1haja4iasxc6pnm7pyblpv80gpcsqb0lx5jlc3kvs8qcgwfqhmaf",
   "fetchSubmodules": false
 }


### PR DESCRIPTION
This probably conflicts with #18. As we really only care for the compilers. I wonder if it would make our life easier if we had the compilers in our own repository. They could happily live next to haskell.nix.