### PR TITLE
Moves nix-tools standard templates into iohk-nix

### DIFF
--- a/config.nix
+++ b/config.nix
@@ -39,6 +39,7 @@
           ./patches/ghc/ghc-8.4.3-Cabal2201-no-hackage-tests.patch
           ./patches/ghc/ghc-8.4.3-Cabal2201-allow-test-wrapper.patch
           ./patches/ghc/ghc-8.4.3-Cabal2201-response-file-support.patch
+          ./patches/ghc/ghc-8.6-Cabal-fix-datadir.patch
           ./patches/ghc/MR95--ghc-pkg-deadlock-fix.patch
           ./patches/ghc/MR196--ghc-pkg-shut-up.patch
          ];

--- a/default.nix
+++ b/default.nix
@@ -60,6 +60,7 @@ let
     default-nix = import ./nix-tools-default.nix (commonLib // { inherit nix-tools; });
     release-nix = import ./nix-tools-release.nix (commonLib // { inherit nix-tools; });
     iohk-module = import ./nix-tools-iohk-module.nix commonLib;
+    iohk-overlay = import ./nix-tools-iohk-overlay.nix commonLib;
   };
 
   stack2nix = rec {

--- a/default.nix
+++ b/default.nix
@@ -55,6 +55,11 @@ let
     regeneratePackages = commonLib.pkgsDefault.callPackage ./nix-tools-regenerate.nix {
       nix-tools = package;
     };
+    # default and release templates that abstract
+    # over the details for CI.
+    default-nix = import ./nix-tools-default.nix (commonLib // { inherit nix-tools; });
+    release-nix = import ./nix-tools-release.nix (commonLib // { inherit nix-tools; });
+    iohk-module = import ./nix-tools-iohk-module.nix commonLib;
   };
 
   stack2nix = rec {

--- a/default.nix
+++ b/default.nix
@@ -59,7 +59,16 @@ let
     # over the details for CI.
     default-nix = import ./nix-tools-default.nix (commonLib // { inherit nix-tools; });
     release-nix = import ./nix-tools-release.nix (commonLib // { inherit nix-tools; });
+
+    # default iohk module and overlay to be used in the pkgs.nix file of the
+    # project.  The module will provide the necessary default overrides for
+    # packages (patches) to work properly in cross compiled settings.
     iohk-module = import ./nix-tools-iohk-module.nix commonLib;
+    # The overlay provides the necessary extra packages that might be missing
+    # from generated plans (mostly from stackage snapshot) as well as patches
+    # to align the packages downloaded from hackage with what GHC ships as those
+    # packages.  That a package of a given version on hackage is identical to
+    # the package that ghc ships with the same version is not a given!
     iohk-overlay = import ./nix-tools-iohk-overlay.nix commonLib;
   };
 

--- a/docs/nix-toolification.org
+++ b/docs/nix-toolification.org
@@ -126,8 +126,8 @@ in rec {
   haskell = import (overrideWith "haskell"
                     (pkgs.fetchFromGitHub { owner  = "angerman";
                                             repo   = "haskell.nix";
-                                            rev    = "3a6c2f823d0db6ac6730dcf78076fd5d904fba85";
-                                            sha256 = "1cv4kw2mfk8d3ck7z5vf8380489z5128638jk919am4iqq5g8k5w";
+                                            rev    = "ed456599a3a52592ffede765e9d12a953b77d606";
+                                            sha256 = "0w7dg50y30zm7k5ilw0mhkggzhmzpb7x8cl2b82iizvscx6xffzc";
                                             name   = "haskell-lib-source"; }))
                    hackage;
 

--- a/docs/nix-toolification.org
+++ b/docs/nix-toolification.org
@@ -116,7 +116,7 @@ let
      default;
 in rec {
   hackage = import (overrideWith "hackage"
-                    (pkgs.fetchFromGitHub { owner  = "angerman";
+                    (pkgs.fetchFromGitHub { owner  = "input-output-hk";
                                             repo   = "hackage.nix";
                                             rev    = "d4ef2536554d78c6adf368816a4476bc909fcd96";
                                             sha256 = "15siby9iwgi8bhkj83q1djvg6b6n4gj08n7yy66ccjck7fw4hbr8";
@@ -124,7 +124,7 @@ in rec {
                    ;
   # a different haskell infrastructure
   haskell = import (overrideWith "haskell"
-                    (pkgs.fetchFromGitHub { owner  = "angerman";
+                    (pkgs.fetchFromGitHub { owner  = "input-output-hk";
                                             repo   = "haskell.nix";
                                             rev    = "ed456599a3a52592ffede765e9d12a953b77d606";
                                             sha256 = "0w7dg50y30zm7k5ilw0mhkggzhmzpb7x8cl2b82iizvscx6xffzc";
@@ -133,7 +133,7 @@ in rec {
 
   # the set of all stackage snapshots
   stackage = import (overrideWith "stackage"
-                     (pkgs.fetchFromGitHub { owner  = "angerman";
+                     (pkgs.fetchFromGitHub { owner  = "input-output-hk";
                                              repo   = "stackage.nix";
                                              rev    = "f58d5b78e7a40260c6142c79e52c2bf3ae9876b9";
                                              sha256 = "1nd9lfm016rlhw3133488f8v8x3lbxrld422gw8gcjhhfls3civn";

--- a/ghc-packages/base-4.12.0.0.nix
+++ b/ghc-packages/base-4.12.0.0.nix
@@ -1,0 +1,33 @@
+{ system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
+  {
+    flags = { integer-simple = false; integer-gmp = false; };
+    package = {
+      specVersion = "2.1";
+      identifier = { name = "base"; version = "4.12.0.0"; };
+      license = "BSD-3-Clause";
+      copyright = "";
+      maintainer = "libraries@haskell.org";
+      author = "";
+      homepage = "";
+      url = "";
+      synopsis = "Basic libraries";
+      description = "This package contains the Standard Haskell \"Prelude\" and its support libraries,\nand a large collection of useful libraries ranging from data\nstructures to parsing combinators and debugging utilities.";
+      buildType = "Configure";
+      };
+    components = {
+      "library" = {
+        depends = (([
+          (hsPkgs.rts)
+          (hsPkgs.ghc-prim)
+          ] ++ (pkgs.lib).optional (!(flags.integer-gmp && !flags.integer-simple || !flags.integer-gmp && flags.integer-simple)) (hsPkgs.invalid-cabal-flag-settings)) ++ (pkgs.lib).optional (flags.integer-simple) (hsPkgs.integer-simple)) ++ (pkgs.lib).optional (flags.integer-gmp) (hsPkgs.integer-gmp);
+        libs = (pkgs.lib).optionals (system.isWindows) [
+          (pkgs."wsock32")
+          (pkgs."user32")
+          (pkgs."shell32")
+          (pkgs."msvcrt")
+          (pkgs."mingw32")
+          (pkgs."mingwex")
+          ];
+        };
+      };
+    } // rec { src = pkgs.fetchurl { url = http://releases.mobilehaskell.org/ghc-packages/base-4.12.0.0.tar.gz; sha256 = "1ajhyyqi1c9gqdmd9icc0zc0dlb64zvcap7dxm982cqd3qksjrd1"; }; }

--- a/ghc-packages/ghc-boot-8.4.4.nix
+++ b/ghc-packages/ghc-boot-8.4.4.nix
@@ -1,0 +1,38 @@
+{ system
+, compiler
+, flags
+, pkgs
+, hsPkgs
+, pkgconfPkgs
+, ... }:
+  {
+    flags = {};
+    package = {
+      specVersion = "1.22";
+      identifier = {
+        name = "ghc-boot";
+        version = "8.4.4";
+      };
+      license = "BSD-3-Clause";
+      copyright = "";
+      maintainer = "ghc-devs@haskell.org";
+      author = "";
+      homepage = "";
+      url = "";
+      synopsis = "Shared functionality between GHC and its boot libraries";
+      description = "This library is shared between GHC, ghc-pkg, and other boot\nlibraries.\n\nA note about \"GHC.PackageDb\": it only deals with the subset of\nthe package database that the compiler cares about: modules\npaths etc and not package metadata like description, authors\netc. It is thus not a library interface to ghc-pkg and is *not*\nsuitable for modifying GHC package databases.\n\nThe package database format and this library are constructed in\nsuch a way that while ghc-pkg depends on Cabal, the GHC library\nand program do not have to depend on Cabal.";
+      buildType = "Simple";
+    };
+    components = {
+      "library" = {
+        depends  = [
+          (hsPkgs.base)
+          (hsPkgs.binary)
+          (hsPkgs.bytestring)
+          (hsPkgs.directory)
+          (hsPkgs.filepath)
+          (hsPkgs.ghc-boot-th)
+        ];
+      };
+    };
+  } // rec { src = pkgs.fetchurl { url = https://s3.eu-central-1.amazonaws.com/ci-static/ghc-cross-windows/ghc-boot-8.4.4.tar.gz; sha256 = "1y72cixzk2zrnha8rqyx9j2q109jb64p1l14g3smvrn9nwwnif2m"; }; }

--- a/ghc-packages/ghc-boot-8.6.1.nix
+++ b/ghc-packages/ghc-boot-8.6.1.nix
@@ -1,0 +1,29 @@
+{ system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
+  {
+    flags = {};
+    package = {
+      specVersion = "1.22";
+      identifier = { name = "ghc-boot"; version = "8.6.1"; };
+      license = "BSD-3-Clause";
+      copyright = "";
+      maintainer = "ghc-devs@haskell.org";
+      author = "";
+      homepage = "";
+      url = "";
+      synopsis = "Shared functionality between GHC and its boot libraries";
+      description = "This library is shared between GHC, ghc-pkg, and other boot\nlibraries.\n\nA note about \"GHC.PackageDb\": it only deals with the subset of\nthe package database that the compiler cares about: modules\npaths etc and not package metadata like description, authors\netc. It is thus not a library interface to ghc-pkg and is *not*\nsuitable for modifying GHC package databases.\n\nThe package database format and this library are constructed in\nsuch a way that while ghc-pkg depends on Cabal, the GHC library\nand program do not have to depend on Cabal.";
+      buildType = "Simple";
+      };
+    components = {
+      "library" = {
+        depends = [
+          (hsPkgs.base)
+          (hsPkgs.binary)
+          (hsPkgs.bytestring)
+          (hsPkgs.directory)
+          (hsPkgs.filepath)
+          (hsPkgs.ghc-boot-th)
+          ];
+        };
+      };
+    } // rec { src = pkgs.fetchurl { url = http://releases.mobilehaskell.org/ghc-packages/ghc-boot-8.6.1.tar.gz; sha256 = "0ba38382ms1xihr6vrf8mpg0jd2yvkr52yxq79v4a7i2hf809lbs"; }; }

--- a/ghc-packages/ghc-boot-8.6.2.nix
+++ b/ghc-packages/ghc-boot-8.6.2.nix
@@ -1,0 +1,29 @@
+{ system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
+  {
+    flags = {};
+    package = {
+      specVersion = "1.22";
+      identifier = { name = "ghc-boot"; version = "8.6.2"; };
+      license = "BSD-3-Clause";
+      copyright = "";
+      maintainer = "ghc-devs@haskell.org";
+      author = "";
+      homepage = "";
+      url = "";
+      synopsis = "Shared functionality between GHC and its boot libraries";
+      description = "This library is shared between GHC, ghc-pkg, and other boot\nlibraries.\n\nA note about \"GHC.PackageDb\": it only deals with the subset of\nthe package database that the compiler cares about: modules\npaths etc and not package metadata like description, authors\netc. It is thus not a library interface to ghc-pkg and is *not*\nsuitable for modifying GHC package databases.\n\nThe package database format and this library are constructed in\nsuch a way that while ghc-pkg depends on Cabal, the GHC library\nand program do not have to depend on Cabal.";
+      buildType = "Simple";
+      };
+    components = {
+      "library" = {
+        depends = [
+          (hsPkgs.base)
+          (hsPkgs.binary)
+          (hsPkgs.bytestring)
+          (hsPkgs.directory)
+          (hsPkgs.filepath)
+          (hsPkgs.ghc-boot-th)
+          ];
+        };
+      };
+    } // rec { src = pkgs.fetchurl { url = http://releases.mobilehaskell.org/ghc-packages/ghc-boot-8.6.2.tar.gz; sha256 = "0y96yqrbcjg6l5l2y9sm2llyk37zrzg2bb0lj3k16ld29j05g1gw"; }; }

--- a/ghc-packages/ghc-boot-8.6.3.nix
+++ b/ghc-packages/ghc-boot-8.6.3.nix
@@ -1,0 +1,29 @@
+{ system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
+  {
+    flags = {};
+    package = {
+      specVersion = "1.22";
+      identifier = { name = "ghc-boot"; version = "8.6.3"; };
+      license = "BSD-3-Clause";
+      copyright = "";
+      maintainer = "ghc-devs@haskell.org";
+      author = "";
+      homepage = "";
+      url = "";
+      synopsis = "Shared functionality between GHC and its boot libraries";
+      description = "This library is shared between GHC, ghc-pkg, and other boot\nlibraries.\n\nA note about \"GHC.PackageDb\": it only deals with the subset of\nthe package database that the compiler cares about: modules\npaths etc and not package metadata like description, authors\netc. It is thus not a library interface to ghc-pkg and is *not*\nsuitable for modifying GHC package databases.\n\nThe package database format and this library are constructed in\nsuch a way that while ghc-pkg depends on Cabal, the GHC library\nand program do not have to depend on Cabal.";
+      buildType = "Simple";
+      };
+    components = {
+      "library" = {
+        depends = [
+          (hsPkgs.base)
+          (hsPkgs.binary)
+          (hsPkgs.bytestring)
+          (hsPkgs.directory)
+          (hsPkgs.filepath)
+          (hsPkgs.ghc-boot-th)
+          ];
+        };
+      };
+    } // rec { src = pkgs.fetchurl { url = http://releases.mobilehaskell.org/ghc-packages/ghc-boot-8.6.3.tar.gz; sha256 = "0b93j8w4gd7793qzdq8lqy63k9lw4kxh50dlr56is1niw6c1hzgw"; }; }

--- a/ghc-packages/ghci-8.4.4.nix
+++ b/ghc-packages/ghci-8.4.4.nix
@@ -1,0 +1,43 @@
+{ system
+, compiler
+, flags
+, pkgs
+, hsPkgs
+, pkgconfPkgs
+, ... }:
+  {
+    flags = { ghci = false; };
+    package = {
+      specVersion = "1.10";
+      identifier = {
+        name = "ghci";
+        version = "8.4.4";
+      };
+      license = "BSD-3-Clause";
+      copyright = "";
+      maintainer = "ghc-devs@haskell.org";
+      author = "";
+      homepage = "";
+      url = "";
+      synopsis = "The library supporting GHC's interactive interpreter";
+      description = "This library offers interfaces which mediate interactions between the\n@ghci@ interactive shell and @iserv@, GHC's out-of-process interpreter\nbackend.";
+      buildType = "Simple";
+    };
+    components = {
+      "library" = {
+        depends  = [
+          (hsPkgs.array)
+          (hsPkgs.base)
+          (hsPkgs.binary)
+          (hsPkgs.bytestring)
+          (hsPkgs.containers)
+          (hsPkgs.deepseq)
+          (hsPkgs.filepath)
+          (hsPkgs.ghc-boot)
+          (hsPkgs.ghc-boot-th)
+          (hsPkgs.template-haskell)
+          (hsPkgs.transformers)
+        ] ++ pkgs.lib.optional (!system.isWindows) (hsPkgs.unix);
+      };
+    };
+  } // rec { src = pkgs.fetchurl { url = https://s3.eu-central-1.amazonaws.com/ci-static/ghc-cross-windows/ghci-8.4.4.tar.gz; sha256 = "1xr91qg32f1z0r380yypkzayd90936y5chhdbqf9g02x7rcvnv18"; }; }

--- a/ghc-packages/ghci-8.6.1.nix
+++ b/ghc-packages/ghci-8.6.1.nix
@@ -1,0 +1,35 @@
+{ system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
+  {
+    flags = { ghci = false; };
+    package = {
+      specVersion = "1.10";
+      identifier = { name = "ghci"; version = "8.6.1"; };
+      license = "BSD-3-Clause";
+      copyright = "";
+      maintainer = "ghc-devs@haskell.org";
+      author = "";
+      homepage = "";
+      url = "";
+      synopsis = "The library supporting GHC's interactive interpreter";
+      description = "This library offers interfaces which mediate interactions between the\n@ghci@ interactive shell and @iserv@, GHC's out-of-process interpreter\nbackend.";
+      buildType = "Simple";
+      };
+    components = {
+      "library" = {
+        depends = [
+          (hsPkgs.array)
+          (hsPkgs.base)
+          (hsPkgs.binary)
+          (hsPkgs.bytestring)
+          (hsPkgs.containers)
+          (hsPkgs.deepseq)
+          (hsPkgs.filepath)
+          (hsPkgs.ghc-boot)
+          (hsPkgs.ghc-boot-th)
+          (hsPkgs.ghc-heap)
+          (hsPkgs.template-haskell)
+          (hsPkgs.transformers)
+          ] ++ (pkgs.lib).optional (!system.isWindows) (hsPkgs.unix);
+        };
+      };
+    } // rec { src = pkgs.fetchurl { url = http://releases.mobilehaskell.org/ghc-packages/ghci-8.6.1.tar.gz; sha256 = "0w6cmpzzby52dm26ga9q4q6260vmi1jan5f03k246f78jgrxj6ys"; }; }

--- a/ghc-packages/ghci-8.6.2.nix
+++ b/ghc-packages/ghci-8.6.2.nix
@@ -1,0 +1,35 @@
+{ system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
+  {
+    flags = { ghci = false; };
+    package = {
+      specVersion = "1.10";
+      identifier = { name = "ghci"; version = "8.6.2"; };
+      license = "BSD-3-Clause";
+      copyright = "";
+      maintainer = "ghc-devs@haskell.org";
+      author = "";
+      homepage = "";
+      url = "";
+      synopsis = "The library supporting GHC's interactive interpreter";
+      description = "This library offers interfaces which mediate interactions between the\n@ghci@ interactive shell and @iserv@, GHC's out-of-process interpreter\nbackend.";
+      buildType = "Simple";
+      };
+    components = {
+      "library" = {
+        depends = [
+          (hsPkgs.array)
+          (hsPkgs.base)
+          (hsPkgs.binary)
+          (hsPkgs.bytestring)
+          (hsPkgs.containers)
+          (hsPkgs.deepseq)
+          (hsPkgs.filepath)
+          (hsPkgs.ghc-boot)
+          (hsPkgs.ghc-boot-th)
+          (hsPkgs.ghc-heap)
+          (hsPkgs.template-haskell)
+          (hsPkgs.transformers)
+          ] ++ (pkgs.lib).optional (!system.isWindows) (hsPkgs.unix);
+        };
+      };
+    } // rec { src = pkgs.fetchurl { url = http://releases.mobilehaskell.org/ghc-packages/ghci-8.6.2.tar.gz; sha256 = "1ry1d8fyx7lh0qmns7vgsfr9rlzaagvz1nvixjnk7j37ql73h5s5"; }; }

--- a/ghc-packages/ghci-8.6.3.nix
+++ b/ghc-packages/ghci-8.6.3.nix
@@ -1,0 +1,35 @@
+{ system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
+  {
+    flags = { ghci = false; };
+    package = {
+      specVersion = "1.10";
+      identifier = { name = "ghci"; version = "8.6.3"; };
+      license = "BSD-3-Clause";
+      copyright = "";
+      maintainer = "ghc-devs@haskell.org";
+      author = "";
+      homepage = "";
+      url = "";
+      synopsis = "The library supporting GHC's interactive interpreter";
+      description = "This library offers interfaces which mediate interactions between the\n@ghci@ interactive shell and @iserv@, GHC's out-of-process interpreter\nbackend.";
+      buildType = "Simple";
+      };
+    components = {
+      "library" = {
+        depends = [
+          (hsPkgs.array)
+          (hsPkgs.base)
+          (hsPkgs.binary)
+          (hsPkgs.bytestring)
+          (hsPkgs.containers)
+          (hsPkgs.deepseq)
+          (hsPkgs.filepath)
+          (hsPkgs.ghc-boot)
+          (hsPkgs.ghc-boot-th)
+          (hsPkgs.ghc-heap)
+          (hsPkgs.template-haskell)
+          (hsPkgs.transformers)
+          ] ++ (pkgs.lib).optional (!system.isWindows) (hsPkgs.unix);
+        };
+      };
+    } // rec { src = pkgs.fetchurl { url = http://releases.mobilehaskell.org/ghc-packages/ghci-8.6.3.tar.gz; sha256 = "0715fx2zf0ng1shy9bfshj19l13y1rrwqcp54nzvb9raqxkg60w9"; }; }

--- a/ghc-packages/iserv-8.6.1.nix
+++ b/ghc-packages/iserv-8.6.1.nix
@@ -1,0 +1,33 @@
+{ system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
+  {
+    flags = {};
+    package = {
+      specVersion = "1.10";
+      identifier = { name = "iserv"; version = "8.6.1"; };
+      license = "BSD-3-Clause";
+      copyright = "XXX";
+      maintainer = "XXX";
+      author = "XXX";
+      homepage = "";
+      url = "";
+      synopsis = "iserv allows GHC to delegate Template Haskell computations";
+      description = "GHC can be provided with a path to the iserv binary with\n@-pgmi=/path/to/iserv-bin@, and will in combination with\n@-fexternal-interpreter@, compile Template Haskell though the\n@iserv-bin@ delegate. This is very similar to how ghcjs has been\ncompiling Template Haskell, by spawning a separate delegate (so\ncalled runner on the javascript vm) and evaluating the splices\nthere.\n\nTo use iserv with cross compilers, please see @libraries/libiserv@\nand @utils/iserv-proxy@.";
+      buildType = "Simple";
+      };
+    components = {
+      exes = {
+        "iserv" = {
+          depends = [
+            (hsPkgs.array)
+            (hsPkgs.base)
+            (hsPkgs.binary)
+            (hsPkgs.bytestring)
+            (hsPkgs.containers)
+            (hsPkgs.deepseq)
+            (hsPkgs.ghci)
+            (hsPkgs.libiserv)
+            ] ++ (pkgs.lib).optional (!system.isWindows) (hsPkgs.unix);
+          };
+        };
+      };
+    } // rec { src = pkgs.fetchurl { url = http://releases.mobilehaskell.org/ghc-packages/iserv-8.6.1.tar.gz; sha256 = "0jsxhfl1nkggv94md6n8bb5x777jl8nc5hdqx1h0r789ws3nxrr3"; }; }

--- a/ghc-packages/iserv-8.6.2.nix
+++ b/ghc-packages/iserv-8.6.2.nix
@@ -1,0 +1,33 @@
+{ system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
+  {
+    flags = {};
+    package = {
+      specVersion = "1.10";
+      identifier = { name = "iserv"; version = "8.6.2"; };
+      license = "BSD-3-Clause";
+      copyright = "XXX";
+      maintainer = "XXX";
+      author = "XXX";
+      homepage = "";
+      url = "";
+      synopsis = "iserv allows GHC to delegate Template Haskell computations";
+      description = "GHC can be provided with a path to the iserv binary with\n@-pgmi=/path/to/iserv-bin@, and will in combination with\n@-fexternal-interpreter@, compile Template Haskell though the\n@iserv-bin@ delegate. This is very similar to how ghcjs has been\ncompiling Template Haskell, by spawning a separate delegate (so\ncalled runner on the javascript vm) and evaluating the splices\nthere.\n\nTo use iserv with cross compilers, please see @libraries/libiserv@\nand @utils/iserv-proxy@.";
+      buildType = "Simple";
+      };
+    components = {
+      exes = {
+        "iserv" = {
+          depends = [
+            (hsPkgs.array)
+            (hsPkgs.base)
+            (hsPkgs.binary)
+            (hsPkgs.bytestring)
+            (hsPkgs.containers)
+            (hsPkgs.deepseq)
+            (hsPkgs.ghci)
+            (hsPkgs.libiserv)
+            ] ++ (pkgs.lib).optional (!system.isWindows) (hsPkgs.unix);
+          };
+        };
+      };
+    } // rec { src = pkgs.fetchurl { url = http://releases.mobilehaskell.org/ghc-packages/iserv-8.6.2.tar.gz; sha256 = "0ybcra29rwr1nj1751mvj96qbc6ifs9gvzp4fhk2f63ljgc8sd64"; }; }

--- a/ghc-packages/iserv-8.6.3.nix
+++ b/ghc-packages/iserv-8.6.3.nix
@@ -1,0 +1,33 @@
+{ system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
+  {
+    flags = {};
+    package = {
+      specVersion = "1.10";
+      identifier = { name = "iserv"; version = "8.6.3"; };
+      license = "BSD-3-Clause";
+      copyright = "XXX";
+      maintainer = "XXX";
+      author = "XXX";
+      homepage = "";
+      url = "";
+      synopsis = "iserv allows GHC to delegate Template Haskell computations";
+      description = "GHC can be provided with a path to the iserv binary with\n@-pgmi=/path/to/iserv-bin@, and will in combination with\n@-fexternal-interpreter@, compile Template Haskell though the\n@iserv-bin@ delegate. This is very similar to how ghcjs has been\ncompiling Template Haskell, by spawning a separate delegate (so\ncalled runner on the javascript vm) and evaluating the splices\nthere.\n\nTo use iserv with cross compilers, please see @libraries/libiserv@\nand @utils/iserv-proxy@.";
+      buildType = "Simple";
+      };
+    components = {
+      exes = {
+        "iserv" = {
+          depends = [
+            (hsPkgs.array)
+            (hsPkgs.base)
+            (hsPkgs.binary)
+            (hsPkgs.bytestring)
+            (hsPkgs.containers)
+            (hsPkgs.deepseq)
+            (hsPkgs.ghci)
+            (hsPkgs.libiserv)
+            ] ++ (pkgs.lib).optional (!system.isWindows) (hsPkgs.unix);
+          };
+        };
+      };
+    } // rec { src = pkgs.fetchurl { url = http://releases.mobilehaskell.org/ghc-packages/iserv-8.6.3.tar.gz; sha256 = "1hj7v998fl9b1ndlr66lrb04rlsmgwkclsjzz4dnsirky85mwq79"; }; }

--- a/ghc-packages/iserv-proxy-8.4.4.nix
+++ b/ghc-packages/iserv-proxy-8.4.4.nix
@@ -1,0 +1,45 @@
+{ system
+, compiler
+, flags
+, pkgs
+, hsPkgs
+, pkgconfPkgs
+, ... }:
+  {
+    flags = {};
+    package = {
+      specVersion = "1.10";
+      identifier = {
+        name = "iserv-proxy";
+        version = "8.5";
+      };
+      license = "BSD-3-Clause";
+      copyright = "XXX";
+      maintainer = "XXX";
+      author = "XXX";
+      homepage = "";
+      url = "";
+      synopsis = "iserv allows GHC to delegate Tempalte Haskell computations";
+      description = "GHC can be provided with a path to the iserv binary with\n@-pgmi=/path/to/iserv-bin@, and will in combination with\n@-fexternal-interpreter@, compile Template Haskell though the\n@iserv-bin@ delegate. This is very similar to how ghcjs has been\ncompiling Template Haskell, by spawning a separate delegate (so\ncalled runner on the javascript vm) and evaluating the splices\nthere.\n\niserv can also be used in combination with cross compilation. For\nthis, the @iserv-proxy@ needs to be built on the host, targeting the\nhost (as it is running on the host). @cabal install -flibrary\n-fproxy@ will yield the proxy.\n\nUsing the cabal for the target @arch-platform-target-cabal install\n-flibrary@ will build the required library that contains the ffi\n@startSlave@ function, which needs to be invoked on the target\n(e.g. in an iOS application) to start the remote iserv slave.\n\ncalling the GHC cross compiler with @-fexternal-interpreter\n-pgmi=\$HOME/.cabal/bin/iserv-proxy -opti\\<ip address\\> -opti\\<port\\>@\nwill cause it to compile Template Haskell via the remote at \\<ip address\\>.\n\nThus to get cross compilation with Template Haskell follow the\nfollowing receipt:\n\n* compile the iserv library for your target\n\n> iserv \$ arch-platform-target-cabal install -flibrary\n\n* setup an application for your target that calls the\n* startSlave function. This could be either haskell or your\n* targets ffi capable language, if needed.\n\n>  void startSlave(false /* verbose */, 5000 /* port */,\n>                  \"/path/to/storagelocation/on/target\");\n\n* build the iserv-proxy\n\n> iserv \$ cabal install -flibrary -fproxy\n* Start your iserv-slave app on your target running on say @10.0.0.1:5000@\n* compiler your sources with -fexternal-interpreter and the proxy\n\n> project \$ arch-platform-target-ghc ModuleContainingTH.hs \\\n>             -fexternal-interpreter \\\n>             -pgmi=\$HOME/.cabal/bin/iserv-proxy \\\n>             -opti10.0.0.1 -opti5000\n\nShould something not work as expected, provide @-opti-v@ for verbose\nlogging of the @iserv-proxy@.";
+      buildType = "Simple";
+    };
+    components = {
+      exes = {
+        "iserv-proxy" = {
+          depends  = [
+            (hsPkgs.array)
+            (hsPkgs.base)
+            (hsPkgs.binary)
+            (hsPkgs.bytestring)
+            (hsPkgs.containers)
+            (hsPkgs.deepseq)
+            (hsPkgs.ghci)
+            (hsPkgs.directory)
+            (hsPkgs.network)
+            (hsPkgs.filepath)
+            (hsPkgs.libiserv)
+          ];
+        };
+      };
+    };
+  } // rec { src = pkgs.fetchurl { url = https://s3.eu-central-1.amazonaws.com/ci-static/ghc-cross-windows/iserv-proxy-8.4.4.tar.gz; sha256 = "121mxf3575d9rh7z1nhahx0g2ch7pxqbr6fvy7557ddqn49w2114"; }; }

--- a/ghc-packages/iserv-proxy-8.6.1.nix
+++ b/ghc-packages/iserv-proxy-8.6.1.nix
@@ -1,0 +1,36 @@
+{ system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
+  {
+    flags = {};
+    package = {
+      specVersion = "1.10";
+      identifier = { name = "iserv-proxy"; version = "8.6.1"; };
+      license = "BSD-3-Clause";
+      copyright = "XXX";
+      maintainer = "XXX";
+      author = "XXX";
+      homepage = "";
+      url = "";
+      synopsis = "iserv allows GHC to delegate Tempalte Haskell computations";
+      description = "GHC can be provided with a path to the iserv binary with\n@-pgmi=/path/to/iserv-bin@, and will in combination with\n@-fexternal-interpreter@, compile Template Haskell though the\n@iserv-bin@ delegate. This is very similar to how ghcjs has been\ncompiling Template Haskell, by spawning a separate delegate (so\ncalled runner on the javascript vm) and evaluating the splices\nthere.\n\niserv can also be used in combination with cross compilation. For\nthis, the @iserv-proxy@ needs to be built on the host, targeting the\nhost (as it is running on the host). @cabal install -flibrary\n-fproxy@ will yield the proxy.\n\nUsing the cabal for the target @arch-platform-target-cabal install\n-flibrary@ will build the required library that contains the ffi\n@startSlave@ function, which needs to be invoked on the target\n(e.g. in an iOS application) to start the remote iserv slave.\n\ncalling the GHC cross compiler with @-fexternal-interpreter\n-pgmi=\$HOME/.cabal/bin/iserv-proxy -opti\\<ip address\\> -opti\\<port\\>@\nwill cause it to compile Template Haskell via the remote at \\<ip address\\>.\n\nThus to get cross compilation with Template Haskell follow the\nfollowing receipt:\n\n* compile the iserv library for your target\n\n> iserv \$ arch-platform-target-cabal install -flibrary\n\n* setup an application for your target that calls the\n* startSlave function. This could be either haskell or your\n* targets ffi capable language, if needed.\n\n>  void startSlave(false /* verbose */, 5000 /* port */,\n>                  \"/path/to/storagelocation/on/target\");\n\n* build the iserv-proxy\n\n> iserv \$ cabal install -flibrary -fproxy\n* Start your iserv-slave app on your target running on say @10.0.0.1:5000@\n* compiler your sources with -fexternal-interpreter and the proxy\n\n> project \$ arch-platform-target-ghc ModuleContainingTH.hs \\\n>             -fexternal-interpreter \\\n>             -pgmi=\$HOME/.cabal/bin/iserv-proxy \\\n>             -opti10.0.0.1 -opti5000\n\nShould something not work as expected, provide @-opti-v@ for verbose\nlogging of the @iserv-proxy@.";
+      buildType = "Simple";
+      };
+    components = {
+      exes = {
+        "iserv-proxy" = {
+          depends = [
+            (hsPkgs.array)
+            (hsPkgs.base)
+            (hsPkgs.binary)
+            (hsPkgs.bytestring)
+            (hsPkgs.containers)
+            (hsPkgs.deepseq)
+            (hsPkgs.directory)
+            (hsPkgs.network)
+            (hsPkgs.filepath)
+            (hsPkgs.ghci)
+            (hsPkgs.libiserv)
+            ];
+          };
+        };
+      };
+    } // rec { src = pkgs.fetchurl { url = http://releases.mobilehaskell.org/ghc-packages/iserv-proxy-8.6.1.tar.gz; sha256 = "08ycvqpq8qhxirlspfpx9d9s31sp1mpwxmnvabqzww45aql4l3g1"; }; }

--- a/ghc-packages/iserv-proxy-8.6.1.nix
+++ b/ghc-packages/iserv-proxy-8.6.1.nix
@@ -33,4 +33,4 @@
           };
         };
       };
-    } // rec { src = pkgs.fetchurl { url = http://releases.mobilehaskell.org/ghc-packages/iserv-proxy-8.6.1.tar.gz; sha256 = "08ycvqpq8qhxirlspfpx9d9s31sp1mpwxmnvabqzww45aql4l3g1"; }; }
+    } // rec { src = pkgs.fetchurl { url = http://releases.mobilehaskell.org/ghc-packages/iserv-proxy-8.6.1.tar.gz; sha256 = "199xix72plq6x443j1ylna8bwgjb2mqvnyj0sr356ihdlh6gwvv9"; }; }

--- a/ghc-packages/iserv-proxy-8.6.2.nix
+++ b/ghc-packages/iserv-proxy-8.6.2.nix
@@ -1,0 +1,36 @@
+{ system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
+  {
+    flags = {};
+    package = {
+      specVersion = "1.10";
+      identifier = { name = "iserv-proxy"; version = "8.6.2"; };
+      license = "BSD-3-Clause";
+      copyright = "XXX";
+      maintainer = "XXX";
+      author = "XXX";
+      homepage = "";
+      url = "";
+      synopsis = "iserv allows GHC to delegate Tempalte Haskell computations";
+      description = "GHC can be provided with a path to the iserv binary with\n@-pgmi=/path/to/iserv-bin@, and will in combination with\n@-fexternal-interpreter@, compile Template Haskell though the\n@iserv-bin@ delegate. This is very similar to how ghcjs has been\ncompiling Template Haskell, by spawning a separate delegate (so\ncalled runner on the javascript vm) and evaluating the splices\nthere.\n\niserv can also be used in combination with cross compilation. For\nthis, the @iserv-proxy@ needs to be built on the host, targeting the\nhost (as it is running on the host). @cabal install -flibrary\n-fproxy@ will yield the proxy.\n\nUsing the cabal for the target @arch-platform-target-cabal install\n-flibrary@ will build the required library that contains the ffi\n@startSlave@ function, which needs to be invoked on the target\n(e.g. in an iOS application) to start the remote iserv slave.\n\ncalling the GHC cross compiler with @-fexternal-interpreter\n-pgmi=\$HOME/.cabal/bin/iserv-proxy -opti\\<ip address\\> -opti\\<port\\>@\nwill cause it to compile Template Haskell via the remote at \\<ip address\\>.\n\nThus to get cross compilation with Template Haskell follow the\nfollowing receipt:\n\n* compile the iserv library for your target\n\n> iserv \$ arch-platform-target-cabal install -flibrary\n\n* setup an application for your target that calls the\n* startSlave function. This could be either haskell or your\n* targets ffi capable language, if needed.\n\n>  void startSlave(false /* verbose */, 5000 /* port */,\n>                  \"/path/to/storagelocation/on/target\");\n\n* build the iserv-proxy\n\n> iserv \$ cabal install -flibrary -fproxy\n* Start your iserv-slave app on your target running on say @10.0.0.1:5000@\n* compiler your sources with -fexternal-interpreter and the proxy\n\n> project \$ arch-platform-target-ghc ModuleContainingTH.hs \\\n>             -fexternal-interpreter \\\n>             -pgmi=\$HOME/.cabal/bin/iserv-proxy \\\n>             -opti10.0.0.1 -opti5000\n\nShould something not work as expected, provide @-opti-v@ for verbose\nlogging of the @iserv-proxy@.";
+      buildType = "Simple";
+      };
+    components = {
+      exes = {
+        "iserv-proxy" = {
+          depends = [
+            (hsPkgs.array)
+            (hsPkgs.base)
+            (hsPkgs.binary)
+            (hsPkgs.bytestring)
+            (hsPkgs.containers)
+            (hsPkgs.deepseq)
+            (hsPkgs.directory)
+            (hsPkgs.network)
+            (hsPkgs.filepath)
+            (hsPkgs.ghci)
+            (hsPkgs.libiserv)
+            ];
+          };
+        };
+      };
+    } // rec { src = pkgs.fetchurl { url = http://releases.mobilehaskell.org/ghc-packages/iserv-proxy-8.6.2.tar.gz; sha256 = "1jg7klpz0518ppymxvsag9qwlczkymik7pz1lvyg5ml2lxh5nvgm"; }; }

--- a/ghc-packages/iserv-proxy-8.6.2.nix
+++ b/ghc-packages/iserv-proxy-8.6.2.nix
@@ -33,4 +33,4 @@
           };
         };
       };
-    } // rec { src = pkgs.fetchurl { url = http://releases.mobilehaskell.org/ghc-packages/iserv-proxy-8.6.2.tar.gz; sha256 = "1jg7klpz0518ppymxvsag9qwlczkymik7pz1lvyg5ml2lxh5nvgm"; }; }
+    } // rec { src = pkgs.fetchurl { url = http://releases.mobilehaskell.org/ghc-packages/iserv-proxy-8.6.2.tar.gz; sha256 = "1vadi0p5gydn15p2m723qmw17ivbcz3k0gik4975a23hmbfzxrcp"; }; }

--- a/ghc-packages/iserv-proxy-8.6.3.nix
+++ b/ghc-packages/iserv-proxy-8.6.3.nix
@@ -33,4 +33,4 @@
           };
         };
       };
-    } // rec { src = pkgs.fetchurl { url = http://releases.mobilehaskell.org/ghc-packages/iserv-proxy-8.6.3.tar.gz; sha256 = "0yffd123g5cksfll6v53vkgnq23h1i18i0w877gnnh7lnak7saxm"; }; }
+    } // rec { src = pkgs.fetchurl { url = http://releases.mobilehaskell.org/ghc-packages/iserv-proxy-8.6.3.tar.gz; sha256 = "0rz8z6zj3bq7cyx17mkpl95vkmwvls3z29f1wxch8alvhjxr2n43"; }; }

--- a/ghc-packages/iserv-proxy-8.6.3.nix
+++ b/ghc-packages/iserv-proxy-8.6.3.nix
@@ -1,0 +1,36 @@
+{ system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
+  {
+    flags = {};
+    package = {
+      specVersion = "1.10";
+      identifier = { name = "iserv-proxy"; version = "8.6.3"; };
+      license = "BSD-3-Clause";
+      copyright = "XXX";
+      maintainer = "XXX";
+      author = "XXX";
+      homepage = "";
+      url = "";
+      synopsis = "iserv allows GHC to delegate Tempalte Haskell computations";
+      description = "GHC can be provided with a path to the iserv binary with\n@-pgmi=/path/to/iserv-bin@, and will in combination with\n@-fexternal-interpreter@, compile Template Haskell though the\n@iserv-bin@ delegate. This is very similar to how ghcjs has been\ncompiling Template Haskell, by spawning a separate delegate (so\ncalled runner on the javascript vm) and evaluating the splices\nthere.\n\niserv can also be used in combination with cross compilation. For\nthis, the @iserv-proxy@ needs to be built on the host, targeting the\nhost (as it is running on the host). @cabal install -flibrary\n-fproxy@ will yield the proxy.\n\nUsing the cabal for the target @arch-platform-target-cabal install\n-flibrary@ will build the required library that contains the ffi\n@startSlave@ function, which needs to be invoked on the target\n(e.g. in an iOS application) to start the remote iserv slave.\n\ncalling the GHC cross compiler with @-fexternal-interpreter\n-pgmi=\$HOME/.cabal/bin/iserv-proxy -opti\\<ip address\\> -opti\\<port\\>@\nwill cause it to compile Template Haskell via the remote at \\<ip address\\>.\n\nThus to get cross compilation with Template Haskell follow the\nfollowing receipt:\n\n* compile the iserv library for your target\n\n> iserv \$ arch-platform-target-cabal install -flibrary\n\n* setup an application for your target that calls the\n* startSlave function. This could be either haskell or your\n* targets ffi capable language, if needed.\n\n>  void startSlave(false /* verbose */, 5000 /* port */,\n>                  \"/path/to/storagelocation/on/target\");\n\n* build the iserv-proxy\n\n> iserv \$ cabal install -flibrary -fproxy\n* Start your iserv-slave app on your target running on say @10.0.0.1:5000@\n* compiler your sources with -fexternal-interpreter and the proxy\n\n> project \$ arch-platform-target-ghc ModuleContainingTH.hs \\\n>             -fexternal-interpreter \\\n>             -pgmi=\$HOME/.cabal/bin/iserv-proxy \\\n>             -opti10.0.0.1 -opti5000\n\nShould something not work as expected, provide @-opti-v@ for verbose\nlogging of the @iserv-proxy@.";
+      buildType = "Simple";
+      };
+    components = {
+      exes = {
+        "iserv-proxy" = {
+          depends = [
+            (hsPkgs.array)
+            (hsPkgs.base)
+            (hsPkgs.binary)
+            (hsPkgs.bytestring)
+            (hsPkgs.containers)
+            (hsPkgs.deepseq)
+            (hsPkgs.directory)
+            (hsPkgs.network)
+            (hsPkgs.filepath)
+            (hsPkgs.ghci)
+            (hsPkgs.libiserv)
+            ];
+          };
+        };
+      };
+    } // rec { src = pkgs.fetchurl { url = http://releases.mobilehaskell.org/ghc-packages/iserv-proxy-8.6.3.tar.gz; sha256 = "0yffd123g5cksfll6v53vkgnq23h1i18i0w877gnnh7lnak7saxm"; }; }

--- a/ghc-packages/libiserv-8.4.4.nix
+++ b/ghc-packages/libiserv-8.4.4.nix
@@ -1,0 +1,42 @@
+{ system
+, compiler
+, flags
+, pkgs
+, hsPkgs
+, pkgconfPkgs
+, ... }:
+  {
+    flags = { network = false; };
+    package = {
+      specVersion = "1.10";
+      identifier = {
+        name = "libiserv";
+        version = "8.5";
+      };
+      license = "BSD-3-Clause";
+      copyright = "XXX";
+      maintainer = "XXX";
+      author = "XXX";
+      homepage = "";
+      url = "";
+      synopsis = "Provides shared functionality between iserv and iserv-proxy";
+      description = "";
+      buildType = "Simple";
+    };
+    components = {
+      "library" = {
+        depends  = ([
+          (hsPkgs.base)
+          (hsPkgs.binary)
+          (hsPkgs.bytestring)
+          (hsPkgs.containers)
+          (hsPkgs.deepseq)
+          (hsPkgs.ghci)
+        ] ++ pkgs.lib.optionals (flags.network) [
+          (hsPkgs.network)
+          (hsPkgs.directory)
+          (hsPkgs.filepath)
+        ]) ++ pkgs.lib.optional (!system.isWindows) (hsPkgs.unix);
+      };
+    };
+  } // rec { src = pkgs.fetchurl { url = https://s3.eu-central-1.amazonaws.com/ci-static/ghc-cross-windows/libiserv-8.4.4.tar.gz; sha256 = "1k2prsqpxpi0r8wfgjfqna1w5h5fcpwnn0v8i9cc3d1nidmn6g80"; }; }

--- a/ghc-packages/libiserv-8.6.1.nix
+++ b/ghc-packages/libiserv-8.6.1.nix
@@ -1,0 +1,33 @@
+{ system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
+  {
+    flags = { network = false; };
+    package = {
+      specVersion = "1.10";
+      identifier = { name = "libiserv"; version = "8.6.1"; };
+      license = "BSD-3-Clause";
+      copyright = "XXX";
+      maintainer = "XXX";
+      author = "XXX";
+      homepage = "";
+      url = "";
+      synopsis = "Provides shared functionality between iserv and iserv-proxy";
+      description = "";
+      buildType = "Simple";
+      };
+    components = {
+      "library" = {
+        depends = ([
+          (hsPkgs.base)
+          (hsPkgs.binary)
+          (hsPkgs.bytestring)
+          (hsPkgs.containers)
+          (hsPkgs.deepseq)
+          (hsPkgs.ghci)
+          ] ++ (pkgs.lib).optionals (flags.network) [
+          (hsPkgs.network)
+          (hsPkgs.directory)
+          (hsPkgs.filepath)
+          ]) ++ (pkgs.lib).optional (!system.isWindows) (hsPkgs.unix);
+        };
+      };
+    } // rec { src = pkgs.fetchurl { url = http://releases.mobilehaskell.org/ghc-packages/libiserv-8.6.1.tar.gz; sha256 = "0lx3jnrn8bsfn1nxzwik9xqqnx09q3gwrylkhx7kgb2n23rzrabx"; }; }

--- a/ghc-packages/libiserv-8.6.1.nix
+++ b/ghc-packages/libiserv-8.6.1.nix
@@ -30,4 +30,4 @@
           ]) ++ (pkgs.lib).optional (!system.isWindows) (hsPkgs.unix);
         };
       };
-    } // rec { src = pkgs.fetchurl { url = http://releases.mobilehaskell.org/ghc-packages/libiserv-8.6.1.tar.gz; sha256 = "0lx3jnrn8bsfn1nxzwik9xqqnx09q3gwrylkhx7kgb2n23rzrabx"; }; }
+    } // rec { src = pkgs.fetchurl { url = http://releases.mobilehaskell.org/ghc-packages/libiserv-8.6.1.tar.gz; sha256 = "0g9b8bdw3fcw9yhl7nirzpby06600vg38ih9mr0793a0vbkf7j6q"; }; }

--- a/ghc-packages/libiserv-8.6.2.nix
+++ b/ghc-packages/libiserv-8.6.2.nix
@@ -30,4 +30,4 @@
           ]) ++ (pkgs.lib).optional (!system.isWindows) (hsPkgs.unix);
         };
       };
-    } // rec { src = pkgs.fetchurl { url = http://releases.mobilehaskell.org/ghc-packages/libiserv-8.6.2.tar.gz; sha256 = "0wn7wqx39yqzqypxdqr0rblfm7mkxwsgr3dm2ykc38rmfa0v0nrx"; }; }
+    } // rec { src = pkgs.fetchurl { url = http://releases.mobilehaskell.org/ghc-packages/libiserv-8.6.2.tar.gz; sha256 = "0x1dpx4ngkacm1mnqmcnf9hh9yaafwn921l62zlp38ppxrp13fr8"; }; }

--- a/ghc-packages/libiserv-8.6.2.nix
+++ b/ghc-packages/libiserv-8.6.2.nix
@@ -1,0 +1,33 @@
+{ system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
+  {
+    flags = { network = false; };
+    package = {
+      specVersion = "1.10";
+      identifier = { name = "libiserv"; version = "8.6.2"; };
+      license = "BSD-3-Clause";
+      copyright = "XXX";
+      maintainer = "XXX";
+      author = "XXX";
+      homepage = "";
+      url = "";
+      synopsis = "Provides shared functionality between iserv and iserv-proxy";
+      description = "";
+      buildType = "Simple";
+      };
+    components = {
+      "library" = {
+        depends = ([
+          (hsPkgs.base)
+          (hsPkgs.binary)
+          (hsPkgs.bytestring)
+          (hsPkgs.containers)
+          (hsPkgs.deepseq)
+          (hsPkgs.ghci)
+          ] ++ (pkgs.lib).optionals (flags.network) [
+          (hsPkgs.network)
+          (hsPkgs.directory)
+          (hsPkgs.filepath)
+          ]) ++ (pkgs.lib).optional (!system.isWindows) (hsPkgs.unix);
+        };
+      };
+    } // rec { src = pkgs.fetchurl { url = http://releases.mobilehaskell.org/ghc-packages/libiserv-8.6.2.tar.gz; sha256 = "0wn7wqx39yqzqypxdqr0rblfm7mkxwsgr3dm2ykc38rmfa0v0nrx"; }; }

--- a/ghc-packages/libiserv-8.6.3.nix
+++ b/ghc-packages/libiserv-8.6.3.nix
@@ -30,4 +30,4 @@
           ]) ++ (pkgs.lib).optional (!system.isWindows) (hsPkgs.unix);
         };
       };
-    } // rec { src = pkgs.fetchurl { url = http://releases.mobilehaskell.org/ghc-packages/libiserv-8.6.3.tar.gz; sha256 = "0sk45pnb90kbm9d9hv1k5rnidhcnmq3q00raillpsnxlvsm6xq84"; }; }
+    } // rec { src = pkgs.fetchurl { url = http://releases.mobilehaskell.org/ghc-packages/libiserv-8.6.3.tar.gz; sha256 = "0pzncp0k5d5jshm0k58gih66cvwh30fkay72yj71s6kvsyqyk612"; }; }

--- a/ghc-packages/libiserv-8.6.3.nix
+++ b/ghc-packages/libiserv-8.6.3.nix
@@ -1,0 +1,33 @@
+{ system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
+  {
+    flags = { network = false; };
+    package = {
+      specVersion = "1.10";
+      identifier = { name = "libiserv"; version = "8.6.3"; };
+      license = "BSD-3-Clause";
+      copyright = "XXX";
+      maintainer = "XXX";
+      author = "XXX";
+      homepage = "";
+      url = "";
+      synopsis = "Provides shared functionality between iserv and iserv-proxy";
+      description = "";
+      buildType = "Simple";
+      };
+    components = {
+      "library" = {
+        depends = ([
+          (hsPkgs.base)
+          (hsPkgs.binary)
+          (hsPkgs.bytestring)
+          (hsPkgs.containers)
+          (hsPkgs.deepseq)
+          (hsPkgs.ghci)
+          ] ++ (pkgs.lib).optionals (flags.network) [
+          (hsPkgs.network)
+          (hsPkgs.directory)
+          (hsPkgs.filepath)
+          ]) ++ (pkgs.lib).optional (!system.isWindows) (hsPkgs.unix);
+        };
+      };
+    } // rec { src = pkgs.fetchurl { url = http://releases.mobilehaskell.org/ghc-packages/libiserv-8.6.3.tar.gz; sha256 = "0sk45pnb90kbm9d9hv1k5rnidhcnmq3q00raillpsnxlvsm6xq84"; }; }

--- a/ghc-packages/remote-iserv-8.4.4.nix
+++ b/ghc-packages/remote-iserv-8.4.4.nix
@@ -1,0 +1,36 @@
+{ system
+, compiler
+, flags
+, pkgs
+, hsPkgs
+, pkgconfPkgs
+, ... }:
+  {
+    flags = {};
+    package = {
+      specVersion = "1.10";
+      identifier = {
+        name = "remote-iserv";
+        version = "8.5";
+      };
+      license = "BSD-3-Clause";
+      copyright = "XXX";
+      maintainer = "XXX";
+      author = "XXX";
+      homepage = "";
+      url = "";
+      synopsis = "iserv allows GHC to delegate Tempalte Haskell computations";
+      description = "";
+      buildType = "Simple";
+    };
+    components = {
+      exes = {
+        "remote-iserv" = {
+          depends  = [
+            (hsPkgs.base)
+            (hsPkgs.libiserv)
+          ];
+        };
+      };
+    };
+  } // rec { src = pkgs.fetchurl { url = https://s3.eu-central-1.amazonaws.com/ci-static/ghc-cross-windows/remote-iserv-8.4.4.tar.gz; sha256 = "0imxhydx5igk12s7b5iv3fzkwflqk3d0byfil8h52ha653b2xzfn"; }; }

--- a/ghc-packages/remote-iserv-8.6.1.nix
+++ b/ghc-packages/remote-iserv-8.6.1.nix
@@ -1,0 +1,22 @@
+{ system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
+  {
+    flags = {};
+    package = {
+      specVersion = "1.10";
+      identifier = { name = "remote-iserv"; version = "8.6.1"; };
+      license = "BSD-3-Clause";
+      copyright = "XXX";
+      maintainer = "Moritz Angermann <moritz.angermann@gmail.com>";
+      author = "Moritz Angermann <moritz.angermann@gmail.com>";
+      homepage = "";
+      url = "";
+      synopsis = "iserv allows GHC to delegate Tempalte Haskell computations";
+      description = "This is a very simple remote runner for iserv, to be used together\nwith iserv-proxy.  The foundamental idea is that this this wrapper\nstarts running libiserv on a given port to which iserv-proxy will\nthen connect.";
+      buildType = "Simple";
+      };
+    components = {
+      exes = {
+        "remote-iserv" = { depends = [ (hsPkgs.base) (hsPkgs.libiserv) ]; };
+        };
+      };
+    } // rec { src = pkgs.fetchurl { url = http://releases.mobilehaskell.org/ghc-packages/remote-iserv-8.6.1.tar.gz; sha256 = "0k91ksqxpqjljsxy8m6aiy68v2gfv28jmr1i7xlvz5vmw8maj9x9"; }; }

--- a/ghc-packages/remote-iserv-8.6.1.nix
+++ b/ghc-packages/remote-iserv-8.6.1.nix
@@ -19,4 +19,4 @@
         "remote-iserv" = { depends = [ (hsPkgs.base) (hsPkgs.libiserv) ]; };
         };
       };
-    } // rec { src = pkgs.fetchurl { url = http://releases.mobilehaskell.org/ghc-packages/remote-iserv-8.6.1.tar.gz; sha256 = "0k91ksqxpqjljsxy8m6aiy68v2gfv28jmr1i7xlvz5vmw8maj9x9"; }; }
+    } // rec { src = pkgs.fetchurl { url = http://releases.mobilehaskell.org/ghc-packages/remote-iserv-8.6.1.tar.gz; sha256 = "1xdl1cghq697s4ifp96zl3gcsq3h4vvldx4qqg5q1l4q9ail622h"; }; }

--- a/ghc-packages/remote-iserv-8.6.2.nix
+++ b/ghc-packages/remote-iserv-8.6.2.nix
@@ -1,0 +1,22 @@
+{ system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
+  {
+    flags = {};
+    package = {
+      specVersion = "1.10";
+      identifier = { name = "remote-iserv"; version = "8.6.2"; };
+      license = "BSD-3-Clause";
+      copyright = "XXX";
+      maintainer = "Moritz Angermann <moritz.angermann@gmail.com>";
+      author = "Moritz Angermann <moritz.angermann@gmail.com>";
+      homepage = "";
+      url = "";
+      synopsis = "iserv allows GHC to delegate Tempalte Haskell computations";
+      description = "This is a very simple remote runner for iserv, to be used together\nwith iserv-proxy.  The foundamental idea is that this this wrapper\nstarts running libiserv on a given port to which iserv-proxy will\nthen connect.";
+      buildType = "Simple";
+      };
+    components = {
+      exes = {
+        "remote-iserv" = { depends = [ (hsPkgs.base) (hsPkgs.libiserv) ]; };
+        };
+      };
+    } // rec { src = pkgs.fetchurl { url = http://releases.mobilehaskell.org/ghc-packages/remote-iserv-8.6.2.tar.gz; sha256 = "0ilzq7ckhf59fpfw0f541762bfa19mb1if35b9ga0lx2yxmbrfd0"; }; }

--- a/ghc-packages/remote-iserv-8.6.2.nix
+++ b/ghc-packages/remote-iserv-8.6.2.nix
@@ -19,4 +19,4 @@
         "remote-iserv" = { depends = [ (hsPkgs.base) (hsPkgs.libiserv) ]; };
         };
       };
-    } // rec { src = pkgs.fetchurl { url = http://releases.mobilehaskell.org/ghc-packages/remote-iserv-8.6.2.tar.gz; sha256 = "0ilzq7ckhf59fpfw0f541762bfa19mb1if35b9ga0lx2yxmbrfd0"; }; }
+    } // rec { src = pkgs.fetchurl { url = http://releases.mobilehaskell.org/ghc-packages/remote-iserv-8.6.2.tar.gz; sha256 = "0w26izn134rbjlyj33lgvnxdma3rzpv9wx6n0kryppixjxhd51rm"; }; }

--- a/ghc-packages/remote-iserv-8.6.3.nix
+++ b/ghc-packages/remote-iserv-8.6.3.nix
@@ -1,0 +1,22 @@
+{ system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
+  {
+    flags = {};
+    package = {
+      specVersion = "1.10";
+      identifier = { name = "remote-iserv"; version = "8.6.3"; };
+      license = "BSD-3-Clause";
+      copyright = "XXX";
+      maintainer = "Moritz Angermann <moritz.angermann@gmail.com>";
+      author = "Moritz Angermann <moritz.angermann@gmail.com>";
+      homepage = "";
+      url = "";
+      synopsis = "iserv allows GHC to delegate Tempalte Haskell computations";
+      description = "This is a very simple remote runner for iserv, to be used together\nwith iserv-proxy.  The foundamental idea is that this this wrapper\nstarts running libiserv on a given port to which iserv-proxy will\nthen connect.";
+      buildType = "Simple";
+      };
+    components = {
+      exes = {
+        "remote-iserv" = { depends = [ (hsPkgs.base) (hsPkgs.libiserv) ]; };
+        };
+      };
+    } // rec { src = pkgs.fetchurl { url = http://releases.mobilehaskell.org/ghc-packages/remote-iserv-8.6.3.tar.gz; sha256 = "0jnklvc9di7gdp47yycp9585985id195vgdbndcd1s9694621hss"; }; }

--- a/ghc-packages/remote-iserv-8.6.3.nix
+++ b/ghc-packages/remote-iserv-8.6.3.nix
@@ -19,4 +19,4 @@
         "remote-iserv" = { depends = [ (hsPkgs.base) (hsPkgs.libiserv) ]; };
         };
       };
-    } // rec { src = pkgs.fetchurl { url = http://releases.mobilehaskell.org/ghc-packages/remote-iserv-8.6.3.tar.gz; sha256 = "0jnklvc9di7gdp47yycp9585985id195vgdbndcd1s9694621hss"; }; }
+    } // rec { src = pkgs.fetchurl { url = http://releases.mobilehaskell.org/ghc-packages/remote-iserv-8.6.3.tar.gz; sha256 = "085jkgdq7r7310336386la2d4zzmsjvq62sy12qdfmjz7hmfd0ky"; }; }

--- a/haskell-hackage-stackage.nix
+++ b/haskell-hackage-stackage.nix
@@ -1,0 +1,38 @@
+{ pkgs }:
+let
+  # overriding logic so we can pass -I to nix, and overide the
+  # relevant import.
+  overrideWith = override: default:
+   let
+     try = builtins.tryEval (builtins.findFile builtins.nixPath override);
+   in if try.success then
+     builtins.trace "using search host <${override}>" try.value
+   else
+     default;
+in rec {
+  # all packages from hackage as nix expressions
+  hackage = import (overrideWith "hackage"
+                    (pkgs.fetchFromGitHub { owner  = "angerman";
+                                            repo   = "hackage.nix";
+                                            rev    = "d4ef2536554d78c6adf368816a4476bc909fcd96";
+                                            sha256 = "15siby9iwgi8bhkj83q1djvg6b6n4gj08n7yy66ccjck7fw4hbr8";
+                                            name   = "hackage-exprs-source"; }))
+                   ;
+  # a different haskell infrastructure
+  haskell = import (overrideWith "haskell"
+                    (pkgs.fetchFromGitHub { owner  = "angerman";
+                                            repo   = "haskell.nix";
+                                            rev    = "ed456599a3a52592ffede765e9d12a953b77d606";
+                                            sha256 = "0w7dg50y30zm7k5ilw0mhkggzhmzpb7x8cl2b82iizvscx6xffzc";
+                                            name   = "haskell-lib-source"; }))
+                   hackage;
+
+  # the set of all stackage snapshots
+  stackage = import (overrideWith "stackage"
+                     (pkgs.fetchFromGitHub { owner  = "angerman";
+                                             repo   = "stackage.nix";
+                                             rev    = "f58d5b78e7a40260c6142c79e52c2bf3ae9876b9";
+                                             sha256 = "1nd9lfm016rlhw3133488f8v8x3lbxrld422gw8gcjhhfls3civn";
+                                             name   = "stackage-snapshot-source"; }))
+                   ;
+}

--- a/haskell-hackage-stackage.nix
+++ b/haskell-hackage-stackage.nix
@@ -12,7 +12,7 @@ let
 in rec {
   # all packages from hackage as nix expressions
   hackage = import (overrideWith "hackage"
-                    (pkgs.fetchFromGitHub { owner  = "angerman";
+                    (pkgs.fetchFromGitHub { owner  = "input-output-hk";
                                             repo   = "hackage.nix";
                                             rev    = "d4ef2536554d78c6adf368816a4476bc909fcd96";
                                             sha256 = "15siby9iwgi8bhkj83q1djvg6b6n4gj08n7yy66ccjck7fw4hbr8";
@@ -20,7 +20,7 @@ in rec {
                    ;
   # a different haskell infrastructure
   haskell = import (overrideWith "haskell"
-                    (pkgs.fetchFromGitHub { owner  = "angerman";
+                    (pkgs.fetchFromGitHub { owner  = "input-output-hk";
                                             repo   = "haskell.nix";
                                             rev    = "dae8025469d94e739aa52f23685bcd87840c72e3";
                                             sha256 = "0bj577aj2v7yl6d1l6rinp0bbn4k9m8k4jd46m4hspqaisfd58hg";
@@ -29,7 +29,7 @@ in rec {
 
   # the set of all stackage snapshots
   stackage = import (overrideWith "stackage"
-                     (pkgs.fetchFromGitHub { owner  = "angerman";
+                     (pkgs.fetchFromGitHub { owner  = "input-output-hk";
                                              repo   = "stackage.nix";
                                              rev    = "f58d5b78e7a40260c6142c79e52c2bf3ae9876b9";
                                              sha256 = "1nd9lfm016rlhw3133488f8v8x3lbxrld422gw8gcjhhfls3civn";

--- a/haskell-hackage-stackage.nix
+++ b/haskell-hackage-stackage.nix
@@ -22,8 +22,8 @@ in rec {
   haskell = import (overrideWith "haskell"
                     (pkgs.fetchFromGitHub { owner  = "angerman";
                                             repo   = "haskell.nix";
-                                            rev    = "ed456599a3a52592ffede765e9d12a953b77d606";
-                                            sha256 = "0w7dg50y30zm7k5ilw0mhkggzhmzpb7x8cl2b82iizvscx6xffzc";
+                                            rev    = "dae8025469d94e739aa52f23685bcd87840c72e3";
+                                            sha256 = "0bj577aj2v7yl6d1l6rinp0bbn4k9m8k4jd46m4hspqaisfd58hg";
                                             name   = "haskell-lib-source"; }))
                    hackage;
 

--- a/haskell-hackage-stackage.nix
+++ b/haskell-hackage-stackage.nix
@@ -1,7 +1,10 @@
 { pkgs }:
 let
   # overriding logic so we can pass -I to nix, and overide the
-  # relevant import.
+  # relevant import. That is if we want to override for example
+  # `hackage`, we can simply provide -I hackage=/path/to/hackage.nix
+  # and have nix use that instead of the one we reference here.
+  # Same for haskell and stackage.
   overrideWith = override: default:
    let
      try = builtins.tryEval (builtins.findFile builtins.nixPath override);

--- a/haskell-hackage-stackage.nix
+++ b/haskell-hackage-stackage.nix
@@ -14,8 +14,8 @@ in rec {
   hackage = import (overrideWith "hackage"
                     (pkgs.fetchFromGitHub { owner  = "input-output-hk";
                                             repo   = "hackage.nix";
-                                            rev    = "d4ef2536554d78c6adf368816a4476bc909fcd96";
-                                            sha256 = "15siby9iwgi8bhkj83q1djvg6b6n4gj08n7yy66ccjck7fw4hbr8";
+                                            rev    = "1bee48237cb87d9ad6432a9ddb7777f858674400";
+                                            sha256 = "0sllxmffrcvcq63wlvz64s0i0ls2249vwix645899k6xh159z5pj";
                                             name   = "hackage-exprs-source"; }))
                    ;
   # a different haskell infrastructure
@@ -31,8 +31,8 @@ in rec {
   stackage = import (overrideWith "stackage"
                      (pkgs.fetchFromGitHub { owner  = "input-output-hk";
                                              repo   = "stackage.nix";
-                                             rev    = "f58d5b78e7a40260c6142c79e52c2bf3ae9876b9";
-                                             sha256 = "1nd9lfm016rlhw3133488f8v8x3lbxrld422gw8gcjhhfls3civn";
+                                             rev    = "5ccfc7662469843768a5c4924d91faafbe5824e1";
+                                             sha256 = "1zwasyscqn4751i10165imwj4715hh5arwmccqkpvpn9bnb6c5ck";
                                              name   = "stackage-snapshot-source"; }))
                    ;
 }

--- a/mingw_w64.nix
+++ b/mingw_w64.nix
@@ -1,0 +1,77 @@
+# Cross compilation logic.
+# Returns override fields for use with nix-tools.
+{ stdenv
+, lib
+, writeScriptBin
+, wine
+, mingw_w64_pthreads
+, iserv-proxy
+, remote-iserv
+, gmp
+# extra libraries. Their dlls are copied
+# when tests are run.
+, extra-test-libs ? []
+}:
+let
+  ################################################################################
+  # Build logic (TH support via remote iserv via wine)
+  #
+  setupBuildFlags = map (opt: "--ghc-option=" + opt) [
+    "-fexternal-interpreter"
+    "-pgmi" "${iserv-proxy}/bin/iserv-proxy"
+    "-opti" "127.0.0.1" "-opti" "$PORT"
+    # TODO: this should be automatically injected based on the extraLibrary.
+    "-L${mingw_w64_pthreads}/lib"
+    "-L${gmp}/lib"
+  ];
+  preBuild = ''
+    # unset the configureFlags.
+    # configure should have run already
+    # without restting it, wine might fail
+    # due to a too large environment.
+    unset configureFlags
+    PORT=$((5000 + $RANDOM % 5000))
+    echo "---> Starting remote-iserv on port $PORT"
+    WINEDLLOVERRIDES="winemac.drv=d" WINEDEBUG=-all+error WINEPREFIX=$TMP ${wine}/bin/wine64 ${remote-iserv}/bin/remote-iserv.exe tmp $PORT &
+    echo "---| remote-iserv should have started on $PORT"
+    RISERV_PID=$!
+  '';
+  postBuild = ''
+    echo "---> killing remote-iserv..."
+    kill $RISERV_PID
+  '';
+
+  ################################################################################
+  # Test logic via wine
+  #
+  wineTestWrapper = writeScriptBin "test-wrapper" ''
+    #!${stdenv.shell}
+    set -euo pipefail
+    WINEDLLOVERRIDES="winemac.drv=d" WINEDEBUG=-all+error LC_ALL=en_US.UTF-8 WINEPREFIX=$TMP ${wine}/bin/wine64 $@*
+  '';
+  setupTestFlags = [ "--test-wrapper ${wineTestWrapper}/bin/test-wrapper" ];
+  preCheck = ''
+    echo "================================================================================"
+    echo "RUNNING TESTS for $name via wine64"
+    echo "================================================================================"
+    echo "Copying extra test libraries ..."
+    for p in ${lib.concatStringsSep " "extra-test-libs}; do
+      find "$p" -iname '*.dll' -exec cp {} . \;
+    done
+    # copy all .dlls into the local directory.
+    # we ask ghc-pkg for *all* dynamic-library-dirs and then iterate over the unique set
+    # to copy over dlls as needed.
+    echo "Copying library dependencies..."
+    for libdir in $(x86_64-pc-mingw32-ghc-pkg --package-db=$packageConfDir field "*" dynamic-library-dirs --simple-output|xargs|sed 's/ /\n/g'|sort -u); do
+      if [ -d "$libdir" ]; then
+        find "$libdir" -iname '*.dll' -exec cp {} . \;
+      fi
+    done
+  '';
+  postCheck = ''
+    echo "================================================================================"
+    echo "END RUNNING TESTS"
+    echo "================================================================================"
+  '';
+
+in { inherit preBuild postBuild preCheck postCheck setupBuildFlags setupTestFlags; }

--- a/mingw_w64.nix
+++ b/mingw_w64.nix
@@ -22,6 +22,7 @@ let
     "-opti" "127.0.0.1" "-opti" "$PORT"
     # TODO: this should be automatically injected based on the extraLibrary.
     "-L${mingw_w64_pthreads}/lib"
+    "-L${mingw_w64_pthreads}/bin"
     "-L${gmp}/lib"
   ];
   preBuild = ''

--- a/nix-tools-default.nix
+++ b/nix-tools-default.nix
@@ -11,7 +11,7 @@ with builtins; with pkgs.lib;
 let  nix-tools = import pkgs-path {
   inherit pkgs;
   # the iohk-module contains cross compilation specific patches
-  inherit (commonLib.nix-tools) iohk-module;
+  inherit (commonLib.nix-tools) iohk-module iohk-overlay;
   inherit (import ./haskell-hackage-stackage.nix { inherit pkgs; }) haskell hackage stackage;
 };
 in {

--- a/nix-tools-default.nix
+++ b/nix-tools-default.nix
@@ -1,0 +1,42 @@
+commonLib: # the iohk-nix commonLib, that provides access to the pinned packages
+pkgs-path: # the path to th local pkgs.nix file for nix-tools that imports all
+           # haskell specific data.
+
+{ system ? builtins.currentSystem
+, crossSystem ? null
+, config ? {}
+, pkgs ? commonLib.getPkgs { inherit system crossSystem config; }
+}:
+with builtins; with pkgs.lib;
+let  nix-tools = import pkgs-path {
+  inherit pkgs;
+  # the iohk-module contains cross compilation specific patches
+  inherit (commonLib.nix-tools) iohk-module;
+  inherit (import ./haskell-hackage-stackage.nix { inherit pkgs; }) haskell hackage stackage;
+};
+in {
+    _lib = commonLib;
+
+    # This will allow us to build
+    # nix-tools.libs.cardano-chain to obtain all libs in a single derivation
+    # nix-tools.exes.cardano-chain for all executables, same for tests and benchmarks.
+    #
+    # The alternative syntax is: nix-tools._raw.cardano-chain.components.$comp
+    # if you want to build only a single component.
+    nix-tools = { _raw = nix-tools; }
+      # some shorthands
+      // { libs = mapAttrs (k: v: if   v ? components && v.components ? "library"
+                                  then v.components.library
+                                  else null) nix-tools; }
+      // { exes = mapAttrs (k: v: if   (v ? components && length (attrValues v.components.exes) > 0)
+                                  then if pkgs.stdenv.targetPlatform.isWindows then pkgs.copyJoin else pkgs.symlinkJoin
+                                       { name = "${k}-exes"; paths = attrValues v.components.exes; }
+                                  else null) nix-tools; }
+      // { tests = mapAttrs (k: v: if v ? components && length (attrValues v.components.tests) > 0
+                                   then v.components.tests
+                                   else null) nix-tools; }
+      // { benchmarks = mapAttrs (k: v: if v ? components && length (attrValues v.components.benchmarks) > 0
+                                   then v.components.benchmarks
+                                   else null) nix-tools; }
+      ;
+  }

--- a/nix-tools-default.nix
+++ b/nix-tools-default.nix
@@ -29,8 +29,11 @@ in {
                                   then v.components.library
                                   else null) nix-tools; }
       // { exes = mapAttrs (k: v: if   (v ? components && length (attrValues v.components.exes) > 0)
-                                  then if pkgs.stdenv.targetPlatform.isWindows then pkgs.copyJoin else pkgs.symlinkJoin
+                                  then (if pkgs.stdenv.targetPlatform.isWindows then pkgs.copyJoin else pkgs.symlinkJoin)
                                        { name = "${k}-exes"; paths = attrValues v.components.exes; }
+                                  else null) nix-tools; }
+      // { cexes = mapAttrs (k: v: if v ? components && length (attrValues v.components.exes) > 0
+                                  then v.components.exes
                                   else null) nix-tools; }
       // { tests = mapAttrs (k: v: if v ? components && length (attrValues v.components.tests) > 0
                                    then v.components.tests

--- a/nix-tools-default.nix
+++ b/nix-tools-default.nix
@@ -1,6 +1,6 @@
-commonLib: # the iohk-nix commonLib, that provides access to the pinned packages
-pkgs-path: # the path to th local pkgs.nix file for nix-tools that imports all
-           # haskell specific data.
+commonLib:           # the iohk-nix commonLib, that provides access to the pinned packages
+nix-tools-pkgs-path: # the path to the local pkgs.nix file for nix-tools that imports all
+                     # haskell specific data.
 
 { system ? builtins.currentSystem
 , crossSystem ? null
@@ -8,7 +8,7 @@ pkgs-path: # the path to th local pkgs.nix file for nix-tools that imports all
 , pkgs ? commonLib.getPkgs { inherit system crossSystem config; }
 }:
 with builtins; with pkgs.lib;
-let  nix-tools = import pkgs-path {
+let  nix-tools = import nix-tools-pkgs-path {
   inherit pkgs;
   # the iohk-module contains cross compilation specific patches
   inherit (commonLib.nix-tools) iohk-module iohk-overlay;

--- a/nix-tools-iohk-module.nix
+++ b/nix-tools-iohk-module.nix
@@ -33,6 +33,28 @@ let
         } // { doCrossCheck = true; };
 in {
   packages = {
+    # This needs true, otherwise we miss most of the interesting
+    # modules.
+    ghci.flags.ghci = true;
+
+    # this needs to be true to expose module
+    #  Message.Remote
+    # as needed by libiserv.
+    libiserv.flags.network = true;
+
+    # libiserv has a bit too restrictive boundaries.
+    # as such it won't build with newer network libraries.
+    # to avoid that we use doExactConfig, which forces cabal
+    # to forgoe its solver and just take the libraries it's
+    # provided with.
+    ghci.components.library.doExactConfig = true;
+    libiserv.components.library.doExactConfig = true;
+    # same for iserv-proxy
+    iserv-proxy.components.exes.iserv-proxy.doExactConfig = true;
+    remote-iserv.components.exes.remote-iserv.doExactConfig = true;
+
+    #ghci.components.library.doExactConfig = true;
+
     # clock hasn't had a release since 2016(!) that is for three(3) years
     # now.
     clock.patches              = [ ({ version, revision }: (if version == "0.7.2" then ./patches/clock-0.7.2.patch else null)) ];
@@ -46,5 +68,6 @@ in {
   } // lib.optionalAttrs nixpkgs.stdenv.hostPlatform.isWindows {
     hedgehog               = withTH;
     cardano-crypto-wrapper = withTH;
+    cardano-chain          = withTH;
   };
 }

--- a/nix-tools-iohk-module.nix
+++ b/nix-tools-iohk-module.nix
@@ -13,7 +13,7 @@
 commonLib:
 # we need nixpkgs as this will be the properly configured one
 # the one that gives us the right host and target platforms.
-nixpkgs:
+{ nixpkgs, th-packages ? [] }:
 { pkgs, buildModules, config, lib, ... }:
 let
         withTH = import ./mingw_w64.nix {
@@ -65,9 +65,5 @@ in {
     streaming-commons.patches  = [ ./patches/streaming-commons-0.2.0.0.patch ];
     x509-system.patches        = [ ./patches/x509-system-1.6.6.patch ];
     file-embed-lzma.patches    = [ ./patches/file-embed-lzma-0.patch ];
-  } // lib.optionalAttrs nixpkgs.stdenv.hostPlatform.isWindows {
-    hedgehog               = withTH;
-    cardano-crypto-wrapper = withTH;
-    cardano-chain          = withTH;
-  };
+  } // lib.optionalAttrs nixpkgs.stdenv.hostPlatform.isWindows (builtins.listToAttrs (map (pkg: { name = pkg; value = withTH; }) th-packages));
 }

--- a/nix-tools-iohk-module.nix
+++ b/nix-tools-iohk-module.nix
@@ -11,6 +11,9 @@
 #    ];
 #
 commonLib:
+# we need nixpkgs as this will be the properly configured one
+# the one that gives us the right host and target platforms.
+nixpkgs:
 { pkgs, buildModules, config, lib, ... }:
 let
         withTH = import ./mingw_w64.nix {
@@ -29,18 +32,19 @@ let
 
         } // { doCrossCheck = true; };
 in {
-  # clock hasn't had a release since 2016(!) that is for three(3) years
-  # now.
-  packages.clock.patches = [ ({ version, revision }: if version == "0.7.2" then ./patches/clock-0.7.2.patch else null) ];
-  # nix calles this package crypto
-  packages.cryptonite-openssl.patches = [ ({ version, revision }: if version == "0.7" then ./patches/cryptonite-openssl-0.7.patch else null) ];
+  packages = {
+    # clock hasn't had a release since 2016(!) that is for three(3) years
+    # now.
+    clock.patches              = [ ({ version, revision }: (if version == "0.7.2" then ./patches/clock-0.7.2.patch else null)) ];
+    # nix calles this package crypto
+    cryptonite-openssl.patches = [ ({ version, revision }: if version == "0.7" then ./patches/cryptonite-openssl-0.7.patch else null) ];
 
-  packages.conduit.patches            = [ ./patches/conduit-1.3.0.2.patch ];
-  packages.streaming-commons.patches  = [ ./patches/streaming-commons-0.2.0.0.patch ];
-  packages.x509-system.patches        = [ ./patches/x509-system-1.6.6.patch ];
-  packages.file-embed-lzma.patches    = [ ./patches/file-embed-lzma-0.patch ];
-
-} // lib.optionalAttrs commonLib.pkgs.stdenv.hostPlatform.isWindows  {
-         packages.hedgehog               = withTH;
-         packages.cardano-crypto-wrapper = withTH;
+    conduit.patches            = [ ./patches/conduit-1.3.0.2.patch ];
+    streaming-commons.patches  = [ ./patches/streaming-commons-0.2.0.0.patch ];
+    x509-system.patches        = [ ./patches/x509-system-1.6.6.patch ];
+    file-embed-lzma.patches    = [ ./patches/file-embed-lzma-0.patch ];
+  } // lib.optionalAttrs nixpkgs.stdenv.hostPlatform.isWindows {
+    hedgehog               = withTH;
+    cardano-crypto-wrapper = withTH;
+  };
 }

--- a/nix-tools-iohk-module.nix
+++ b/nix-tools-iohk-module.nix
@@ -11,10 +11,36 @@
 #    ];
 #
 commonLib:
-{
+{ pkgs, buildModules, config, lib, ... }:
+let
+        withTH = import ./mingw_w64.nix {
+          inherit (commonLib.pkgs) stdenv lib writeScriptBin;
+          wine = pkgs.buildPackages.winePackages.minimal;
+          inherit (pkgs.windows) mingw_w64_pthreads;
+          inherit (pkgs) gmp;
+          # iserv-proxy needs to come from the buildPackages, as it needs to run on the
+          # build host.
+          inherit (config.hsPkgs.buildPackages.iserv-proxy.components.exes) iserv-proxy;
+          # remote-iserv however needs to come from the regular packages as it has to
+          # run on the target host.
+          inherit (config.hsPkgs.remote-iserv.components.exes) remote-iserv;
+          # we need to use openssl.bin here, because the .dll's are in the .bin expression.
+          extra-test-libs = [ pkgs.rocksdb pkgs.openssl.bin ];
+
+        } // { doCrossCheck = true; };
+in {
   # clock hasn't had a release since 2016(!) that is for three(3) years
   # now.
   packages.clock.patches = [ ({ version, revision }: if version == "0.7.2" then ./patches/clock-0.7.2.patch else null) ];
   # nix calles this package crypto
   packages.cryptonite-openssl.patches = [ ({ version, revision }: if version == "0.7" then ./patches/cryptonite-openssl-0.7.patch else null) ];
+
+  packages.conduit.patches            = [ ./patches/conduit-1.3.0.2.patch ];
+  packages.streaming-commons.patches  = [ ./patches/streaming-commons-0.2.0.0.patch ];
+  packages.x509-system.patches        = [ ./patches/x509-system-1.6.6.patch ];
+  packages.file-embed-lzma.patches    = [ ./patches/file-embed-lzma-0.patch ];
+
+} // lib.optionalAttrs commonLib.pkgs.stdenv.hostPlatform.isWindows  {
+         packages.hedgehog               = withTH;
+         packages.cardano-crypto-wrapper = withTH;
 }

--- a/nix-tools-iohk-module.nix
+++ b/nix-tools-iohk-module.nix
@@ -1,0 +1,20 @@
+# This file contains patches across haskell packages that
+# amend the packages to be cross-compilable to windows,
+# and potentially later other targets.
+#
+# The module is supposed to be used as part of the pkgSet's
+# `modules` setion:
+# Example:
+#    modules = [
+#      haskell.ghcHackagePatches.${(stack-pkgs.overlay hackage).compiler.nix-name}
+#      iohk-module
+#    ];
+#
+commonLib:
+{
+  # clock hasn't had a release since 2016(!) that is for three(3) years
+  # now.
+  packages.clock.patches = [ ({ version, revision }: if version == "0.7.2" then ./patches/clock-0.7.2.patch else null) ];
+  # nix calles this package crypto
+  packages.cryptonite-openssl.patches = [ ({ version, revision }: if version == "0.7" then ./patches/cryptonite-openssl-0.7.patch else null) ];
+}

--- a/nix-tools-iohk-overlay.nix
+++ b/nix-tools-iohk-overlay.nix
@@ -1,6 +1,10 @@
 commonLib:
 let
-  ghc84 = {};
+  ghc84 = hackage: {
+    hsc2hs = hackage.hsc2hs."0.68.4".revisions.default;
+    # stackage beautifully omitts the Win32 pkg
+    Win32 = hackage.Win32."2.6.2.0".revisions.default;
+  };
   ghc86 = hackage: {
     hsc2hs = hackage.hsc2hs."0.68.4".revisions.default;
     # stackage beautifully omitts the Win32 pkg
@@ -9,7 +13,13 @@ let
 in {
   ghc842 = ghc84;
   ghc843 = ghc84;
-  ghc844 = ghc84;
+  ghc844 = h: ghc84 h // {
+   ghci         = ./ghc-packages/ghci-8.4.4.nix;
+   ghc-boot     = ./ghc-packages/ghc-boot-8.4.4.nix;
+   libiserv     = ./ghc-packages/libiserv-8.4.4.nix;
+   remote-iserv = ./ghc-packages/remote-iserv-8.4.4.nix;
+   iserv-proxy  = ./ghc-packages/iserv-proxy-8.4.4.nix;
+  };
   ghc861 = h: ghc86 h // {
     ghci         = ./ghc-packages/ghci-8.6.1.nix;
     ghc-boot     = ./ghc-packages/ghc-boot-8.6.1.nix;

--- a/nix-tools-iohk-overlay.nix
+++ b/nix-tools-iohk-overlay.nix
@@ -1,0 +1,17 @@
+commonLib:
+let
+  ghc84 = {};
+  ghc86 = hackage: {
+    hsc2hs = hackage.hsc2hs."0.68.4".revisions.default;
+    # stackage beautifully omitts the Win32 pkg
+    Win32 = hackage.Win32."2.6.2.0".revisions.default;
+  };
+in {
+  ghc842 = ghc84;
+  ghc843 = ghc84;
+  ghc844 = ghc84;
+  ghc861 = ghc86;
+  ghc862 = ghc86;
+  ghc863 = ghc86;
+  ghc864 = ghc86;
+}

--- a/nix-tools-iohk-overlay.nix
+++ b/nix-tools-iohk-overlay.nix
@@ -10,8 +10,26 @@ in {
   ghc842 = ghc84;
   ghc843 = ghc84;
   ghc844 = ghc84;
-  ghc861 = ghc86;
-  ghc862 = ghc86;
-  ghc863 = ghc86;
+  ghc861 = h: ghc86 h // {
+    ghci         = ./ghc-packages/ghci-8.6.1.nix;
+    ghc-boot     = ./ghc-packages/ghc-boot-8.6.1.nix;
+    libiserv     = ./ghc-packages/libiserv-8.6.1.nix;
+    remote-iserv = ./ghc-packages/remote-iserv-8.6.1.nix;
+    iserv-proxy  = ./ghc-packages/iserv-proxy-8.6.1.nix;
+  };
+  ghc862 = h: ghc86 h // {
+    ghci         = ./ghc-packages/ghci-8.6.2.nix;
+    ghc-boot     = ./ghc-packages/ghc-boot-8.6.2.nix;
+    libiserv     = ./ghc-packages/libiserv-8.6.2.nix;
+    remote-iserv = ./ghc-packages/remote-iserv-8.6.2.nix;
+    iserv-proxy  = ./ghc-packages/iserv-proxy-8.6.2.nix;
+  };
+  ghc863 = h: ghc86 h // {
+    ghci         = ./ghc-packages/ghci-8.6.3.nix;
+    ghc-boot     = ./ghc-packages/ghc-boot-8.6.3.nix;
+    libiserv     = ./ghc-packages/libiserv-8.6.3.nix;
+    remote-iserv = ./ghc-packages/remote-iserv-8.6.3.nix;
+    iserv-proxy  = ./ghc-packages/iserv-proxy-8.6.3.nix;
+  };
   ghc864 = ghc86;
 }

--- a/nix-tools-iohk-overlay.nix
+++ b/nix-tools-iohk-overlay.nix
@@ -1,3 +1,16 @@
+# This file contains the necessary overrides per ghc
+# version. Thus the ghcXXX here are just keys to
+# look up the relevant additional package definitions
+# per GHC version.
+#
+# This is supposed to be used in the pkgs.nix file
+# as
+# pkgSet = haskell.mkPkgSet {
+#   ...
+#   pkg-def-overlays = [ iohk-overlay.${compiler} ];
+#   ...
+# };
+#
 commonLib:
 let
   ghc84 = hackage: {
@@ -6,7 +19,6 @@ let
     Win32 = hackage.Win32."2.6.2.0".revisions.default;
   };
   ghc86 = hackage: {
-    hsc2hs = hackage.hsc2hs."0.68.4".revisions.default;
     # stackage beautifully omitts the Win32 pkg
     Win32 = hackage.Win32."2.6.2.0".revisions.default;
   };

--- a/nix-tools-iohk-overlay.nix
+++ b/nix-tools-iohk-overlay.nix
@@ -19,6 +19,7 @@ let
     Win32 = hackage.Win32."2.6.2.0".revisions.default;
   };
   ghc86 = hackage: {
+    hsc2hs = hackage.hsc2hs."0.68.4".revisions.default;
     # stackage beautifully omitts the Win32 pkg
     Win32 = hackage.Win32."2.6.2.0".revisions.default;
   };

--- a/nix-tools-release.nix
+++ b/nix-tools-release.nix
@@ -1,0 +1,65 @@
+commonLib: # the iohk-nix commonLib
+{ packages ? []
+, required-name ? "required"
+, other-packages ? {}
+, config ? {}
+, package-set-path # usually import ./. {}
+}:
+{ system ? builtins.currentSystem
+, pkgs ? commonLib.getPkgs { inherit system config; }
+
+, scrubJobs ? true
+, supportedSystems ? [ "x86_64-linux" "x86_64-darwin" ]
+, nixpkgsArgs ? {
+    config = config // { allowUnfree = false; inHydra = true; };
+  }
+}:
+with (import (commonLib.nixpkgs + "/pkgs/top-level/release-lib.nix") {
+  inherit supportedSystems scrubJobs nixpkgsArgs;
+  packageSet = import package-set-path;
+});
+with pkgs.lib;
+let
+
+
+  traceId = x: builtins.trace (builtins.deepSeq x x) x;
+
+  packageSet = import package-set-path {};
+  nix-tools-pkgs = supportedSystems: {
+    nix-tools.libs =
+      mapAttrs (_: _: supportedSystems)
+        (filterAttrs (n: v: builtins.elem n packages && v != null) packageSet.nix-tools.libs);
+    nix-tools.exes =
+      mapAttrs (_: mapAttrs (_: _: supportedSystems))
+        (filterAttrs (n: v: builtins.elem n packages && v != null) packageSet.nix-tools.exes);
+    nix-tools.tests =
+      mapAttrs (_: mapAttrs (_: _: supportedSystems))
+        (filterAttrs (n: v: builtins.elem n packages && v != null) packageSet.nix-tools.tests);
+    nix-tools.benchmarks =
+      mapAttrs (_: mapAttrs (_: _: supportedSystems))
+        (filterAttrs (n: v: builtins.elem n packages && v != null) packageSet.nix-tools.benchmarks);
+  };
+
+  mapped-pkgs = mapTestOn (nix-tools-pkgs supportedSystems);
+  mapped-pkgs-mingw32 = mapTestOnCross lib.systems.examples.mingwW64 (nix-tools-pkgs [ "x86_64-linux" ]);
+
+  mapped-pkgs-all
+    = lib.recursiveUpdate
+        (mapped-pkgs)
+        (lib.mapAttrs (_: (lib.mapAttrs (_: (lib.mapAttrs' (n: v: lib.nameValuePair (lib.systems.examples.mingwW64.config + "-" + n) v)))))
+          mapped-pkgs-mingw32);
+
+in fix (self: other-packages // mapped-pkgs-all
+// {
+#  forceNewEval = pkgs.writeText "forceNewEval" chain.rev;
+
+  required = pkgs.lib.hydraJob (pkgs.releaseTools.aggregate {
+    name = required-name;
+    constituents = with self;
+      [ # forceNewEval
+        mapped-pkgs-all
+        other-packages
+      ];
+  });
+
+})

--- a/nix-tools-release.nix
+++ b/nix-tools-release.nix
@@ -45,7 +45,7 @@ let
   # thus someone on macOS will be able to build the .x86_64-darwin cross expressions, while
   # someone on linux will be able to build the .x86_64-linux ones.  As hydra is running on
   # linux, this should also only present CI with the .x86_64-linux targets.
-  mapped-pkgs-mingw32 = mapTestOnCross lib.systems.examples.mingwW64 (nix-tools-pkgs builtins.currentSystem);
+  mapped-pkgs-mingw32 = mapTestOnCross lib.systems.examples.mingwW64 (nix-tools-pkgs [ builtins.currentSystem ]);
 
   mapped-pkgs-all
     = lib.recursiveUpdate

--- a/nix-tools-release.nix
+++ b/nix-tools-release.nix
@@ -1,6 +1,7 @@
 commonLib: # the iohk-nix commonLib
 { packages ? []
 , required-name ? "required"
+, required-targets ? (jobsets: [])
 , other-packages ? {}
 , config ? {}
 , package-set-path # usually import ./. {}
@@ -55,11 +56,7 @@ in fix (self: other-packages // mapped-pkgs-all
 
   required = pkgs.lib.hydraJob (pkgs.releaseTools.aggregate {
     name = required-name;
-    constituents = with self;
-      [ # forceNewEval
-        mapped-pkgs-all
-        other-packages
-      ];
+    constituents = required-targets self;
   });
 
 })

--- a/nix-tools-release.nix
+++ b/nix-tools-release.nix
@@ -41,7 +41,7 @@ let
   };
 
   mapped-pkgs = mapTestOn (nix-tools-pkgs supportedSystems);
-  mapped-pkgs-mingw32 = mapTestOnCross lib.systems.examples.mingwW64 (nix-tools-pkgs [ "x86_64-linux" ]);
+  mapped-pkgs-mingw32 = mapTestOnCross lib.systems.examples.mingwW64 (nix-tools-pkgs supportedSystems); #[ "x86_64-linux" ]);
 
   mapped-pkgs-all
     = lib.recursiveUpdate

--- a/nix-tools-release.nix
+++ b/nix-tools-release.nix
@@ -49,7 +49,7 @@ let
         (lib.mapAttrs (_: (lib.mapAttrs (_: (lib.mapAttrs' (n: v: lib.nameValuePair (lib.systems.examples.mingwW64.config + "-" + n) v)))))
           mapped-pkgs-mingw32);
 
-in fix (self: (builtins.removeAttrs packageSet ["nix-tools"]) // mapped-pkgs-all
+in fix (self: (builtins.removeAttrs packageSet ["nix-tools" "_lib"]) // mapped-pkgs-all
 // {
 #  forceNewEval = pkgs.writeText "forceNewEval" chain.rev;
 

--- a/nix-tools-release.nix
+++ b/nix-tools-release.nix
@@ -2,7 +2,6 @@ commonLib: # the iohk-nix commonLib
 { packages ? []
 , required-name ? "required"
 , required-targets ? (jobsets: [])
-, other-packages ? {}
 , config ? {}
 , package-set-path # usually import ./. {}
 }:
@@ -50,7 +49,7 @@ let
         (lib.mapAttrs (_: (lib.mapAttrs (_: (lib.mapAttrs' (n: v: lib.nameValuePair (lib.systems.examples.mingwW64.config + "-" + n) v)))))
           mapped-pkgs-mingw32);
 
-in fix (self: other-packages // mapped-pkgs-all
+in fix (self: (builtins.removeAttrs packageSet ["nix-tools"]) // mapped-pkgs-all
 // {
 #  forceNewEval = pkgs.writeText "forceNewEval" chain.rev;
 

--- a/nix-tools-release.nix
+++ b/nix-tools-release.nix
@@ -58,7 +58,7 @@ in fix (self: (builtins.removeAttrs packageSet ["nix-tools" "_lib"]) // mapped-p
   forceNewEval = pkgs.writeText "forceNewEval" rev;
   required = pkgs.lib.hydraJob (pkgs.releaseTools.aggregate {
     name = required-name;
-    constituents = [ forceNewEval ] ++ required-targets self;
+    constituents = [ self.forceNewEval ] ++ required-targets self;
   });
 
 })

--- a/nix-tools-release.nix
+++ b/nix-tools-release.nix
@@ -5,7 +5,7 @@ commonLib: # the iohk-nix commonLib
 , config ? {}
 # information hydra passes in about the current
 # package under evaluation.
-, _this { outPath = ./.; rev ? "abcdef"; }
+, _this ? { outPath = ./.; rev = "abcdef"; }
 , package-set-path # usually ./.
 }:
 { system ? builtins.currentSystem

--- a/nix-tools-release.nix
+++ b/nix-tools-release.nix
@@ -29,9 +29,14 @@ let
     nix-tools.libs =
       mapAttrs (_: _: supportedSystems)
         (filterAttrs (n: v: builtins.elem n packages && v != null) packageSet.nix-tools.libs);
+    # aggreated exes
     nix-tools.exes =
-      mapAttrs (_: mapAttrs (_: _: supportedSystems))
+      mapAttrs (_: _: supportedSystems)
         (filterAttrs (n: v: builtins.elem n packages && v != null) packageSet.nix-tools.exes);
+    # component exes exposed
+    nix-tools.cexes =
+      mapAttrs (_: mapAttrs (_: _: supportedSystems))
+        (filterAttrs (n: v: builtins.elem n packages && v != null) packageSet.nix-tools.cexes);
     nix-tools.tests =
       mapAttrs (_: mapAttrs (_: _: supportedSystems))
         (filterAttrs (n: v: builtins.elem n packages && v != null) packageSet.nix-tools.tests);

--- a/nixpkgs-pins/default-nixpkgs-src.json
+++ b/nixpkgs-pins/default-nixpkgs-src.json
@@ -1,6 +1,6 @@
 {
   "url": "https://github.com/input-output-hk/nixpkgs",
-  "rev": "f6bf43195dfe41aadc4cbd9a4d0a0ce95a21f436",
-  "sha256": "15kh7q8v8vfhfkqfg3rqmxp26jnskbjljkiddk9g5xcgbakbpdp7",
+  "rev": "38cae07c47c0be9bcf976170168d6775dc881a9e",
+  "sha256": "161nph84jza8dv9r61l0ynd863irzr5vdynlm6y692z6wbzc1wk6",
   "fetchSubmodules": false
 }

--- a/nixpkgs-pins/default-nixpkgs-src.json
+++ b/nixpkgs-pins/default-nixpkgs-src.json
@@ -1,6 +1,6 @@
 {
   "url": "https://github.com/input-output-hk/nixpkgs",
-  "rev": "f1cef7764a981d9595c594b88eb8481721af1157",
-  "sha256": "1p2hw0xvg47a8fya7khcfyxki92npjyqf144h7q4fx43ah0zrc8r",
+  "rev": "f6bf43195dfe41aadc4cbd9a4d0a0ce95a21f436",
+  "sha256": "15kh7q8v8vfhfkqfg3rqmxp26jnskbjljkiddk9g5xcgbakbpdp7",
   "fetchSubmodules": false
 }

--- a/patches/clock-0.7.2.patch
+++ b/patches/clock-0.7.2.patch
@@ -1,0 +1,59 @@
+diff --git a/System/Clock.hsc b/System/Clock.hsc
+index 297607b..c21196b 100644
+--- a/System/Clock.hsc
++++ b/System/Clock.hsc
+@@ -41,7 +41,9 @@ import GHC.Generics (Generic)
+ #  endif
+ #endif
+
+-#let alignment t = "%lu", (unsigned long)offsetof(struct {char x__; t (y__); }, y__)
++#if __GLASGOW_HASKELL__ < 800
++#  let alignment t = "%lu", (unsigned long)offsetof(struct {char x__; t (y__); }, y__)
++#endif
+
+ -- | Clock types. A clock may be system-wide (that is, visible to all processes)
+ --   or per-process (measuring time that is meaningful only within a process).
+diff --git a/cbits/hs_clock_win32.c b/cbits/hs_clock_win32.c
+index 5dcc2a9..ebdb7fe 100644
+--- a/cbits/hs_clock_win32.c
++++ b/cbits/hs_clock_win32.c
+@@ -28,12 +28,22 @@ static void to_timespec_from_100ns(ULONGLONG t_100ns, long long *t)
+     t[1] = 100*(long)(t_100ns % 10000000UL);
+ }
+
++/* See https://ghc.haskell.org/trac/ghc/ticket/15094 */
++#if defined(_WIN32) && !defined(_WIN64)
++__attribute__((optimize("-fno-expensive-optimizations")))
++#endif
+ void hs_clock_win32_gettime_monotonic(long long* t)
+ {
+    LARGE_INTEGER time;
+-   LARGE_INTEGER frequency;
++   static LARGE_INTEGER frequency;
++   static int hasFreq = 0;
++
+    QueryPerformanceCounter(&time);
+-   QueryPerformanceFrequency(&frequency);
++   if (!hasFreq)
++   {
++      hasFreq = 1;
++      QueryPerformanceFrequency(&frequency);
++   }
+    // seconds
+    t[0] = time.QuadPart / frequency.QuadPart;
+    // nanos =
+diff --git a/clock.cabal b/clock.cabal
+index 0f2d18a..67d232e 100644
+--- a/clock.cabal
++++ b/clock.cabal
+@@ -41,8 +41,8 @@ description:   A package for convenient access to high-resolution clock and
+ copyright:     Copyright © Cetin Sert 2009-2016, Eugene Kirpichov 2010, Finn Espen Gundersen 2013, Gerolf Seitz 2013, Mathieu Boespflug 2014 2015, Chris Done 2015, Dimitri Sabadie 2015, Christian Burger 2015, Mario Longobardi 2016
+ license:       BSD3
+ license-file:  LICENSE
+-author:        Cetin Sert <cetin@corsis.eu>, Corsis Research
+-maintainer:    Cetin Sert <cetin@corsis.eu>, Corsis Research
++author:        Cetin Sert <cetin@corsis.tech>, Corsis Research
++maintainer:    Cetin Sert <cetin@corsis.tech>, Corsis Research
+ homepage:      https://github.com/corsis/clock
+ bug-reports:   https://github.com/corsis/clock/issues
+ category:      System

--- a/patches/conduit-1.3.0.2.patch
+++ b/patches/conduit-1.3.0.2.patch
@@ -1,0 +1,15 @@
+diff --git a/src/System/Win32File.hsc b/src/System/Win32File.hsc
+index a524c77..8e8071d 100644
+--- a/src/System/Win32File.hsc
++++ b/src/System/Win32File.hsc
+@@ -31,8 +31,8 @@ import Data.ByteString.Lazy.Internal (defaultChunkSize)
+ 
+ 
+ #include <fcntl.h>
+-#include <Share.h>
+-#include <SYS/Stat.h>
++#include <share.h>
++#include <sys/stat.h>
+ #include <errno.h>
+ 
+ newtype OFlag = OFlag CInt

--- a/patches/cryptonite-openssl-0.7.patch
+++ b/patches/cryptonite-openssl-0.7.patch
@@ -1,0 +1,13 @@
+diff --git a/cryptonite-openssl.cabal b/cryptonite-openssl.cabal
+index ceb275a..96994b2 100644
+--- a/cryptonite-openssl.cabal
++++ b/cryptonite-openssl.cabal
+@@ -39,7 +39,7 @@ Library
+   ghc-options:       -Wall -fwarn-tabs -optc-O3
+   default-language:  Haskell2010
+   if os(mingw32) || os(windows)
+-    extra-libraries: eay32, ssl32
++    extra-libraries: crypto
+   else
+     if os(osx)
+       include-dirs: /usr/local/opt/openssl/include

--- a/patches/file-embed-lzma-0.patch
+++ b/patches/file-embed-lzma-0.patch
@@ -1,0 +1,44 @@
+diff --git a/src/FileEmbedLzma.hs b/src/FileEmbedLzma.hs
+index ca0c394..bc1960f 100644
+--- a/src/FileEmbedLzma.hs
++++ b/src/FileEmbedLzma.hs
+@@ -36,7 +36,6 @@ import Data.Foldable                    (for_)
+ import Data.Functor.Compose             (Compose (..))
+ import Data.Int                         (Int64)
+ import Language.Haskell.TH
+-import Language.Haskell.TH.Syntax       (qAddDependentFile)
+ import System.Directory
+        (doesDirectoryExist, getDirectoryContents)
+ import System.FilePath                  (makeRelative, (</>))
+@@ -124,7 +123,6 @@ concatEntries xs = (bslEndo BSL.empty, ys)
+ embedDir :: FilePath -> Q Exp
+ embedDir topdir = do
+     pairs' <- runIO $ listDirectoryFiles topdir
+-    for_ pairs' $ qAddDependentFile . fst
+     let pairs = makeAllRelative topdir pairs'
+     embedPairs pairs
+ 
+@@ -151,7 +149,6 @@ embedPairs pairs = do
+ embedRecursiveDir :: FilePath -> Q Exp
+ embedRecursiveDir topdir = do
+     pairs' <- runIO $ listRecursiveDirectoryFiles topdir
+-    for_ pairs' $ qAddDependentFile . fst
+     let pairs = makeAllRelative topdir pairs'
+     embedPairs pairs
+ 
+@@ -162,7 +159,6 @@ embedRecursiveDir topdir = do
+ -- | Embed a lazy 'Data.ByteString.Lazy.ByteString' from a file.
+ embedLazyByteString :: FilePath -> Q Exp
+ embedLazyByteString fp = do
+-    qAddDependentFile fp
+     bsl <- runIO $ BSL.readFile fp
+     lazyBytestringE bsl
+ 
+@@ -173,7 +169,6 @@ embedByteString fp = [| BSL.toStrict $(embedLazyByteString fp) :: BS.ByteString
+ -- | Embed a lazy 'Data.Text.Lazy.Text' from a UTF8-encoded file.
+ embedLazyText :: FilePath -> Q Exp
+ embedLazyText fp = do
+-    qAddDependentFile fp
+     bsl <- runIO $ BSL.readFile fp
+     case TLE.decodeUtf8' bsl of
+         Left e  -> reportError (show e)

--- a/patches/ghc/T16057--ghci-doa-on-windows.patch
+++ b/patches/ghc/T16057--ghci-doa-on-windows.patch
@@ -1,0 +1,70 @@
+diff --git a/compiler/main/DriverPipeline.hs b/compiler/main/DriverPipeline.hs
+index 6d2e5b7e84..92e3455521 100644
+--- a/compiler/main/DriverPipeline.hs
++++ b/compiler/main/DriverPipeline.hs
+@@ -1337,11 +1337,6 @@ runPhase (RealPhase (As with_cpp)) input_fn dflags
+                        (local_includes ++ global_includes
+                        -- See Note [-fPIC for assembler]
+                        ++ map SysTools.Option pic_c_flags
+-                       -- See Note [Produce big objects on Windows]
+-                       ++ [ SysTools.Option "-Wa,-mbig-obj"
+-                          | platformOS (targetPlatform dflags) == OSMinGW32
+-                          , not $ target32Bit (targetPlatform dflags)
+-                          ]
+
+         -- We only support SparcV9 and better because V8 lacks an atomic CAS
+         -- instruction so we have to make sure that the assembler accepts the
+@@ -2154,32 +2149,6 @@ generateMacros prefix name version =
+ -- ---------------------------------------------------------------------------
+ -- join object files into a single relocatable object file, using ld -r
+
+-{-
+-Note [Produce big objects on Windows]
+-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-
+-The Windows Portable Executable object format has a limit of 32k sections, which
+-we tend to blow through pretty easily. Thankfully, there is a "big object"
+-extension, which raises this limit to 2^32. However, it must be explicitly
+-enabled in the toolchain:
+-
+- * the assembler accepts the -mbig-obj flag, which causes it to produce a
+-   bigobj-enabled COFF object.
+-
+- * the linker accepts the --oformat pe-bigobj-x86-64 flag. Despite what the name
+-   suggests, this tells the linker to produce a bigobj-enabled COFF object, no a
+-   PE executable.
+-
+-We must enable bigobj output in a few places:
+-
+- * When merging object files (DriverPipeline.joinObjectFiles)
+-
+- * When assembling (DriverPipeline.runPhase (RealPhase As ...))
+-
+-Unfortunately the big object format is not supported on 32-bit targets so
+-none of this can be used in that case.
+--}
+-
+ joinObjectFiles :: DynFlags -> [FilePath] -> FilePath -> IO ()
+ joinObjectFiles dflags o_files output_fn = do
+   let mySettings = settings dflags
+@@ -2189,7 +2158,7 @@ joinObjectFiles dflags o_files output_fn = do
+                        SysTools.Option "-nostdlib",
+                        SysTools.Option "-Wl,-r"
+                      ]
+-                        -- See Note [No PIE while linking] in DynFlags
++                        -- See Note [No PIE while linking] in SysTools
+                      ++ (if sGccSupportsNoPie mySettings
+                           then [SysTools.Option "-no-pie"]
+                           else [])
+@@ -2208,11 +2177,6 @@ joinObjectFiles dflags o_files output_fn = do
+                          && ldIsGnuLd
+                             then [SysTools.Option "-Wl,-no-relax"]
+                             else [])
+-                        -- See Note [Produce big objects on Windows]
+-                     ++ [ SysTools.Option "-Wl,--oformat,pe-bigobj-x86-64"
+-                        | OSMinGW32 == osInfo
+-                        , not $ target32Bit (targetPlatform dflags)
+-                        ]
+                      ++ map SysTools.Option ld_build_id
+                      ++ [ SysTools.Option "-o",
+                           SysTools.FileOption "" output_fn ]

--- a/patches/ghc/ghc-8.6-Cabal-fix-datadir.patch
+++ b/patches/ghc/ghc-8.6-Cabal-fix-datadir.patch
@@ -1,0 +1,21 @@
+Submodule libraries/Cabal contains modified content
+diff --git a/libraries/Cabal/Cabal/Distribution/Simple/Build/PathsModule.hs b/libraries/Cabal/Cabal/Distribution/Simple/Build/PathsModule.hs
+index 678ccbca3..ffa712e8a 100644
+--- a/libraries/Cabal/Cabal/Distribution/Simple/Build/PathsModule.hs
++++ b/libraries/Cabal/Cabal/Distribution/Simple/Build/PathsModule.hs
+@@ -192,10 +192,14 @@ generate pkg_descr lbi clbi =
+           bindir     = flat_bindir,
+           libdir     = flat_libdir,
+           dynlibdir  = flat_dynlibdir,
+-          datadir    = flat_datadir,
+           libexecdir = flat_libexecdir,
+           sysconfdir = flat_sysconfdir
+         } = absoluteComponentInstallDirs pkg_descr lbi cid NoCopyDest
++
++        InstallDirs {
++          datadir    = flat_datadir
++        } = absoluteInstallDirs pkg_descr lbi NoCopyDest
++
+         InstallDirs {
+           bindir     = flat_bindirrel,
+           libdir     = flat_libdirrel,

--- a/patches/ghc/ghc-8.6.1-iserv-changes.patch
+++ b/patches/ghc/ghc-8.6.1-iserv-changes.patch
@@ -1,0 +1,811 @@
+diff --git a/configure.ac b/configure.ac
+index 5fd3441563..7eb8f90f25 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -1334,7 +1334,7 @@ checkMake380() {
+ checkMake380 make
+ checkMake380 gmake
+ 
+-AC_CONFIG_FILES([mk/config.mk mk/install.mk mk/project.mk rts/rts.cabal compiler/ghc.cabal ghc/ghc-bin.cabal utils/runghc/runghc.cabal utils/gen-dll/gen-dll.cabal libraries/ghc-boot/ghc-boot.cabal libraries/ghc-boot-th/ghc-boot-th.cabal libraries/ghci/ghci.cabal libraries/ghc-heap/ghc-heap.cabal settings docs/users_guide/ghc_config.py docs/index.html libraries/prologue.txt distrib/configure.ac])
++AC_CONFIG_FILES([mk/config.mk mk/install.mk mk/project.mk rts/rts.cabal compiler/ghc.cabal ghc/ghc-bin.cabal utils/iserv/iserv.cabal utils/iserv-proxy/iserv-proxy.cabal utils/remote-iserv/remote-iserv.cabal utils/runghc/runghc.cabal utils/gen-dll/gen-dll.cabal libraries/ghc-boot/ghc-boot.cabal libraries/ghc-boot-th/ghc-boot-th.cabal libraries/ghci/ghci.cabal libraries/ghc-heap/ghc-heap.cabal libraries/libiserv/libiserv.cabal settings docs/users_guide/ghc_config.py docs/index.html libraries/prologue.txt distrib/configure.ac])
+ AC_OUTPUT
+ [
+ if test "$print_make_warning" = "true"; then
+diff --git a/libraries/libiserv/libiserv.cabal b/libraries/libiserv/libiserv.cabal
+deleted file mode 100644
+index fc0a022120..0000000000
+--- a/libraries/libiserv/libiserv.cabal
++++ /dev/null
+@@ -1,39 +0,0 @@
+-Name: libiserv
+-Version: 8.6.1
+-Copyright: XXX
+-License: BSD3
+-License-File: LICENSE
+-Author: XXX
+-Maintainer: XXX
+-Synopsis: Provides shared functionality between iserv and iserv-proxy
+-Description:
+-Category: Development
+-build-type: Simple
+-cabal-version: >=1.10
+-
+-Flag network
+-    Description:   Build libiserv with over-the-network support
+-    Default:       False
+-
+-Library
+-    Default-Language: Haskell2010
+-    Hs-Source-Dirs: src
+-    Exposed-Modules: Lib
+-                   , GHCi.Utils
+-    Build-Depends: base       >= 4   && < 5,
+-                   binary     >= 0.7 && < 0.11,
+-                   bytestring >= 0.10 && < 0.11,
+-                   containers >= 0.5 && < 0.7,
+-                   deepseq    >= 1.4 && < 1.5,
+-                   ghci       == 8.6.*
+-    if flag(network)
+-       Exposed-Modules: Remote.Message
+-                      , Remote.Slave
+-       Build-Depends: network    >= 2.6 && < 2.7,
+-                      directory  >= 1.3 && < 1.4,
+-                      filepath   >= 1.4 && < 1.5
+-
+-    if os(windows)
+-       Cpp-Options: -DWINDOWS
+-   else
+-       Build-Depends: unix   >= 2.7 && < 2.9
+diff --git a/libraries/libiserv/libiserv.cabal.in b/libraries/libiserv/libiserv.cabal.in
+new file mode 100644
+index 0000000000..31eaaeb838
+--- /dev/null
++++ b/libraries/libiserv/libiserv.cabal.in
+@@ -0,0 +1,43 @@
++-- WARNING: libiserv.cabal is automatically generated from libiserv.cabal.in by
++-- ../../configure.  Make sure you are editing libiserv.cabal.in, not
++-- libiserv.cabal.
++
++Name: libiserv
++Version: @ProjectVersionMunged@
++Copyright: XXX
++License: BSD3
++License-File: LICENSE
++Author: XXX
++Maintainer: XXX
++Synopsis: Provides shared functionality between iserv and iserv-proxy
++Description:
++Category: Development
++build-type: Simple
++cabal-version: >=1.10
++
++Flag network
++    Description:   Build libiserv with over-the-network support
++    Default:       False
++
++Library
++    Default-Language: Haskell2010
++    Hs-Source-Dirs: src
++    Exposed-Modules: Lib
++                   , GHCi.Utils
++    Build-Depends: base       >= 4   && < 5,
++                   binary     >= 0.7 && < 0.11,
++                   bytestring >= 0.10 && < 0.11,
++                   containers >= 0.5 && < 0.7,
++                   deepseq    >= 1.4 && < 1.5,
++                   ghci       == @ProjectVersionMunged@
++    if flag(network)
++       Exposed-Modules: Remote.Message
++                      , Remote.Slave
++       Build-Depends: network    >= 2.6 && < 2.7,
++                      directory  >= 1.3 && < 1.4,
++                      filepath   >= 1.4 && < 1.5
++
++    if os(windows)
++       Cpp-Options: -DWINDOWS
++   else
++       Build-Depends: unix   >= 2.7 && < 2.9
+diff --git a/utils/iserv-proxy/Makefile b/utils/iserv-proxy/Makefile
+index f160978c19..dec92996f7 100644
+--- a/utils/iserv-proxy/Makefile
++++ b/utils/iserv-proxy/Makefile
+@@ -10,6 +10,6 @@
+ #
+ # -----------------------------------------------------------------------------
+ 
+-dir = iserv
+-TOP = ..
++dir = iserv-proxy
++TOP = ../..
+ include $(TOP)/mk/sub-makefile.mk
+diff --git a/utils/iserv-proxy/iserv-proxy.cabal b/utils/iserv-proxy/iserv-proxy.cabal
+deleted file mode 100644
+index 5d276b244d..0000000000
+--- a/utils/iserv-proxy/iserv-proxy.cabal
++++ /dev/null
+@@ -1,78 +0,0 @@
+-Name: iserv-proxy
+-Version: 8.6
+-Copyright: XXX
+-License: BSD3
+--- XXX License-File: LICENSE
+-Author: XXX
+-Maintainer: XXX
+-Synopsis: iserv allows GHC to delegate Tempalte Haskell computations
+-Description:
+-  GHC can be provided with a path to the iserv binary with
+-  @-pgmi=/path/to/iserv-bin@, and will in combination with
+-  @-fexternal-interpreter@, compile Template Haskell though the
+-  @iserv-bin@ delegate. This is very similar to how ghcjs has been
+-  compiling Template Haskell, by spawning a separate delegate (so
+-  called runner on the javascript vm) and evaluating the splices
+-  there.
+-  .
+-  iserv can also be used in combination with cross compilation. For
+-  this, the @iserv-proxy@ needs to be built on the host, targeting the
+-  host (as it is running on the host). @cabal install -flibrary
+-  -fproxy@ will yield the proxy.
+-  .
+-  Using the cabal for the target @arch-platform-target-cabal install
+-  -flibrary@ will build the required library that contains the ffi
+-  @startSlave@ function, which needs to be invoked on the target
+-  (e.g. in an iOS application) to start the remote iserv slave.
+-  .
+-  calling the GHC cross compiler with @-fexternal-interpreter
+-  -pgmi=$HOME/.cabal/bin/iserv-proxy -opti\<ip address\> -opti\<port\>@
+-  will cause it to compile Template Haskell via the remote at \<ip address\>.
+-  .
+-  Thus to get cross compilation with Template Haskell follow the
+-  following receipt:
+-  .
+-  * compile the iserv library for your target
+-  .
+-      > iserv $ arch-platform-target-cabal install -flibrary
+-  .
+-  * setup an application for your target that calls the
+-  * startSlave function. This could be either haskell or your
+-  * targets ffi capable language, if needed.
+-  .
+-      >  void startSlave(false /* verbose */, 5000 /* port */,
+-      >                  "/path/to/storagelocation/on/target");
+-  .
+-  * build the iserv-proxy
+-  .
+-      > iserv $ cabal install -flibrary -fproxy
+-  * Start your iserv-slave app on your target running on say @10.0.0.1:5000@
+-  * compiler your sources with -fexternal-interpreter and the proxy
+-  .
+-      > project $ arch-platform-target-ghc ModuleContainingTH.hs \
+-      >             -fexternal-interpreter \
+-      >             -pgmi=$HOME/.cabal/bin/iserv-proxy \
+-      >             -opti10.0.0.1 -opti5000
+-  .
+-  Should something not work as expected, provide @-opti-v@ for verbose
+-  logging of the @iserv-proxy@.
+-
+-Category: Development
+-build-type: Simple
+-cabal-version: >=1.10
+-
+-Executable iserv-proxy
+-   Default-Language: Haskell2010
+-   Main-Is: Main.hs
+-   Hs-Source-Dirs: src
+-   Build-Depends: array      >= 0.5 && < 0.6,
+-                  base       >= 4   && < 5,
+-                  binary     >= 0.7 && < 0.9,
+-                  bytestring >= 0.10 && < 0.11,
+-                  containers >= 0.5 && < 0.6,
+-                  deepseq    >= 1.4 && < 1.5,
+-                  directory  >= 1.3 && < 1.4,
+-                  network    >= 2.6,
+-                  filepath   >= 1.4 && < 1.5,
+-                  ghci       == 8.6.*,
+-                  libiserv   == 8.6.*
+diff --git a/utils/iserv-proxy/iserv-proxy.cabal.in b/utils/iserv-proxy/iserv-proxy.cabal.in
+new file mode 100644
+index 0000000000..0819064601
+--- /dev/null
++++ b/utils/iserv-proxy/iserv-proxy.cabal.in
+@@ -0,0 +1,82 @@
++-- WARNING: iserv-proxy.cabal is automatically generated from iserv-proxy.cabal.in by
++-- ../../configure.  Make sure you are editing iserv-proxy.cabal.in, not
++-- iserv-proxy.cabal.
++
++Name: iserv-proxy
++Version: @ProjectVersion@
++Copyright: XXX
++License: BSD3
++-- XXX License-File: LICENSE
++Author: XXX
++Maintainer: XXX
++Synopsis: iserv allows GHC to delegate Tempalte Haskell computations
++Description:
++  GHC can be provided with a path to the iserv binary with
++  @-pgmi=/path/to/iserv-bin@, and will in combination with
++  @-fexternal-interpreter@, compile Template Haskell though the
++  @iserv-bin@ delegate. This is very similar to how ghcjs has been
++  compiling Template Haskell, by spawning a separate delegate (so
++  called runner on the javascript vm) and evaluating the splices
++  there.
++  .
++  iserv can also be used in combination with cross compilation. For
++  this, the @iserv-proxy@ needs to be built on the host, targeting the
++  host (as it is running on the host). @cabal install -flibrary
++  -fproxy@ will yield the proxy.
++  .
++  Using the cabal for the target @arch-platform-target-cabal install
++  -flibrary@ will build the required library that contains the ffi
++  @startSlave@ function, which needs to be invoked on the target
++  (e.g. in an iOS application) to start the remote iserv slave.
++  .
++  calling the GHC cross compiler with @-fexternal-interpreter
++  -pgmi=$HOME/.cabal/bin/iserv-proxy -opti\<ip address\> -opti\<port\>@
++  will cause it to compile Template Haskell via the remote at \<ip address\>.
++  .
++  Thus to get cross compilation with Template Haskell follow the
++  following receipt:
++  .
++  * compile the iserv library for your target
++  .
++      > iserv $ arch-platform-target-cabal install -flibrary
++  .
++  * setup an application for your target that calls the
++  * startSlave function. This could be either haskell or your
++  * targets ffi capable language, if needed.
++  .
++      >  void startSlave(false /* verbose */, 5000 /* port */,
++      >                  "/path/to/storagelocation/on/target");
++  .
++  * build the iserv-proxy
++  .
++      > iserv $ cabal install -flibrary -fproxy
++  * Start your iserv-slave app on your target running on say @10.0.0.1:5000@
++  * compiler your sources with -fexternal-interpreter and the proxy
++  .
++      > project $ arch-platform-target-ghc ModuleContainingTH.hs \
++      >             -fexternal-interpreter \
++      >             -pgmi=$HOME/.cabal/bin/iserv-proxy \
++      >             -opti10.0.0.1 -opti5000
++  .
++  Should something not work as expected, provide @-opti-v@ for verbose
++  logging of the @iserv-proxy@.
++
++Category: Development
++build-type: Simple
++cabal-version: >=1.10
++
++Executable iserv-proxy
++   Default-Language: Haskell2010
++   Main-Is: Main.hs
++   Hs-Source-Dirs: src
++   Build-Depends: array      >= 0.5 && < 0.6,
++                  base       >= 4   && < 5,
++                  binary     >= 0.7 && < 0.9,
++                  bytestring >= 0.10 && < 0.11,
++                  containers >= 0.5 && < 0.6,
++                  deepseq    >= 1.4 && < 1.5,
++                  directory  >= 1.3 && < 1.4,
++                  network    >= 2.6,
++                  filepath   >= 1.4 && < 1.5,
++                  ghci       == @ProjectVersionMunged@,
++                  libiserv   == @ProjectVersionMunged@
+diff --git a/utils/iserv-proxy/src/Main.hs b/utils/iserv-proxy/src/Main.hs
+index c91b2d08c6..7805147b76 100644
+--- a/utils/iserv-proxy/src/Main.hs
++++ b/utils/iserv-proxy/src/Main.hs
+@@ -1,4 +1,7 @@
+-{-# LANGUAGE CPP, GADTs, OverloadedStrings #-}
++{-# LANGUAGE CPP               #-}
++{-# LANGUAGE GADTs             #-}
++{-# LANGUAGE LambdaCase        #-}
++{-# LANGUAGE OverloadedStrings #-}
+ 
+ {-
+ This is the proxy portion of iserv.
+@@ -45,26 +48,33 @@ and object files.
+ 
+ module Main (main) where
+ 
+-import System.IO
+-import GHCi.Message
+-import GHCi.Utils
+-import GHCi.Signals
++import           GHCi.Message
++import           GHCi.Signals
++import           GHCi.Utils
++import           System.IO
+ 
+-import Remote.Message
++import           Remote.Message
+ 
+-import Network.Socket
+-import Data.IORef
+-import Control.Monad
+-import System.Environment
+-import System.Exit
+-import Text.Printf
+-import GHC.Fingerprint (getFileHash)
+-import System.Directory
+-import System.FilePath (isAbsolute)
++import           Control.Concurrent (threadDelay)
++import qualified Control.Exception as E
++import           Control.Monad
++import           Data.IORef
++import           GHC.Fingerprint (getFileHash)
++import           Network.Socket
++import           System.Directory
++import           System.Environment
++import           System.Exit
++import           System.FilePath (isAbsolute)
++import           Text.Printf
+ 
+-import Data.Binary
++import           Data.Binary
+ import qualified Data.ByteString as BS
+ 
++import           Debug.Trace (traceIO)
++
++trace :: String -> IO ()
++trace s = getProgName >>= \name -> traceIO ("[" ++ name ++ "] " ++ s)
++
+ dieWithUsage :: IO a
+ dieWithUsage = do
+     prog <- getProgName
+@@ -104,11 +114,16 @@ main = do
+   let in_pipe = Pipe{pipeRead = inh, pipeWrite = outh, pipeLeftovers = lo_ref}
+ 
+   when verbose $
+-    putStrLn ("Trying to connect to " ++ host_ip ++ ":" ++ (show port))
+-  out_pipe <- connectTo host_ip port >>= socketToPipe
+-
+-  putStrLn "Starting proxy"
++    trace ("Trying to connect to " ++ host_ip ++ ":" ++ (show port))
++  out_pipe <- do
++    let go n = E.try (connectTo host_ip port >>= socketToPipe) >>= \case
++          Left e | n == 0 -> E.throw (e :: E.SomeException)
++                 | n >  0 -> threadDelay 500000 >> go (n - 1)
++          Right a -> return a
++      in go 120 -- wait for up to 60seconds (polling every 0.5s).
++  trace "Starting proxy"
+   proxy verbose in_pipe out_pipe
++  trace "Proxy done"
+ 
+ -- | A hook, to transform outgoing (proxy -> slave)
+ -- messages prior to sending them to the slave.
+@@ -140,10 +155,10 @@ fwdTHCall verbose local remote msg = do
+       loopTH = do
+         THMsg msg' <- readPipe remote getTHMessage
+         when verbose $
+-          putStrLn ("| TH Msg: ghc <- proxy -- slave: " ++ show msg')
++          trace ("| TH Msg: ghc <- proxy -- slave: " ++ show msg')
+         res <- fwdTHMsg local msg'
+         when verbose $
+-          putStrLn ("| Resp.:  ghc -- proxy -> slave: " ++ show res)
++          trace ("| Resp.:  ghc -- proxy -> slave: " ++ show res)
+         writePipe remote (put res)
+         case msg' of
+           RunTHDone -> return ()
+@@ -161,8 +176,11 @@ fwdTHCall verbose local remote msg = do
+ --
+ fwdLoadCall :: (Binary a, Show a) => Bool -> Pipe -> Pipe -> Message a -> IO a
+ fwdLoadCall verbose _ remote msg = do
++  when verbose $ trace ("fwdLoadCall...")
++  when verbose $ trace ("fwdLoadCall: writing remote pipe")
+   writePipe remote (putMessage msg)
+   loopLoad
++  when verbose $ trace ("fwdLoadCall: reading remote pipe")
+   readPipe remote get
+   where
+     truncateMsg :: Int -> String -> String
+@@ -171,17 +189,19 @@ fwdLoadCall verbose _ remote msg = do
+     reply :: (Binary a, Show a) => a -> IO ()
+     reply m = do
+       when verbose $
+-        putStrLn ("| Resp.:         proxy -> slave: "
++        trace ("| Resp.:         proxy -> slave: "
+                   ++ truncateMsg 80 (show m))
+       writePipe remote (put m)
+     loopLoad :: IO ()
+     loopLoad = do
++      when verbose $ trace ("fwdLoadCall: reading remote pipe (slave message)")
+       SlaveMsg msg' <- readPipe remote getSlaveMessage
+       when verbose $
+-        putStrLn ("| Sl Msg:        proxy <- slave: " ++ show msg')
++        trace ("| Sl Msg:        proxy <- slave: " ++ show msg')
+       case msg' of
+         Done -> return ()
+         Missing path -> do
++          trace("fwdLoadCall: missing path: " ++ path)
+           reply =<< BS.readFile path
+           loopLoad
+         Have path remoteHash -> do
+@@ -198,20 +218,23 @@ proxy verbose local remote = loop
+   where
+     fwdCall :: (Binary a, Show a) => Message a -> IO a
+     fwdCall msg = do
++      when verbose $ trace ("proxy/fwdCall: writing remote pipe")
+       writePipe remote (putMessage msg)
++      when verbose $ trace ("proxy/fwdCall: reading remote pipe")
+       readPipe remote get
+ 
+     -- reply to ghc.
+     reply :: (Show a, Binary a) => a -> IO ()
+     reply msg = do
+       when verbose $
+-        putStrLn ("Resp.:    ghc <- proxy -- slave: " ++ show msg)
++        trace ("Resp.:    ghc <- proxy -- slave: " ++ show msg)
+       writePipe local (put msg)
+ 
+     loop = do
++      when verbose $ trace ("reading local pipe...")
+       (Msg msg) <- readPipe local getMessage
+       when verbose $
+-        putStrLn ("Msg:      ghc -- proxy -> slave: " ++ show msg)
++        trace ("Msg:      ghc -- proxy -> slave: " ++ show msg)
+       (Msg msg') <- hook (Msg msg)
+       case msg' of
+         -- TH might send some message back to ghc.
+@@ -233,24 +256,29 @@ proxy verbose local remote = loop
+           resp <- fwdLoadCall verbose local remote msg'
+           reply resp
+           loop
+-        LoadDLL path | isAbsolute path -> do
+-          resp <- fwdLoadCall verbose local remote msg'
+-          reply resp
+-          loop
++        -- LoadDLL path | isAbsolute path -> do
++        --   resp <- fwdLoadCall verbose local remote msg'
++        --   reply resp
++        --   loop
+         Shutdown{}    -> fwdCall msg' >> return ()
+         _other        -> fwdCall msg' >>= reply >> loop
+ 
+ 
+ connectTo :: String -> PortNumber -> IO Socket
+ connectTo host port = do
+-  let hints = defaultHints { addrFlags = [AI_NUMERICHOST, AI_NUMERICSERV]
+-                           , addrSocketType = Stream }
+-  addr:_ <- getAddrInfo (Just hints) (Just host) (Just (show port))
+-  sock <- socket (addrFamily addr) (addrSocketType addr) (addrProtocol addr)
+-  putStrLn $ "Created socket for " ++ host ++ ":" ++ show port
+-  connect sock (addrAddress addr)
+-  putStrLn "connected"
+-  return sock
++  addr <- resolve host (show port)
++  open addr
++  where
++    resolve host port = do
++        let hints = defaultHints { addrSocketType = Stream }
++        addr:_ <- getAddrInfo (Just hints) (Just host) (Just port)
++        return addr
++    open addr = do
++        sock <- socket (addrFamily addr) (addrSocketType addr) (addrProtocol addr)
++        trace $ "Created socket for " ++ host ++ ":" ++ show port
++        connect sock $ addrAddress addr
++        trace "connected"
++        return sock
+ 
+ -- | Turn a socket into an unbuffered pipe.
+ socketToPipe :: Socket -> IO Pipe
+diff --git a/utils/iserv/iserv.cabal b/utils/iserv/iserv.cabal
+deleted file mode 100644
+index 6e78317ec4..0000000000
+--- a/utils/iserv/iserv.cabal
++++ /dev/null
+@@ -1,44 +0,0 @@
+-Name: iserv
+-Version: 8.6.1
+-Copyright: XXX
+-License: BSD3
+--- XXX License-File: LICENSE
+-Author: XXX
+-Maintainer: XXX
+-Synopsis: iserv allows GHC to delegate Tempalte Haskell computations
+-Description:
+-  GHC can be provided with a path to the iserv binary with
+-  @-pgmi=/path/to/iserv-bin@, and will in combination with
+-  @-fexternal-interpreter@, compile Template Haskell though the
+-  @iserv-bin@ delegate. This is very similar to how ghcjs has been
+-  compiling Template Haskell, by spawning a separate delegate (so
+-  called runner on the javascript vm) and evaluating the splices
+-  there.
+-  .
+-  To use iserv with cross compilers, please see @libraries/libiserv@
+-  and @utils/iserv-proxy@.
+-
+-Category: Development
+-build-type: Simple
+-cabal-version: >=1.10
+-
+-Executable iserv
+-    Default-Language: Haskell2010
+-    ghc-options: -no-hs-main
+-    Main-Is: Main.hs
+-    C-Sources: cbits/iservmain.c
+-    Hs-Source-Dirs: src
+-    include-dirs: .
+-    Build-Depends: array      >= 0.5 && < 0.6,
+-                   base       >= 4   && < 5,
+-                   binary     >= 0.7 && < 0.11,
+-                   bytestring >= 0.10 && < 0.11,
+-                   containers >= 0.5 && < 0.7,
+-                   deepseq    >= 1.4 && < 1.5,
+-                   ghci       == 8.6.*,
+-                   libiserv   == 8.6.*
+-
+-    if os(windows)
+-        Cpp-Options: -DWINDOWS
+-    else
+-        Build-Depends: unix   >= 2.7 && < 2.9
+diff --git a/utils/iserv/iserv.cabal.in b/utils/iserv/iserv.cabal.in
+new file mode 100644
+index 0000000000..356c8a444a
+--- /dev/null
++++ b/utils/iserv/iserv.cabal.in
+@@ -0,0 +1,48 @@
++-- WARNING: iserv.cabal is automatically generated from iserv.cabal.in by
++-- ../../configure.  Make sure you are editing iserv.cabal.in, not
++-- iserv.cabal.
++
++Name: iserv
++Version: @ProjectVersion@
++Copyright: XXX
++License: BSD3
++-- XXX License-File: LICENSE
++Author: XXX
++Maintainer: XXX
++Synopsis: iserv allows GHC to delegate Template Haskell computations
++Description:
++  GHC can be provided with a path to the iserv binary with
++  @-pgmi=/path/to/iserv-bin@, and will in combination with
++  @-fexternal-interpreter@, compile Template Haskell though the
++  @iserv-bin@ delegate. This is very similar to how ghcjs has been
++  compiling Template Haskell, by spawning a separate delegate (so
++  called runner on the javascript vm) and evaluating the splices
++  there.
++  .
++  To use iserv with cross compilers, please see @libraries/libiserv@
++  and @utils/iserv-proxy@.
++
++Category: Development
++build-type: Simple
++cabal-version: >=1.10
++
++Executable iserv
++    Default-Language: Haskell2010
++    ghc-options: -no-hs-main
++    Main-Is: Main.hs
++    C-Sources: cbits/iservmain.c
++    Hs-Source-Dirs: src
++    include-dirs: .
++    Build-Depends: array      >= 0.5 && < 0.6,
++                   base       >= 4   && < 5,
++                   binary     >= 0.7 && < 0.11,
++                   bytestring >= 0.10 && < 0.11,
++                   containers >= 0.5 && < 0.7,
++                   deepseq    >= 1.4 && < 1.5,
++                   ghci       == @ProjectVersionMunged@,
++                   libiserv   == @ProjectVersionMunged@
++
++    if os(windows)
++        Cpp-Options: -DWINDOWS
++    else
++        Build-Depends: unix   >= 2.7 && < 2.9
+diff --git a/utils/remote-iserv/Makefile b/utils/remote-iserv/Makefile
+new file mode 100644
+index 0000000000..c659a21a20
+--- /dev/null
++++ b/utils/remote-iserv/Makefile
+@@ -0,0 +1,15 @@
++# -----------------------------------------------------------------------------
++#
++# (c) 2009 The University of Glasgow
++#
++# This file is part of the GHC build system.
++#
++# To understand how the build system works and how to modify it, see
++#      http://ghc.haskell.org/trac/ghc/wiki/Building/Architecture
++#      http://ghc.haskell.org/trac/ghc/wiki/Building/Modifying
++#
++# -----------------------------------------------------------------------------
++
++dir = remote-iserv
++TOP = ../..
++include $(TOP)/mk/sub-makefile.mk
+diff --git a/utils/remote-iserv/Setup.hs b/utils/remote-iserv/Setup.hs
+new file mode 100644
+index 0000000000..44671092b2
+--- /dev/null
++++ b/utils/remote-iserv/Setup.hs
+@@ -0,0 +1,2 @@
++import           Distribution.Simple
++main = defaultMain
+diff --git a/utils/remote-iserv/ghc.mk b/utils/remote-iserv/ghc.mk
+new file mode 100644
+index 0000000000..db8f32fc22
+--- /dev/null
++++ b/utils/remote-iserv/ghc.mk
+@@ -0,0 +1,113 @@
++# -----------------------------------------------------------------------------
++#
++# (c) 2009-2012 The University of Glasgow
++#
++# This file is part of the GHC build system.
++#
++# To understand how the build system works and how to modify it, see
++#      http://ghc.haskell.org/trac/ghc/wiki/Building/Architecture
++#      http://ghc.haskell.org/trac/ghc/wiki/Building/Modifying
++#
++# -----------------------------------------------------------------------------
++
++utils/remote-iserv_USES_CABAL = YES
++utils/remote-iserv_PACKAGE = remote-iserv
++utils/remote-iserv_EXECUTABLE = remote-iserv
++
++ifeq "$(GhcDebugged)" "YES"
++utils/remote-iserv_stage2_MORE_HC_OPTS += -debug
++utils/remote-iserv_stage2_p_MORE_HC_OPTS += -debug
++utils/remote-iserv_stage2_dyn_MORE_HC_OPTS += -debug
++endif
++
++ifeq "$(GhcThreaded)" "YES"
++utils/remote-iserv_stage2_MORE_HC_OPTS += -threaded
++utils/remote-iserv_stage2_p_MORE_HC_OPTS += -threaded
++utils/remote-iserv_stage2_dyn_MORE_HC_OPTS += -threaded
++endif
++
++# Add -Wl,--export-dynamic enables GHCi to load dynamic objects that
++# refer to the RTS.  This is harmless if you don't use it (adds a bit
++# of overhead to startup and increases the binary sizes) but if you
++# need it there's no alternative.
++ifeq "$(TargetElf)" "YES"
++ifneq "$(TargetOS_CPP)" "solaris2"
++# The Solaris linker does not support --export-dynamic option. It also
++# does not need it since it exports all dynamic symbols by default
++utils/remote-iserv_stage2_MORE_HC_OPTS += -optl-Wl,--export-dynamic
++utils/remote-iserv_stage2_p_MORE_HC_OPTS += -optl-Wl,--export-dynamic
++utils/remote-iserv_stage2_dyn_MORE_HC_OPTS += -optl-Wl,--export-dynamic
++endif
++endif
++
++# Override the default way, because we want a specific version of this
++# program for each way.  Note that it's important to do this even for
++# the vanilla version, otherwise we get a dynamic executable when
++# DYNAMIC_GHC_PROGRAMS=YES.
++utils/remote-iserv_stage2_PROGRAM_WAY = v
++utils/remote-iserv_stage2_p_PROGRAM_WAY = p
++utils/remote-iserv_stage2_dyn_PROGRAM_WAY = dyn
++
++utils/remote-iserv_stage2_PROGNAME = ghc-iserv
++utils/remote-iserv_stage2_p_PROGNAME = ghc-iserv-prof
++utils/remote-iserv_stage2_dyn_PROGNAME = ghc-iserv-dyn
++
++utils/remote-iserv_stage2_MORE_HC_OPTS += -no-hs-main
++utils/remote-iserv_stage2_p_MORE_HC_OPTS += -no-hs-main
++utils/remote-iserv_stage2_dyn_MORE_HC_OPTS += -no-hs-main
++
++utils/remote-iserv_stage2_INSTALL = YES
++utils/remote-iserv_stage2_p_INSTALL = YES
++utils/remote-iserv_stage2_dyn_INSTALL = YES
++
++# Install in $(libexec), not in $(bindir)
++utils/remote-iserv_stage2_TOPDIR = YES
++utils/remote-iserv_stage2_p_TOPDIR = YES
++utils/remote-iserv_stage2_dyn_TOPDIR = YES
++
++utils/remote-iserv_stage2_INSTALL_INPLACE = YES
++utils/remote-iserv_stage2_p_INSTALL_INPLACE = YES
++utils/remote-iserv_stage2_dyn_INSTALL_INPLACE = YES
++
++ifeq "$(CLEANING)" "YES"
++
++NEED_iserv = YES
++NEED_iserv_p = YES
++NEED_iserv_dyn = YES
++
++else
++
++ifneq "$(findstring v, $(GhcLibWays))" ""
++NEED_iserv = YES
++else
++NEED_iserv = NO
++endif
++
++ifneq "$(findstring p, $(GhcLibWays))" ""
++NEED_iserv_p = YES
++else
++NEED_iserv_p = NO
++endif
++
++ifneq "$(findstring dyn, $(GhcLibWays))" ""
++NEED_iserv_dyn = YES
++else
++NEED_iserv_dyn = NO
++endif
++endif
++
++ifeq "$(NEED_iserv)" "YES"
++$(eval $(call build-prog,utils/remote-iserv,stage2,1))
++endif
++
++ifeq "$(NEED_iserv_p)" "YES"
++$(eval $(call build-prog,utils/remote-iserv,stage2_p,1))
++endif
++
++ifeq "$(NEED_iserv_dyn)" "YES"
++$(eval $(call build-prog,utils/remote-iserv,stage2_dyn,1))
++endif
++
++all_ghc_stage2 : $(remote-iserv-stage2_INPLACE)
++all_ghc_stage2 : $(remote-iserv-stage2_p_INPLACE)
++all_ghc_stage2 : $(remote-iserv-stage2_dyn_INPLACE)
+diff --git a/utils/remote-iserv/remote-iserv.cabal.in b/utils/remote-iserv/remote-iserv.cabal.in
+new file mode 100644
+index 0000000000..2e9123bf5e
+--- /dev/null
++++ b/utils/remote-iserv/remote-iserv.cabal.in
+@@ -0,0 +1,27 @@
++-- WARNING: iserv-proxy.cabal is automatically generated from iserv-proxy.cabal.in by
++-- ../../configure.  Make sure you are editing iserv-proxy.cabal.in, not
++-- iserv-proxy.cabal.
++
++Name: remote-iserv
++Version: @ProjectVersion@
++Copyright: XXX
++License: BSD3
++-- XXX License-File: LICENSE
++Author: Moritz Angermann <moritz.angermann@gmail.com>
++Maintainer: Moritz Angermann <moritz.angermann@gmail.com>
++Synopsis: iserv allows GHC to delegate Tempalte Haskell computations
++Description:
++  This is a very simple remote runner for iserv, to be used together
++  with iserv-proxy.  The foundamental idea is that this this wrapper
++  starts running libiserv on a given port to which iserv-proxy will
++  then connect.
++Category: Development
++build-type: Simple
++cabal-version: >=1.10
++
++Executable remote-iserv
++   Default-Language: Haskell2010
++   Main-Is: Cli.hs
++   Hs-Source-Dirs: src
++   Build-Depends: base       >= 4   && < 5,
++                  libiserv   == @ProjectVersionMunged@
+diff --git a/utils/remote-iserv/src/Cli.hs b/utils/remote-iserv/src/Cli.hs
+new file mode 100644
+index 0000000000..400105d80e
+--- /dev/null
++++ b/utils/remote-iserv/src/Cli.hs
+@@ -0,0 +1,30 @@
++module Main where
++
++import           Remote.Slave (startSlave')
++import           System.Environment (getArgs, getProgName)
++import           System.Exit (die)
++
++main :: IO ()
++main = getArgs >>= startSlave
++
++dieWithUsage :: IO a
++dieWithUsage = do
++  prog <- getProgName
++  die $ prog  ++ ": " ++ msg
++ where
++  msg = "usage: iserv-slave /path/to/storage PORT [-v]"
++
++startSlave :: [String] -> IO ()
++startSlave args0
++	| "--help" `elem` args0 = dieWithUsage
++	| otherwise = do
++		(path, port, rest) <- case args0 of
++			arg0:arg1:rest -> return (arg0, read arg1, rest)
++			_              -> dieWithUsage
++		verbose <- case rest of
++			["-v"] -> return True
++			[]     -> return False
++			_      -> dieWithUsage
++
++		startSlave' verbose path port
++

--- a/patches/ghc/iserv-proxy-cleanup.patch
+++ b/patches/ghc/iserv-proxy-cleanup.patch
@@ -1,0 +1,912 @@
+diff --git a/configure.ac b/configure.ac
+index 846924727d..0e67c1051a 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -1334,7 +1334,7 @@ checkMake380() {
+ checkMake380 make
+ checkMake380 gmake
+ 
+-AC_CONFIG_FILES([mk/config.mk mk/install.mk mk/project.mk rts/rts.cabal compiler/ghc.cabal ghc/ghc-bin.cabal utils/runghc/runghc.cabal utils/gen-dll/gen-dll.cabal libraries/ghc-boot/ghc-boot.cabal libraries/ghc-boot-th/ghc-boot-th.cabal libraries/ghci/ghci.cabal libraries/ghc-heap/ghc-heap.cabal settings docs/users_guide/ghc_config.py docs/index.html libraries/prologue.txt distrib/configure.ac])
++AC_CONFIG_FILES([mk/config.mk mk/install.mk mk/project.mk rts/rts.cabal compiler/ghc.cabal ghc/ghc-bin.cabal utils/iserv/iserv.cabal utils/iserv-proxy/iserv-proxy.cabal utils/remote-iserv/remote-iserv.cabal utils/runghc/runghc.cabal utils/gen-dll/gen-dll.cabal libraries/ghc-boot/ghc-boot.cabal libraries/ghc-boot-th/ghc-boot-th.cabal libraries/ghci/ghci.cabal libraries/ghc-heap/ghc-heap.cabal libraries/libiserv/libiserv.cabal settings docs/users_guide/ghc_config.py docs/index.html libraries/prologue.txt distrib/configure.ac])
+ AC_OUTPUT
+ [
+ if test "$print_make_warning" = "true"; then
+diff --git a/docs/users_guide/ghci.rst b/docs/users_guide/ghci.rst
+index 49a96caa0b..e974840d7d 100644
+--- a/docs/users_guide/ghci.rst
++++ b/docs/users_guide/ghci.rst
+@@ -3287,6 +3287,38 @@ dynamically-linked) from GHC itself.  So for example:
+ This feature is experimental in GHC 8.0.x, but it may become the
+ default in future releases.
+ 
++.. _external-interpreter-proxy:
++
++Running the interpreter on a different host
++-------------------------------------------
++
++When using the flag :ghc-flag:`-fexternal-interpreter` GHC will
++spawn and communicate with the separate process using pipes.  There
++are scenarios (e.g. when cross compiling) where it is favourable to
++have the communication happen over the network. GHC provides two
++utilities for this, which can be found in the ``utils`` directory.
++
++- ``remote-iserv`` needs to be built with the cross compiler to be
++  executed on the remote host. Or in the case of using it on the
++  same host the stage2 compiler will do as well.
++
++- ``iserv-proxy`` needs to be built on the build machine by the
++  build compiler.
++
++After starting ``remote-iserv ⟨tmp_dir⟩ ⟨port⟩`` on the target and
++providing it with a temporary folder (where it will copy the
++necessary libraries to load to) and port it will listen for
++the proxy to connect.
++
++Providing :ghc-flag:`-pgmi /path/to/iserv-proxy`, :ghc-flag:`-pgmo ⟨option⟩`
++and :ghc-flag:`-pgmo ⟨port⟩` in addition to :ghc-flag:`-fexternal-interpreter`
++will then make ghc go through the proxy instead.
++
++There are some limitations when using this. File and process IO
++will be executed on the target. As such packages like git-embed,
++file-embed and others might not behave as expected if the target
++and host do not share the same filesystem.
++
+ .. _ghci-faq:
+ 
+ FAQ and Things To Watch Out For
+diff --git a/libraries/libiserv/libiserv.cabal.in b/libraries/libiserv/libiserv.cabal.in
+new file mode 100644
+index 0000000000..31eaaeb838
+--- /dev/null
++++ b/libraries/libiserv/libiserv.cabal.in
+@@ -0,0 +1,43 @@
++-- WARNING: libiserv.cabal is automatically generated from libiserv.cabal.in by
++-- ../../configure.  Make sure you are editing libiserv.cabal.in, not
++-- libiserv.cabal.
++
++Name: libiserv
++Version: @ProjectVersionMunged@
++Copyright: XXX
++License: BSD3
++License-File: LICENSE
++Author: XXX
++Maintainer: XXX
++Synopsis: Provides shared functionality between iserv and iserv-proxy
++Description:
++Category: Development
++build-type: Simple
++cabal-version: >=1.10
++
++Flag network
++    Description:   Build libiserv with over-the-network support
++    Default:       False
++
++Library
++    Default-Language: Haskell2010
++    Hs-Source-Dirs: src
++    Exposed-Modules: Lib
++                   , GHCi.Utils
++    Build-Depends: base       >= 4   && < 5,
++                   binary     >= 0.7 && < 0.11,
++                   bytestring >= 0.10 && < 0.11,
++                   containers >= 0.5 && < 0.7,
++                   deepseq    >= 1.4 && < 1.5,
++                   ghci       == @ProjectVersionMunged@
++    if flag(network)
++       Exposed-Modules: Remote.Message
++                      , Remote.Slave
++       Build-Depends: network    >= 2.6 && < 2.7,
++                      directory  >= 1.3 && < 1.4,
++                      filepath   >= 1.4 && < 1.5
++
++    if os(windows)
++       Cpp-Options: -DWINDOWS
++   else
++       Build-Depends: unix   >= 2.7 && < 2.9
+diff --git a/libraries/libiserv/src/Lib.hs b/libraries/libiserv/src/Lib.hs
+index 57e65706c3..707966dc2d 100644
+--- a/libraries/libiserv/src/Lib.hs
++++ b/libraries/libiserv/src/Lib.hs
+@@ -10,25 +10,33 @@ import Control.Exception
+ import Control.Monad
+ import Data.Binary
+ 
++import Text.Printf
++import System.Environment (getProgName)
++
+ type MessageHook = Msg -> IO Msg
+ 
++trace :: String -> IO ()
++trace s = getProgName >>= \name -> printf "[%20s] %s\n" name s
++
+ serv :: Bool -> MessageHook -> Pipe -> (forall a .IO a -> IO a) -> IO ()
+ serv verbose hook pipe@Pipe{..} restore = loop
+  where
+   loop = do
++    when verbose $ trace "reading pipe..."
+     Msg msg <- readPipe pipe getMessage >>= hook
+-    discardCtrlC
+ 
+-    when verbose $ putStrLn ("iserv: " ++ show msg)
++    discardCtrlC verbose
++
++    when verbose $ trace ("msg: " ++ (show msg))
+     case msg of
+       Shutdown -> return ()
+-      RunTH st q ty loc -> wrapRunTH $ runTH pipe st q ty loc
+-      RunModFinalizers st qrefs -> wrapRunTH $ runModFinalizerRefs pipe st qrefs
++      RunTH st q ty loc -> wrapRunTH verbose $ runTH pipe st q ty loc
++      RunModFinalizers st qrefs -> wrapRunTH verbose $ runModFinalizerRefs pipe st qrefs
+       _other -> run msg >>= reply
+ 
+   reply :: forall a. (Binary a, Show a) => a -> IO ()
+   reply r = do
+-    when verbose $ putStrLn ("iserv: return: " ++ show r)
++    when verbose $ trace ("writing pipe: " ++ show r)
+     writePipe pipe (put r)
+     loop
+ 
+@@ -36,36 +44,43 @@ serv verbose hook pipe@Pipe{..} restore = loop
+   -- THMessage requests, and then finally send RunTHDone followed by a
+   -- QResult.  For an overview of how TH works with Remote GHCi, see
+   -- Note [Remote Template Haskell] in libraries/ghci/GHCi/TH.hs.
+-  wrapRunTH :: forall a. (Binary a, Show a) => IO a -> IO ()
+-  wrapRunTH io = do
+-    r <- try io
++  wrapRunTH :: forall a. (Binary a, Show a) => Bool -> IO a -> IO ()
++  wrapRunTH verbose io = do
++    when verbose $ trace "wrapRunTH..."
++    r <- Right <$> io -- try io
++    when verbose $ trace "wrapRunTH done."
++    when verbose $ trace "writing RunTHDone."
+     writePipe pipe (putTHMessage RunTHDone)
+     case r of
+       Left e
+-        | Just (GHCiQException _ err) <- fromException e  ->
++        | Just (GHCiQException _ err) <- fromException e  -> do
++           when verbose $ trace ("QFail " ++ show err)
+            reply (QFail err :: QResult a)
+         | otherwise -> do
+-           str <- showException e
++           str <- showException verbose e
++           when verbose $ trace ("QException " ++ str)
+            reply (QException str :: QResult a)
+       Right a -> do
+-        when verbose $ putStrLn "iserv: QDone"
++        when verbose $ trace "QDone"
+         reply (QDone a)
+ 
+   -- carefully when showing an exception, there might be other exceptions
+   -- lurking inside it.  If so, we return the inner exception instead.
+-  showException :: SomeException -> IO String
+-  showException e0 = do
++  showException :: Bool -> SomeException -> IO String
++  showException verbose e0 = do
++     when verbose $ trace "showException"
+      r <- try $ evaluate (force (show (e0::SomeException)))
+      case r of
+-       Left e -> showException e
++       Left e -> showException verbose e
+        Right str -> return str
+ 
+   -- throw away any pending ^C exceptions while we're not running
+   -- interpreted code.  GHC will also get the ^C, and either ignore it
+   -- (if this is GHCi), or tell us to quit with a Shutdown message.
+-  discardCtrlC = do
++  discardCtrlC verbose = do
++    when verbose $ trace "discardCtrlC"
+     r <- try $ restore $ return ()
+     case r of
+-      Left UserInterrupt -> return () >> discardCtrlC
++      Left UserInterrupt -> return () >> discardCtrlC verbose
+       Left e -> throwIO e
+       _ -> return ()
+diff --git a/libraries/libiserv/src/Remote/Slave.hs b/libraries/libiserv/src/Remote/Slave.hs
+index b80d09592f..577161f35f 100644
+--- a/libraries/libiserv/src/Remote/Slave.hs
++++ b/libraries/libiserv/src/Remote/Slave.hs
+@@ -25,6 +25,11 @@ import GHC.Fingerprint (getFileHash)
+ 
+ import qualified Data.ByteString as BS
+ 
++import Text.Printf
++import System.Environment (getProgName)
++
++trace :: String -> IO ()
++trace s = getProgName >>= \name -> printf "[%20s] %s\n" name s
+ 
+ dropLeadingPathSeparator :: FilePath -> FilePath
+ dropLeadingPathSeparator p | isAbsolute p = joinPath (drop 1 (splitPath p))
+@@ -43,9 +48,8 @@ foreign export ccall startSlave :: Bool -> Int -> CString -> IO ()
+ -- start the slave process, and runs iserv.
+ startSlave :: Bool -> Int -> CString -> IO ()
+ startSlave verbose port s = do
+-  putStr "DocRoot: "
+   base_path <- peekCString s
+-  putStrLn base_path
++  trace $ "DocRoot: " ++ base_path
+   _ <- forkIO $ startSlave' verbose base_path (toEnum port)
+   return ()
+ 
+@@ -54,16 +58,18 @@ startSlave verbose port s = do
+ -- slave process.
+ startSlave' :: Bool -> String -> PortNumber -> IO ()
+ startSlave' verbose base_path port = do
++  hSetBuffering stdin LineBuffering
++  hSetBuffering stdout LineBuffering
+ 
+   sock <- openSocket port
+ 
+   forever $ do
+-    when verbose $ putStrLn "Opening socket"
++    when verbose $ trace "Opening socket"
+     pipe <- acceptSocket sock >>= socketToPipe
+     putStrLn $ "Listening on port " ++ show port
+-    when verbose $ putStrLn "Starting serv"
++    when verbose $ trace "Starting serv"
+     uninterruptibleMask $ serv verbose (hook verbose base_path pipe) pipe
+-    when verbose $ putStrLn "serv ended"
++    when verbose $ trace "serv ended"
+     return ()
+ 
+ -- | The iserv library may need access to files, specifically
+@@ -117,9 +123,13 @@ hook verbose base_path pipe m = case m of
+   -- when loading DLLs (.so, .dylib, .dll, ...) and these are provided
+   -- as relative paths, the intention is to load a pre-existing system library,
+   -- therefore we hook the LoadDLL call only for absolute paths to ship the
+-  -- dll from the host to the target.
++  -- dll from the host to the target.  On windows we assume that we don't
++  -- want to copy libraries that are referenced in C:\ these are usually
++  -- system libraries.
++  Msg (LoadDLL path@('C':':':_)) -> do
++    return m
+   Msg (LoadDLL path) | isAbsolute path -> do
+-    when verbose $ putStrLn ("Need DLL: " ++ (base_path <//> path))
++    when verbose $ trace ("Need DLL: " ++ (base_path <//> path))
+     handleLoad pipe path (base_path <//> path)
+     return $ Msg (LoadDLL (base_path <//> path))
+   _other -> return m
+diff --git a/utils/iserv-proxy/Makefile b/utils/iserv-proxy/Makefile
+index f160978c19..dec92996f7 100644
+--- a/utils/iserv-proxy/Makefile
++++ b/utils/iserv-proxy/Makefile
+@@ -10,6 +10,6 @@
+ #
+ # -----------------------------------------------------------------------------
+ 
+-dir = iserv
+-TOP = ..
++dir = iserv-proxy
++TOP = ../..
+ include $(TOP)/mk/sub-makefile.mk
+diff --git a/utils/iserv-proxy/iserv-proxy.cabal b/utils/iserv-proxy/iserv-proxy.cabal
+deleted file mode 100644
+index 5d276b244d..0000000000
+--- a/utils/iserv-proxy/iserv-proxy.cabal
++++ /dev/null
+@@ -1,78 +0,0 @@
+-Name: iserv-proxy
+-Version: 8.6
+-Copyright: XXX
+-License: BSD3
+--- XXX License-File: LICENSE
+-Author: XXX
+-Maintainer: XXX
+-Synopsis: iserv allows GHC to delegate Tempalte Haskell computations
+-Description:
+-  GHC can be provided with a path to the iserv binary with
+-  @-pgmi=/path/to/iserv-bin@, and will in combination with
+-  @-fexternal-interpreter@, compile Template Haskell though the
+-  @iserv-bin@ delegate. This is very similar to how ghcjs has been
+-  compiling Template Haskell, by spawning a separate delegate (so
+-  called runner on the javascript vm) and evaluating the splices
+-  there.
+-  .
+-  iserv can also be used in combination with cross compilation. For
+-  this, the @iserv-proxy@ needs to be built on the host, targeting the
+-  host (as it is running on the host). @cabal install -flibrary
+-  -fproxy@ will yield the proxy.
+-  .
+-  Using the cabal for the target @arch-platform-target-cabal install
+-  -flibrary@ will build the required library that contains the ffi
+-  @startSlave@ function, which needs to be invoked on the target
+-  (e.g. in an iOS application) to start the remote iserv slave.
+-  .
+-  calling the GHC cross compiler with @-fexternal-interpreter
+-  -pgmi=$HOME/.cabal/bin/iserv-proxy -opti\<ip address\> -opti\<port\>@
+-  will cause it to compile Template Haskell via the remote at \<ip address\>.
+-  .
+-  Thus to get cross compilation with Template Haskell follow the
+-  following receipt:
+-  .
+-  * compile the iserv library for your target
+-  .
+-      > iserv $ arch-platform-target-cabal install -flibrary
+-  .
+-  * setup an application for your target that calls the
+-  * startSlave function. This could be either haskell or your
+-  * targets ffi capable language, if needed.
+-  .
+-      >  void startSlave(false /* verbose */, 5000 /* port */,
+-      >                  "/path/to/storagelocation/on/target");
+-  .
+-  * build the iserv-proxy
+-  .
+-      > iserv $ cabal install -flibrary -fproxy
+-  * Start your iserv-slave app on your target running on say @10.0.0.1:5000@
+-  * compiler your sources with -fexternal-interpreter and the proxy
+-  .
+-      > project $ arch-platform-target-ghc ModuleContainingTH.hs \
+-      >             -fexternal-interpreter \
+-      >             -pgmi=$HOME/.cabal/bin/iserv-proxy \
+-      >             -opti10.0.0.1 -opti5000
+-  .
+-  Should something not work as expected, provide @-opti-v@ for verbose
+-  logging of the @iserv-proxy@.
+-
+-Category: Development
+-build-type: Simple
+-cabal-version: >=1.10
+-
+-Executable iserv-proxy
+-   Default-Language: Haskell2010
+-   Main-Is: Main.hs
+-   Hs-Source-Dirs: src
+-   Build-Depends: array      >= 0.5 && < 0.6,
+-                  base       >= 4   && < 5,
+-                  binary     >= 0.7 && < 0.9,
+-                  bytestring >= 0.10 && < 0.11,
+-                  containers >= 0.5 && < 0.6,
+-                  deepseq    >= 1.4 && < 1.5,
+-                  directory  >= 1.3 && < 1.4,
+-                  network    >= 2.6,
+-                  filepath   >= 1.4 && < 1.5,
+-                  ghci       == 8.6.*,
+-                  libiserv   == 8.6.*
+diff --git a/utils/iserv-proxy/iserv-proxy.cabal.in b/utils/iserv-proxy/iserv-proxy.cabal.in
+new file mode 100644
+index 0000000000..0819064601
+--- /dev/null
++++ b/utils/iserv-proxy/iserv-proxy.cabal.in
+@@ -0,0 +1,82 @@
++-- WARNING: iserv-proxy.cabal is automatically generated from iserv-proxy.cabal.in by
++-- ../../configure.  Make sure you are editing iserv-proxy.cabal.in, not
++-- iserv-proxy.cabal.
++
++Name: iserv-proxy
++Version: @ProjectVersion@
++Copyright: XXX
++License: BSD3
++-- XXX License-File: LICENSE
++Author: XXX
++Maintainer: XXX
++Synopsis: iserv allows GHC to delegate Tempalte Haskell computations
++Description:
++  GHC can be provided with a path to the iserv binary with
++  @-pgmi=/path/to/iserv-bin@, and will in combination with
++  @-fexternal-interpreter@, compile Template Haskell though the
++  @iserv-bin@ delegate. This is very similar to how ghcjs has been
++  compiling Template Haskell, by spawning a separate delegate (so
++  called runner on the javascript vm) and evaluating the splices
++  there.
++  .
++  iserv can also be used in combination with cross compilation. For
++  this, the @iserv-proxy@ needs to be built on the host, targeting the
++  host (as it is running on the host). @cabal install -flibrary
++  -fproxy@ will yield the proxy.
++  .
++  Using the cabal for the target @arch-platform-target-cabal install
++  -flibrary@ will build the required library that contains the ffi
++  @startSlave@ function, which needs to be invoked on the target
++  (e.g. in an iOS application) to start the remote iserv slave.
++  .
++  calling the GHC cross compiler with @-fexternal-interpreter
++  -pgmi=$HOME/.cabal/bin/iserv-proxy -opti\<ip address\> -opti\<port\>@
++  will cause it to compile Template Haskell via the remote at \<ip address\>.
++  .
++  Thus to get cross compilation with Template Haskell follow the
++  following receipt:
++  .
++  * compile the iserv library for your target
++  .
++      > iserv $ arch-platform-target-cabal install -flibrary
++  .
++  * setup an application for your target that calls the
++  * startSlave function. This could be either haskell or your
++  * targets ffi capable language, if needed.
++  .
++      >  void startSlave(false /* verbose */, 5000 /* port */,
++      >                  "/path/to/storagelocation/on/target");
++  .
++  * build the iserv-proxy
++  .
++      > iserv $ cabal install -flibrary -fproxy
++  * Start your iserv-slave app on your target running on say @10.0.0.1:5000@
++  * compiler your sources with -fexternal-interpreter and the proxy
++  .
++      > project $ arch-platform-target-ghc ModuleContainingTH.hs \
++      >             -fexternal-interpreter \
++      >             -pgmi=$HOME/.cabal/bin/iserv-proxy \
++      >             -opti10.0.0.1 -opti5000
++  .
++  Should something not work as expected, provide @-opti-v@ for verbose
++  logging of the @iserv-proxy@.
++
++Category: Development
++build-type: Simple
++cabal-version: >=1.10
++
++Executable iserv-proxy
++   Default-Language: Haskell2010
++   Main-Is: Main.hs
++   Hs-Source-Dirs: src
++   Build-Depends: array      >= 0.5 && < 0.6,
++                  base       >= 4   && < 5,
++                  binary     >= 0.7 && < 0.9,
++                  bytestring >= 0.10 && < 0.11,
++                  containers >= 0.5 && < 0.6,
++                  deepseq    >= 1.4 && < 1.5,
++                  directory  >= 1.3 && < 1.4,
++                  network    >= 2.6,
++                  filepath   >= 1.4 && < 1.5,
++                  ghci       == @ProjectVersionMunged@,
++                  libiserv   == @ProjectVersionMunged@
+diff --git a/utils/iserv-proxy/src/Main.hs b/utils/iserv-proxy/src/Main.hs
+index c91b2d08c6..3970ad5df1 100644
+--- a/utils/iserv-proxy/src/Main.hs
++++ b/utils/iserv-proxy/src/Main.hs
+@@ -1,4 +1,4 @@
+-{-# LANGUAGE CPP, GADTs, OverloadedStrings #-}
++{-# LANGUAGE CPP, GADTs, OverloadedStrings, LambdaCase #-}
+ 
+ {-
+ This is the proxy portion of iserv.
+@@ -65,6 +65,12 @@ import System.FilePath (isAbsolute)
+ import Data.Binary
+ import qualified Data.ByteString as BS
+ 
++import Control.Concurrent (threadDelay)
++import qualified Control.Exception as E
++
++trace :: String -> IO ()
++trace s = getProgName >>= \name -> printf "[%20s] %s\n" name s
++
+ dieWithUsage :: IO a
+ dieWithUsage = do
+     prog <- getProgName
+@@ -78,6 +84,9 @@ dieWithUsage = do
+ 
+ main :: IO ()
+ main = do
++  hSetBuffering stdin LineBuffering
++  hSetBuffering stdout LineBuffering
++
+   args <- getArgs
+   (wfd1, rfd2, host_ip, port, rest) <-
+       case args of
+@@ -104,10 +113,16 @@ main = do
+   let in_pipe = Pipe{pipeRead = inh, pipeWrite = outh, pipeLeftovers = lo_ref}
+ 
+   when verbose $
+-    putStrLn ("Trying to connect to " ++ host_ip ++ ":" ++ (show port))
+-  out_pipe <- connectTo host_ip port >>= socketToPipe
++    trace ("Trying to connect to " ++ host_ip ++ ":" ++ (show port))
+ 
+-  putStrLn "Starting proxy"
++  out_pipe <- do
++    let go n = E.try (connectTo host_ip port >>= socketToPipe) >>= \case
++          Left e | n == 0 -> E.throw (e :: E.SomeException)
++                 | n >  0 -> threadDelay 500000 >> go (n - 1)
++          Right a -> return a
++      in go 120 -- wait for up to 60seconds (polling every 0.5s).
++
++  trace "Starting proxy"
+   proxy verbose in_pipe out_pipe
+ 
+ -- | A hook, to transform outgoing (proxy -> slave)
+@@ -131,19 +146,24 @@ fwdTHMsg local msg = do
+ -- | Fowarard a @Message@ call and handle @THMessages@.
+ fwdTHCall :: (Binary a) => Bool -> Pipe -> Pipe -> Message a -> IO a
+ fwdTHCall verbose local remote msg = do
++  when verbose $ trace ("fwdTHCall: " ++ show msg)
+   writePipe remote (putMessage msg)
+   -- wait for control instructions
++  when verbose $ trace "waiting for control instructions..."
+   loopTH
++  when verbose $ trace "reading remote pipe result"
+   readPipe remote get
+     where
+       loopTH :: IO ()
+       loopTH = do
++        when verbose $
++          trace "fwdTHCall/loopTH: reading remote pipe..."
+         THMsg msg' <- readPipe remote getTHMessage
+         when verbose $
+-          putStrLn ("| TH Msg: ghc <- proxy -- slave: " ++ show msg')
++          trace ("| TH Msg: ghc <- proxy -- slave: " ++ show msg')
+         res <- fwdTHMsg local msg'
+         when verbose $
+-          putStrLn ("| Resp.:  ghc -- proxy -> slave: " ++ show res)
++          trace ("| Resp.:  ghc -- proxy -> slave: " ++ show res)
+         writePipe remote (put res)
+         case msg' of
+           RunTHDone -> return ()
+@@ -161,8 +181,10 @@ fwdTHCall verbose local remote msg = do
+ --
+ fwdLoadCall :: (Binary a, Show a) => Bool -> Pipe -> Pipe -> Message a -> IO a
+ fwdLoadCall verbose _ remote msg = do
++  when verbose $ trace "fwdLoadCall: writing remote pipe"
+   writePipe remote (putMessage msg)
+   loopLoad
++  when verbose $ trace "fwdLoadCall: reading local pipe"
+   readPipe remote get
+   where
+     truncateMsg :: Int -> String -> String
+@@ -171,17 +193,19 @@ fwdLoadCall verbose _ remote msg = do
+     reply :: (Binary a, Show a) => a -> IO ()
+     reply m = do
+       when verbose $
+-        putStrLn ("| Resp.:         proxy -> slave: "
++        trace ("| Resp.:         proxy -> slave: "
+                   ++ truncateMsg 80 (show m))
+       writePipe remote (put m)
+     loopLoad :: IO ()
+     loopLoad = do
++      when verbose $ trace "fwdLoadCall: reading remote pipe"
+       SlaveMsg msg' <- readPipe remote getSlaveMessage
+       when verbose $
+-        putStrLn ("| Sl Msg:        proxy <- slave: " ++ show msg')
++        trace ("| Sl Msg:        proxy <- slave: " ++ show msg')
+       case msg' of
+         Done -> return ()
+         Missing path -> do
++          trace $ "fwdLoadCall: missing path: " ++ path
+           reply =<< BS.readFile path
+           loopLoad
+         Have path remoteHash -> do
+@@ -198,21 +222,33 @@ proxy verbose local remote = loop
+   where
+     fwdCall :: (Binary a, Show a) => Message a -> IO a
+     fwdCall msg = do
++      when verbose $ trace "proxy/fwdCall: writing remote pipe"
+       writePipe remote (putMessage msg)
++      when verbose $ trace "proxy/fwdCall: reading remote pipe"
+       readPipe remote get
+ 
+     -- reply to ghc.
+     reply :: (Show a, Binary a) => a -> IO ()
+     reply msg = do
+       when verbose $
+-        putStrLn ("Resp.:    ghc <- proxy -- slave: " ++ show msg)
++        trace ("Resp.:    ghc <- proxy -- slave: " ++ show msg)
+       writePipe local (put msg)
+ 
+     loop = do
+       (Msg msg) <- readPipe local getMessage
+       when verbose $
+-        putStrLn ("Msg:      ghc -- proxy -> slave: " ++ show msg)
++        trace ("Msg:      ghc -- proxy -> slave: " ++ show msg)
+       (Msg msg') <- hook (Msg msg)
++      -- Note [proxy-communication]
++      --
++      -- The fwdTHCall/fwdLoadCall/fwdCall's have to match up
++      -- with their endpoints in libiserv:Remote.Slave otherwise
++      -- you will end up with hung connections.
++      --
++      -- We are intercepting some calls between ghc and iserv
++      -- and augment the protocol here.  Thus these two sides
++      -- need to line up and know what request/reply to expect.
++      --
+       case msg' of
+         -- TH might send some message back to ghc.
+         RunTH{} -> do
+@@ -233,6 +269,10 @@ proxy verbose local remote = loop
+           resp <- fwdLoadCall verbose local remote msg'
+           reply resp
+           loop
++        -- On windows we assume that we don't want to copy libraries
++        -- that are referenced in C:\ these are usually system libraries.
++        LoadDLL path@('C':':':_) -> do
++          fwdCall msg' >>= reply >> loop
+         LoadDLL path | isAbsolute path -> do
+           resp <- fwdLoadCall verbose local remote msg'
+           reply resp
+@@ -243,14 +283,19 @@ proxy verbose local remote = loop
+ 
+ connectTo :: String -> PortNumber -> IO Socket
+ connectTo host port = do
+-  let hints = defaultHints { addrFlags = [AI_NUMERICHOST, AI_NUMERICSERV]
+-                           , addrSocketType = Stream }
+-  addr:_ <- getAddrInfo (Just hints) (Just host) (Just (show port))
+-  sock <- socket (addrFamily addr) (addrSocketType addr) (addrProtocol addr)
+-  putStrLn $ "Created socket for " ++ host ++ ":" ++ show port
+-  connect sock (addrAddress addr)
+-  putStrLn "connected"
+-  return sock
++  addr <- resolve host (show port)
++  open addr
++  where
++    resolve host port = do
++        let hints = defaultHints { addrSocketType = Stream }
++        addr:_ <- getAddrInfo (Just hints) (Just host) (Just port)
++        return addr
++    open addr = do
++        sock <- socket (addrFamily addr) (addrSocketType addr) (addrProtocol addr)
++        trace $ "Created socket for " ++ host ++ ":" ++ show port
++        connect sock $ addrAddress addr
++        trace "connected"
++        return sock
+ 
+ -- | Turn a socket into an unbuffered pipe.
+ socketToPipe :: Socket -> IO Pipe
+diff --git a/utils/iserv/iserv.cabal.in b/utils/iserv/iserv.cabal.in
+new file mode 100644
+index 0000000000..356c8a444a
+--- /dev/null
++++ b/utils/iserv/iserv.cabal.in
+@@ -0,0 +1,48 @@
++-- WARNING: iserv.cabal is automatically generated from iserv.cabal.in by
++-- ../../configure.  Make sure you are editing iserv.cabal.in, not
++-- iserv.cabal.
++
++Name: iserv
++Version: @ProjectVersion@
++Copyright: XXX
++License: BSD3
++-- XXX License-File: LICENSE
++Author: XXX
++Maintainer: XXX
++Synopsis: iserv allows GHC to delegate Template Haskell computations
++Description:
++  GHC can be provided with a path to the iserv binary with
++  @-pgmi=/path/to/iserv-bin@, and will in combination with
++  @-fexternal-interpreter@, compile Template Haskell though the
++  @iserv-bin@ delegate. This is very similar to how ghcjs has been
++  compiling Template Haskell, by spawning a separate delegate (so
++  called runner on the javascript vm) and evaluating the splices
++  there.
++  .
++  To use iserv with cross compilers, please see @libraries/libiserv@
++  and @utils/iserv-proxy@.
++
++Category: Development
++build-type: Simple
++cabal-version: >=1.10
++
++Executable iserv
++    Default-Language: Haskell2010
++    ghc-options: -no-hs-main
++    Main-Is: Main.hs
++    C-Sources: cbits/iservmain.c
++    Hs-Source-Dirs: src
++    include-dirs: .
++    Build-Depends: array      >= 0.5 && < 0.6,
++                   base       >= 4   && < 5,
++                   binary     >= 0.7 && < 0.11,
++                   bytestring >= 0.10 && < 0.11,
++                   containers >= 0.5 && < 0.7,
++                   deepseq    >= 1.4 && < 1.5,
++                   ghci       == @ProjectVersionMunged@,
++                   libiserv   == @ProjectVersionMunged@
++
++    if os(windows)
++        Cpp-Options: -DWINDOWS
++    else
++        Build-Depends: unix   >= 2.7 && < 2.9
+diff --git a/utils/remote-iserv/Makefile b/utils/remote-iserv/Makefile
+new file mode 100644
+index 0000000000..c659a21a20
+--- /dev/null
++++ b/utils/remote-iserv/Makefile
+@@ -0,0 +1,15 @@
++# -----------------------------------------------------------------------------
++#
++# (c) 2009 The University of Glasgow
++#
++# This file is part of the GHC build system.
++#
++# To understand how the build system works and how to modify it, see
++#      http://ghc.haskell.org/trac/ghc/wiki/Building/Architecture
++#      http://ghc.haskell.org/trac/ghc/wiki/Building/Modifying
++#
++# -----------------------------------------------------------------------------
++
++dir = remote-iserv
++TOP = ../..
++include $(TOP)/mk/sub-makefile.mk
+diff --git a/utils/remote-iserv/Setup.hs b/utils/remote-iserv/Setup.hs
+new file mode 100644
+index 0000000000..44671092b2
+--- /dev/null
++++ b/utils/remote-iserv/Setup.hs
+@@ -0,0 +1,2 @@
++import           Distribution.Simple
++main = defaultMain
+diff --git a/utils/remote-iserv/ghc.mk b/utils/remote-iserv/ghc.mk
+new file mode 100644
+index 0000000000..db8f32fc22
+--- /dev/null
++++ b/utils/remote-iserv/ghc.mk
+@@ -0,0 +1,113 @@
++# -----------------------------------------------------------------------------
++#
++# (c) 2009-2012 The University of Glasgow
++#
++# This file is part of the GHC build system.
++#
++# To understand how the build system works and how to modify it, see
++#      http://ghc.haskell.org/trac/ghc/wiki/Building/Architecture
++#      http://ghc.haskell.org/trac/ghc/wiki/Building/Modifying
++#
++# -----------------------------------------------------------------------------
++
++utils/remote-iserv_USES_CABAL = YES
++utils/remote-iserv_PACKAGE = remote-iserv
++utils/remote-iserv_EXECUTABLE = remote-iserv
++
++ifeq "$(GhcDebugged)" "YES"
++utils/remote-iserv_stage2_MORE_HC_OPTS += -debug
++utils/remote-iserv_stage2_p_MORE_HC_OPTS += -debug
++utils/remote-iserv_stage2_dyn_MORE_HC_OPTS += -debug
++endif
++
++ifeq "$(GhcThreaded)" "YES"
++utils/remote-iserv_stage2_MORE_HC_OPTS += -threaded
++utils/remote-iserv_stage2_p_MORE_HC_OPTS += -threaded
++utils/remote-iserv_stage2_dyn_MORE_HC_OPTS += -threaded
++endif
++
++# Add -Wl,--export-dynamic enables GHCi to load dynamic objects that
++# refer to the RTS.  This is harmless if you don't use it (adds a bit
++# of overhead to startup and increases the binary sizes) but if you
++# need it there's no alternative.
++ifeq "$(TargetElf)" "YES"
++ifneq "$(TargetOS_CPP)" "solaris2"
++# The Solaris linker does not support --export-dynamic option. It also
++# does not need it since it exports all dynamic symbols by default
++utils/remote-iserv_stage2_MORE_HC_OPTS += -optl-Wl,--export-dynamic
++utils/remote-iserv_stage2_p_MORE_HC_OPTS += -optl-Wl,--export-dynamic
++utils/remote-iserv_stage2_dyn_MORE_HC_OPTS += -optl-Wl,--export-dynamic
++endif
++endif
++
++# Override the default way, because we want a specific version of this
++# program for each way.  Note that it's important to do this even for
++# the vanilla version, otherwise we get a dynamic executable when
++# DYNAMIC_GHC_PROGRAMS=YES.
++utils/remote-iserv_stage2_PROGRAM_WAY = v
++utils/remote-iserv_stage2_p_PROGRAM_WAY = p
++utils/remote-iserv_stage2_dyn_PROGRAM_WAY = dyn
++
++utils/remote-iserv_stage2_PROGNAME = ghc-iserv
++utils/remote-iserv_stage2_p_PROGNAME = ghc-iserv-prof
++utils/remote-iserv_stage2_dyn_PROGNAME = ghc-iserv-dyn
++
++utils/remote-iserv_stage2_MORE_HC_OPTS += -no-hs-main
++utils/remote-iserv_stage2_p_MORE_HC_OPTS += -no-hs-main
++utils/remote-iserv_stage2_dyn_MORE_HC_OPTS += -no-hs-main
++
++utils/remote-iserv_stage2_INSTALL = YES
++utils/remote-iserv_stage2_p_INSTALL = YES
++utils/remote-iserv_stage2_dyn_INSTALL = YES
++
++# Install in $(libexec), not in $(bindir)
++utils/remote-iserv_stage2_TOPDIR = YES
++utils/remote-iserv_stage2_p_TOPDIR = YES
++utils/remote-iserv_stage2_dyn_TOPDIR = YES
++
++utils/remote-iserv_stage2_INSTALL_INPLACE = YES
++utils/remote-iserv_stage2_p_INSTALL_INPLACE = YES
++utils/remote-iserv_stage2_dyn_INSTALL_INPLACE = YES
++
++ifeq "$(CLEANING)" "YES"
++
++NEED_iserv = YES
++NEED_iserv_p = YES
++NEED_iserv_dyn = YES
++
++else
++
++ifneq "$(findstring v, $(GhcLibWays))" ""
++NEED_iserv = YES
++else
++NEED_iserv = NO
++endif
++
++ifneq "$(findstring p, $(GhcLibWays))" ""
++NEED_iserv_p = YES
++else
++NEED_iserv_p = NO
++endif
++
++ifneq "$(findstring dyn, $(GhcLibWays))" ""
++NEED_iserv_dyn = YES
++else
++NEED_iserv_dyn = NO
++endif
++endif
++
++ifeq "$(NEED_iserv)" "YES"
++$(eval $(call build-prog,utils/remote-iserv,stage2,1))
++endif
++
++ifeq "$(NEED_iserv_p)" "YES"
++$(eval $(call build-prog,utils/remote-iserv,stage2_p,1))
++endif
++
++ifeq "$(NEED_iserv_dyn)" "YES"
++$(eval $(call build-prog,utils/remote-iserv,stage2_dyn,1))
++endif
++
++all_ghc_stage2 : $(remote-iserv-stage2_INPLACE)
++all_ghc_stage2 : $(remote-iserv-stage2_p_INPLACE)
++all_ghc_stage2 : $(remote-iserv-stage2_dyn_INPLACE)
+diff --git a/utils/remote-iserv/remote-iserv.cabal.in b/utils/remote-iserv/remote-iserv.cabal.in
+new file mode 100644
+index 0000000000..2e9123bf5e
+--- /dev/null
++++ b/utils/remote-iserv/remote-iserv.cabal.in
+@@ -0,0 +1,27 @@
++-- WARNING: iserv-proxy.cabal is automatically generated from iserv-proxy.cabal.in by
++-- ../../configure.  Make sure you are editing iserv-proxy.cabal.in, not
++-- iserv-proxy.cabal.
++
++Name: remote-iserv
++Version: @ProjectVersion@
++Copyright: XXX
++License: BSD3
++-- XXX License-File: LICENSE
++Author: Moritz Angermann <moritz.angermann@gmail.com>
++Maintainer: Moritz Angermann <moritz.angermann@gmail.com>
++Synopsis: iserv allows GHC to delegate Tempalte Haskell computations
++Description:
++  This is a very simple remote runner for iserv, to be used together
++  with iserv-proxy.  The foundamental idea is that this this wrapper
++  starts running libiserv on a given port to which iserv-proxy will
++  then connect.
++Category: Development
++build-type: Simple
++cabal-version: >=1.10
++
++Executable remote-iserv
++   Default-Language: Haskell2010
++   Main-Is: Cli.hs
++   Hs-Source-Dirs: src
++   Build-Depends: base       >= 4   && < 5,
++                  libiserv   == @ProjectVersionMunged@
+diff --git a/utils/remote-iserv/src/Cli.hs b/utils/remote-iserv/src/Cli.hs
+new file mode 100644
+index 0000000000..eb8f92c39c
+--- /dev/null
++++ b/utils/remote-iserv/src/Cli.hs
+@@ -0,0 +1,30 @@
++module Main where
++
++import           Remote.Slave (startSlave')
++import           System.Environment (getArgs, getProgName)
++import           System.Exit (die)
++
++main :: IO ()
++main = getArgs >>= startSlave
++
++dieWithUsage :: IO a
++dieWithUsage = do
++  prog <- getProgName
++  die $ msg prog
++ where
++  msg name = "usage: " ++ name ++ " /path/to/storage PORT [-v]"
++
++startSlave :: [String] -> IO ()
++startSlave args0
++  | "--help" `elem` args0 = dieWithUsage
++  | otherwise = do
++      (path, port, rest) <- case args0 of
++        arg0:arg1:rest -> return (arg0, read arg1, rest)
++        _              -> dieWithUsage
++
++      verbose <- case rest of
++        ["-v"] -> return True
++        []     -> return False
++        _      -> dieWithUsage
++
++      startSlave' verbose path port

--- a/patches/ghc/mistuke-ghc-err_clean_up_error_handler-8ab1a89af89848f1713e6849f189de66c0ed7898.diff
+++ b/patches/ghc/mistuke-ghc-err_clean_up_error_handler-8ab1a89af89848f1713e6849f189de66c0ed7898.diff
@@ -1,0 +1,98 @@
+diff --git a/rts/win32/veh_excn.c b/rts/win32/veh_excn.c
+index 2d9de52199b..b86abe64b0c 100644
+--- a/rts/win32/veh_excn.c
++++ b/rts/win32/veh_excn.c
+@@ -92,14 +92,9 @@
+ // Registered exception handler
+ PVOID __hs_handle = NULL;
+ LPTOP_LEVEL_EXCEPTION_FILTER oldTopFilter = NULL;
+-bool crash_dump = false;
+-bool filter_called = false;
+ 
+ long WINAPI __hs_exception_handler(struct _EXCEPTION_POINTERS *exception_data)
+ {
+-    if (!crash_dump && filter_called)
+-      return EXCEPTION_CONTINUE_EXECUTION;
+-
+     long action   = EXCEPTION_CONTINUE_SEARCH;
+     int exit_code = EXIT_FAILURE;
+     ULONG_PTR what;
+@@ -107,7 +102,9 @@ long WINAPI __hs_exception_handler(struct _EXCEPTION_POINTERS *exception_data)
+ 
+     // When the system unwinds the VEH stack after having handled an excn,
+     // return immediately.
+-    if ((exception_data->ExceptionRecord->ExceptionFlags & EH_UNWINDING) == 0)
++    if (exception_data
++        && exception_data->ExceptionRecord
++        && (exception_data->ExceptionRecord->ExceptionFlags & EH_UNWINDING) ==0)
+     {
+         // Error handling cases covered by this implementation.
+         switch (exception_data->ExceptionRecord->ExceptionCode) {
+@@ -122,20 +119,31 @@ long WINAPI __hs_exception_handler(struct _EXCEPTION_POINTERS *exception_data)
+                 action = EXCEPTION_CONTINUE_EXECUTION;
+                 break;
+             case EXCEPTION_ACCESS_VIOLATION:
+-                what = exception_data->ExceptionRecord->ExceptionInformation[0];
+-                fprintf(stderr, "Access violation in generated code"
+-                                " when %s 0x%" PRIxPTR "\n"
+-                                , what == 0 ? "reading"
+-                                : what == 1 ? "writing"
+-                                : what == 8 ? "executing data at"
+-                                :             "?"
+-                                , (uintptr_t) exception_data
+-                                                ->ExceptionRecord
+-                                                ->ExceptionInformation[1]
++              {
++                if (exception_data->ExceptionRecord->NumberParameters < 2)
++                  {
++                    fprintf(stderr, "Access violation in generated code. "
++                                    "Empty exception record.");
++                  }
++                else
++                  {
++                    what = exception_data->ExceptionRecord
++                                         ->ExceptionInformation[0];
++                    fprintf(stderr, "Access violation in generated code"
++                                    " when %s 0x%" PRIxPTR "\n"
++                                    , what == 0 ? "reading"
++                                    : what == 1 ? "writing"
++                                    : what == 8 ? "executing data at"
++                                    :             "?"
++                                    , (uintptr_t) exception_data
++                                                    ->ExceptionRecord
++                                                    ->ExceptionInformation[1]
+                                 );
++                  }
+                 action = EXCEPTION_CONTINUE_EXECUTION;
+                 exit_code = SIGSEGV;
+                 break;
++              }
+             default:;
+         }
+ 
+@@ -154,19 +162,22 @@ long WINAPI __hs_exception_handler(struct _EXCEPTION_POINTERS *exception_data)
+     return action;
+ }
+ 
++/* Registered top level exception filter.  We're not very interested in handling
++   the error here, that's why we have __hs_exception_handler, but we do want
++   to register the fact that the filter was called.  This allows us to prevent
++   continuing to run when the exception was completely unhandled.
++   EXCEPTION_CONTINUE_EXECUTION is returned so that the OS gives the VEH
++   handlers a chance to run.  */
+ long WINAPI __hs_exception_filter(struct _EXCEPTION_POINTERS *exception_data)
+ {
+-    filter_called = true;
+     long result = EXCEPTION_CONTINUE_EXECUTION;
+     if (oldTopFilter)
+     {
+         result = (*oldTopFilter)(exception_data);
+         if (EXCEPTION_CONTINUE_SEARCH == result)
+             result = EXCEPTION_CONTINUE_EXECUTION;
+-        return result;
+     }
+ 
+-    crash_dump = true;
+     return result;
+ }
+ 

--- a/patches/streaming-commons-0.2.0.0.patch
+++ b/patches/streaming-commons-0.2.0.0.patch
@@ -1,0 +1,15 @@
+diff --git a/System/Win32File.hsc b/System/Win32File.hsc
+index a524c77..8e8071d 100644
+--- a/System/Win32File.hsc
++++ b/System/Win32File.hsc
+@@ -31,8 +31,8 @@ import Data.ByteString.Lazy.Internal (defaultChunkSize)
+ 
+ 
+ #include <fcntl.h>
+-#include <Share.h>
+-#include <SYS/Stat.h>
++#include <share.h>
++#include <sys/stat.h>
+ #include <errno.h>
+ 
+ newtype OFlag = OFlag CInt

--- a/patches/x509-system-1.6.6.patch
+++ b/patches/x509-system-1.6.6.patch
@@ -1,0 +1,13 @@
+diff --git a/x509-system.cabal b/x509-system.cabal
+index 95a21a1..8b23b3d 100644
+--- a/x509-system.cabal
++++ b/x509-system.cabal
+@@ -32,7 +32,7 @@ Library
+   if os(windows)
+      cpp-options:     -DWINDOWS
+      Build-Depends:   Win32, asn1-encoding
+-     extra-libraries: Crypt32
++     extra-libraries: crypt32
+      Exposed-modules: System.X509.Win32
+   if os(OSX)
+      cpp-options: -DMACOSX

--- a/pkgs/rocksdb-prebuilt.nix
+++ b/pkgs/rocksdb-prebuilt.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchurl, unzip }:
+stdenv.mkDerivation {
+  name = "rocksdb-prebuilt";
+  src = fetchurl {
+    url = "https://s3.eu-central-1.amazonaws.com/ci-static/serokell-rocksdb-haskell-325427fc709183c8fdf777ad5ea09f8d92bf8585.zip";
+    sha256 = "11w6nbg39y7n3j7d5p4mvls3h5sbld71nx8yxxrckh8ak8yr6kwp";
+  };
+  nativeBuildInputs = [ unzip ];
+  buildInputs = [ unzip ];
+
+  unpackPhase = ''
+    unzip $src
+  '';
+  dontBuild = true;
+  installPhase = ''
+    install -d $out/lib
+    # dlls
+    for dll in $(find . -name "*.dll"); do
+        install -C -m 755 $dll $out/lib
+    done
+    # libs
+    for lib in $(find . -name "*.lib"); do
+        install -C -m 755 $lib $out/lib
+    done
+    # archives
+    for archive in $(find . -name "*.a"); do
+        install -C -m 755 $archive $out/lib
+    done
+  '';
+}


### PR DESCRIPTION
As such we can now define:

```nix
let
  localLib = import ./lib.nix;
in
{ pkgs, ... }@args
localLib.nix-tools.default-nix ./nix/pkgs.nix args // {
    # additional non-haskell packages we want to build on CI.
    byronLedgerSpec = import ./specs/ledger/latex {};
    byronChainSpec = import ./specs/chain/latex {};
    semanticsSpec = import ./specs/semantics/latex {};
}
```
as `default.nix`

and

```nix
let
  localLib = import ./lib.nix;
in
localLib.nix-tools.release-nix {
  package-set-path = ./.;

  # packages from our stack.yaml or plan file (via nix/pkgs.nix) we
  # are intereted in building on CI via nix-tools.
  packages = [ "cardano-chain" "cs-ledger" "small-steps" "cs-blockchain" ];

  # The set of jobs we consider crutial for each CI run.
  # if a single one of these fails, the build will be marked
  # as failed.
  #
  # The names can be looked up on hydra when in doubt.
  #
  # custom jobs will follow their name as set forth in
  # other-packages.
  #
  # nix-tools packages withh be prefixed with nix-tools and
  # follow the following naming convention:
  #
  #   namespace                      optional cross compilation prefix                 build machine
  #   .-------.                              .-----------------.                .--------------------------.
  #   nix-tools.{libs,exes,tests,benchmarks}.{x86_64-pc-mingw-,}$pkg.$component.{x86_64-linux,x86_64-darwin}
  #             '--------------------------'                    '-------------'
  #                 component type                          cabal pkg and component*
  #
  # * note that for libs, $component is empty, as cabal only
  # provides a single library for packages right now.
  #
  # Example:
  #
  #   libs.cardano-chain.x86_64-darwin -- will build the cardano-chain library on and for macOS
  #   libs.cardano-chain.x86_64-linux -- will build the cardano-chain library on and for linux
  #   libs.x86_64-pc-mingw32-cardano-chain.x86_64-linux -- will build the cardano-chain library on linux for windows.
  #   tests.cs-ledger.ledger-delegation-test.x86_64-linux -- will build and run the ledger-delegation-test from the
  #                                                          cs-ledger package on linux.
  #
  required-name = "cardano-chain-required-checks";
  required-targets = jobs: [
    jobs.byronLedgerSpec
    jobs.byronChainSpec
    jobs.semanticsSpec

    jobs.nix-tools.libs.cs-blockchain.x86_64-darwin
    # ...

    # windows cross compilation targets
    jobs.nix-tools.libs.x86_64-pc-mingw32-cardano-chain.x86_64-linux
    # ...
  ];
}
```
as `release.nix`.