### PR TITLE
Use config.nix with haskell by default

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -50,11 +50,7 @@ let
     # stack.yaml files.
     package = haskell.nix-tools;
     # A different haskell infrastructure
-    haskell = commonLib.pkgsDefault.callPackage ./haskell.nix {
-      # We need to pass `pkgs` here, otherwise we loose all
-      # config customizations that are essential.
-      pkgs = commonLib.pkgs;
-    };
+    haskell = commonLib.pkgsDefault.callPackage ./haskell.nix;
     # Script to invoke nix-tools stack-to-nix on a repo.
     regeneratePackages = commonLib.pkgsDefault.callPackage ./nix-tools-regenerate.nix {
       nix-tools = package;

--- a/default.nix
+++ b/default.nix
@@ -51,7 +51,9 @@ let
     package = haskell.nix-tools;
     # A different haskell infrastructure
     haskell = commonLib.pkgsDefault.callPackage ./haskell.nix {
-      pkgs = commonLib.pkgsDefault;
+      # We need to pass `pkgs` here, otherwise we loose all
+      # config customizations that are essential.
+      pkgs = commonLib.pkgs;
     };
     # Script to invoke nix-tools stack-to-nix on a repo.
     regeneratePackages = commonLib.pkgsDefault.callPackage ./nix-tools-regenerate.nix {

--- a/default.nix
+++ b/default.nix
@@ -48,9 +48,9 @@ let
   nix-tools = rec {
     # Programs for generating nix haskell package sets from cabal and
     # stack.yaml files.
-    package = haskell.nix-tools;
+    package = (haskell { pkgs = commonLib.pkgsDefault; }).nix-tools;
     # A different haskell infrastructure
-    haskell = commonLib.pkgsDefault.callPackage ./haskell.nix;
+    haskell = import ./haskell.nix;
     # Script to invoke nix-tools stack-to-nix on a repo.
     regeneratePackages = commonLib.pkgsDefault.callPackage ./nix-tools-regenerate.nix {
       nix-tools = package;

--- a/nix-tools-default.nix
+++ b/nix-tools-default.nix
@@ -9,9 +9,14 @@ nix-tools-pkgs-path: # the path to the local pkgs.nix file for nix-tools that im
 }:
 with builtins; with pkgs.lib;
 let  nix-tools = import nix-tools-pkgs-path {
+  haskell = commonLib.nix-tools.haskell {
+    # We need to pass `pkgs` here, otherwise we loose all
+    # config customizations that are essential.
+    inherit pkgs;
+  };
   inherit pkgs;
   # the iohk-module contains cross compilation specific patches
-  inherit (commonLib.nix-tools) haskell iohk-module iohk-overlay;
+  inherit (commonLib.nix-tools) iohk-module iohk-overlay;
 };
 in {
     _lib = commonLib;

--- a/pins/haskell-nix.json
+++ b/pins/haskell-nix.json
@@ -1,7 +1,7 @@
 {
   "url": "https://github.com/input-output-hk/haskell.nix",
-  "rev": "3584345a9ab001d1867e972a1a20b4406cbffd68",
-  "date": "2019-02-14T09:35:57+08:00",
-  "sha256": "08pzfvspfl5nvn5szy7bv3rbwymjgmbdm1ac571c64fzhrwf5ghw",
+  "rev": "0b2d033eefeaf9339320b27a0b159e80a890fc29",
+  "date": "2019-03-05T08:35:36+10:00",
+  "sha256": "0x594a72kyhs4vd3pj401x131ilwjgm4lz6sns8hfb6l166qywf3",
   "fetchSubmodules": false
 }


### PR DESCRIPTION
We have a lot of patches in our config.nix file and those whould be
auto-applied to our package set.  Hence we want commonLib.pkgs instead
of commonLib.pkgsDefault.