### PR TITLE
Move haskell pkgs argument application

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -50,11 +50,7 @@ let
     # stack.yaml files.
     package = haskell.nix-tools;
     # A different haskell infrastructure
-    haskell = commonLib.pkgsDefault.callPackage ./haskell.nix {
-      # We need to pass `pkgs` here, otherwise we loose all
-      # config customizations that are essential.
-      pkgs = commonLib.pkgs;
-    };
+    haskell = commonLib.pkgsDefault.callPackage ./haskell.nix;
     # Script to invoke nix-tools stack-to-nix on a repo.
     regeneratePackages = commonLib.pkgsDefault.callPackage ./nix-tools-regenerate.nix {
       nix-tools = package;

--- a/nix-tools-default.nix
+++ b/nix-tools-default.nix
@@ -9,9 +9,14 @@ nix-tools-pkgs-path: # the path to the local pkgs.nix file for nix-tools that im
 }:
 with builtins; with pkgs.lib;
 let  nix-tools = import nix-tools-pkgs-path {
+  haskell = commonLib.nix-tools.haskell {
+    # We need to pass `pkgs` here, otherwise we loose all
+    # config customizations that are essential.
+    inherit pkgs;
+  };
   inherit pkgs;
   # the iohk-module contains cross compilation specific patches
-  inherit (commonLib.nix-tools) haskell iohk-module iohk-overlay;
+  inherit (commonLib.nix-tools) iohk-module iohk-overlay;
 };
 in {
     _lib = commonLib;


### PR DESCRIPTION
 to where it matters for cross-compilation. (I think?)

Though cross-build still fails with:
```
building '/nix/store/p8lps3zabjjjw31kl3j9cxdcc3vj9fky-auto-update-0.1.4-lib-auto-update-x86_64-pc-mingw32.drv'...
unpacking sources
unpacking source archive /nix/store/v2rifjrd3zhgwgpggfcpkqjisfq1w8f6-auto-update-0.1.4.tar.gz
source root is auto-update-0.1.4
setting SOURCE_DATE_EPOCH to timestamp 1462772624 of file auto-update-0.1.4/Setup.hs
patching sources
configuring
Configure flags:
--prefix=/nix/store/gnpvpnj4m3wrijy1fwdgqqc7mbpx6xm6-auto-update-0.1.4-lib-auto-update-x86_64-pc-mingw32 lib:auto-update --package-db=clear --package-db=/nix/store/ixijzblhr6r51l2aqw12i0zxlfadjr4x-auto-update-0.1.4-lib-auto-update-config-x86_64-pc-mingw32/package.conf.d --with-ghc=x86_64-pc-mingw32-ghc --with-ghc-pkg=x86_64-pc-mingw32-ghc-pkg --with-hsc2hs=x86_64-pc-mingw32-hsc2hs --with-gcc=x86_64-pc-mingw32-cc --with-ld=x86_64-pc-mingw32-ld --with-ar=x86_64-pc-mingw32-ar --with-strip=x86_64-pc-mingw32-strip --enable-executable-stripping --enable-library-stripping --docdir=/nix/store/nh3hw88wxala3i7mddii9phxwgx4kn8w-auto-update-0.1.4-lib-auto-update-x86_64-pc-mingw32-doc/share/doc/auto-update --hsc2hs-option=--cross-compile --hsc2hs-option=--via-asm
Configuring library for auto-update-0.1.4..
Loaded package environment from /nix/store/ixijzblhr6r51l2aqw12i0zxlfadjr4x-auto-update-0.1.4-lib-auto-update-config-x86_64-pc-mingw32/ghc-environment
building
Preprocessing library for auto-update-0.1.4..
Building library for auto-update-0.1.4..
Loaded package environment from /nix/store/ixijzblhr6r51l2aqw12i0zxlfadjr4x-auto-update-0.1.4-lib-auto-update-config-x86_64-pc-mingw32/ghc-environment
Loaded package environment from /nix/store/ixijzblhr6r51l2aqw12i0zxlfadjr4x-auto-update-0.1.4-lib-auto-update-config-x86_64-pc-mingw32/ghc-environment
[1 of 4] Compiling Control.AutoUpdate ( Control/AutoUpdate.hs, dist/build/Control/AutoUpdate.o )
[2 of 4] Compiling Control.AutoUpdate.Util ( Control/AutoUpdate/Util.hs, dist/build/Control/AutoUpdate/Util.o )
[3 of 4] Compiling Control.Debounce ( Control/Debounce.hs, dist/build/Control/Debounce.o )
[4 of 4] Compiling Control.Reaper   ( Control/Reaper.hs, dist/build/Control/Reaper.o )
haddockPhase
Setup: The program 'haddock' version >=2.0 is required but it could not be
found.

builder for '/nix/store/p8lps3zabjjjw31kl3j9cxdcc3vj9fky-auto-update-0.1.4-lib-auto-update-x86_64-pc-mingw32.drv' failed with exit code 1
building '/nix/store/lbyrjl6afp5msmgnw0qk6pwj4vdjy7r3-bytestring-0.10.8.2-lib-bytestring-x86_64-pc-mingw32.drv'...
cannot build derivation '/nix/store/ri756z31z9haaliz6d8pj3vmflpsm65x-iohk-monitoring-0.1.1.0-exe-example-simple-config-x86_64-pc-mingw32.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/94vx389nbwck4c0901shk8lmm2k4alin-iohk-monitoring-0.1.1.0-exe-example-simple-x86_64-pc-mingw32.drv': 1 dependencies couldn't be built
error: build of '/nix/store/94vx389nbwck4c0901shk8lmm2k4alin-iohk-monitoring-0.1.1.0-exe-example-simple-x86_64-pc-mingw32.drv' failed
```

Should `doHaddock` be set to false when cross-building packages?
or a "not cross-compiled" haddock be made available somehow.