### PR TITLE
Add Nix gotcha - unix/win32 dependency issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This repo contains build code and tools shared between IOHK projects.
 6. Nix packages and overlay for the [rust-cardano](https://github.com/input-output-hk/rust-cardano)
    projects.
 
+
 ## How to use in your project
 
 Use `iohk-nix` by "pinning" its git revision and source hash in a JSON
@@ -54,6 +55,7 @@ the HEAD of the `master` branch.
 $ nix-prefetch-git https://github.com/input-output-hk/iohk-nix [ --rev master ] | tee ./nix/iohk-nix.json
 ```
 
+
 ## How to update the `iohk-nix` revision.
 
 To get the latest version of `iohk-nix`, update the `iohk-nix.json` file:
@@ -65,9 +67,11 @@ $ nix-prefetch-git https://github.com/input-output-hk/iohk-nix | tee ./nix/iohk-
 Some things may have changed which could break your build, so refer to
 the [ChangeLog](./changelog.md).
 
+
 ## How to use Haskell.nix and `stack-to-nix`
 
 The [documentation](./docs/nix-toolification.org) needs to be updated.
+
 
 ## After updating your Stackage LTS
 
@@ -83,6 +87,14 @@ that version of GHC, and you will get an error such as:
 In this case, update the `iohk-nix` revision to the latest
 available. The nixpkgs version may also need to be bumped in
 `iohk-nix`.
+
+
+## Nix Gotchas
+
+The [gotchas folder](./gotchas) is dedicated to typical Nix errors encountered while developing with Haskell and Nix.
+The hope is developers will add Nix related problems they've encountered and solved to this folder.
+
+* [Gotcha 1](./gotchas/gotcha-1.md) - attribute `unbuildable` missing (win32/unix dependency issues)
 
 
 ## When making changes to `iohk-nix`

--- a/gotchas/README.md
+++ b/gotchas/README.md
@@ -1,0 +1,7 @@
+# Nix Gotchas
+
+This folder is dedicated to typical Nix errors encountered while developing with Haskell and Nix.
+The hope is developers will add Nix related problems they've encountered and solved to this folder.
+
+####Gotcha 1
+ attribute `unbuildable` missing (win32/unix dependency issues)

--- a/gotchas/README.md
+++ b/gotchas/README.md
@@ -1,7 +1,0 @@
-# Nix Gotchas
-
-This folder is dedicated to typical Nix errors encountered while developing with Haskell and Nix.
-The hope is developers will add Nix related problems they've encountered and solved to this folder.
-
-####Gotcha 1
- attribute `unbuildable` missing (win32/unix dependency issues)

--- a/gotchas/gotcha-1.md
+++ b/gotchas/gotcha-1.md
@@ -1,0 +1,40 @@
+## attribute `unbuildable` missing
+
+```
+ERROR: evaluation completed in 9.13 seconds with 3 errors
+nix-tools.cexes.x86_64-pc-mingw32-cardano-ledger.cardano-chain-validation-exe.x86_64-linux: attribute 'unbuildable' missing,
+at /nix/store/16sxhsfhvya2yvn6xdjqrz5c6m9w8yp1-hackage-exprs-source/hackage/unix-2.7.2.2-r2-4ef1d010d70a4a07a717e853d4a440c105dad38c6199316e320fdd4c48dacd34.nix:23:56
+...
+```
+### Probable cause
+
+This usually arises when using dependencies that are incompatible with the compilation target (i.e. in this case `unix` when building windows binaries)
+
+### Diagnosis
+
+We know the compilation target is windows and the dependency Nix is failing to build is `unix` because of `.x86_64-pc-mingw32-cardano-ledger` and `/hackage/unix-2.7.2.2`
+in the error message.
+
+If we look at the `unix` [cabal file](https://github.com/haskell/unix/blob/master/unix.cabal#L66):
+
+    if os(windows)
+        -- This package currently supports neither Cygwin nor MinGW,
+        -- therefore os(windows) is effectively not supported.
+        build-depends: unbuildable<0
+        buildable: False
+
+This is the source of our error!
+
+### Fix
+
+We need to locate which package has the `unix` dependency. If it's not in your package's `.cabal` file, you will need to check each of your depdendencies to see which has a `unix` dependency.
+
+
+When you have located the offending dependency, in the nix derivation for that dependency you should see `(hsPkgs.unix)` which should be replaced with:
+```
+          (if system.isWindows
+           then (hsPkgs.Win32)
+           else (hsPkgs.unix))
+```
+
+This will allow nix to build the appropriate dependencies and your error should be gone!


### PR DESCRIPTION
This PR adds:
- A folder that aims to collect Nix & Haskell related problems (Nix gotchas) during development. 
- A Nix gotcha related to unix/win32 dependency issues