### PR TITLE
Cleanup the config.nix

### DIFF
--- a/config.nix
+++ b/config.nix
@@ -43,6 +43,7 @@
          ++ lib.optional (versionAtLeast "8.2")                           ./patches/ghc/MR545--ghc-pkg-databases.patch                        # https://gitlab.haskell.org/ghc/ghc/merge_requests/545  -- merged; ghc-8.8.1
          ++ lib.optional (versionAtLeast "8.6")                           ./patches/ghc/outputtable-assert-8.6.patch
          ++ lib.optional (versionAtLeast "8.6")                           ./patches/ghc/mistuke-ghc-err_clean_up_error_handler-8ab1a89af89848f1713e6849f189de66c0ed7898.diff # this is part of Phyx- revamped io-manager.
+         ++ lib.optional (versionAtLeast "8.6.4")                         ./patches/ghc/ghc-8.6.4-reenable-th-qq-in-stage1.patch
          ++ [
           ./patches/ghc/ghc-add-keepCAFs-to-rts.patch                         # https://gitlab.haskell.org/ghc/ghc/merge_requests/950  -- open
           ./patches/ghc/lowercase-8.6.patch                                   # https://gitlab.haskell.org/ghc/ghc/merge_requests/949  -- merged; ghc-8.8.1
@@ -61,8 +62,6 @@
          ++ lib.optional (drv.version == "8.6.3")                         ./patches/ghc/ghc-8.6.3-reinstallable-lib-ghc.patch
          ++ lib.optional (drv.version == "8.6.4")                         ./patches/ghc/ghc-8.6.4-reinstallable-lib-ghc.patch
          ++ lib.optional (drv.version == "8.6.5")                         ./patches/ghc/ghc-8.6.5-reinstallable-lib-ghc.patch
-         ++ lib.optional (drv.version == "8.6.4")                         ./patches/ghc/ghc-8.6.4-reenable-th-qq-in-stage1.patch
-         ++ lib.optional (drv.version == "8.6.5")                         ./patches/ghc/ghc-8.6.4-reenable-th-qq-in-stage1.patch
          ++ lib.optional (drv.version == "8.6.4")                         ./patches/ghc/ghc-8.6.4-better-plusSimplCountErrors.patch
          ;
         # Run autoconf again, because an .ac file may have been patched

--- a/config.nix
+++ b/config.nix
@@ -17,11 +17,13 @@
         enableShared = ps.stdenv.targetPlatform == ps.stdenv.hostPlatform;
         enableIntegerSimple = false;
       };
-    ghcDrvOverrides = drv: {
+    ghcDrvOverrides = drv: y{
         dontStrip = true;
-        hardeningDisable = [ "stackprotector" "format" ];
+        hardeningDisable = (drv.hardeningDisable or []) ++ [ "stackprotector" "format" ];
         patches = (drv.patches or [])
-         ++ lib.optional (builtins.compareVersions drv.version "8.6.3" == 0)  ./patches/ghc/T16057--ghci-doa-on-windows.patch
+         # Patches for which we know they have been merged into a public release already
+         ++ lib.optional (builtins.compareVersions drv.version "8.4.3" == 1
+                       && builtins.compareVersions drv.version "8.6" == -1)   ./patches/ghc/ghc-8.4.4-reinstallable-lib-ghc.patch
          ++ lib.optional (builtins.compareVersions drv.version "8.6" == -1)   ./patches/ghc/move-iserv-8.4.2.patch
          ++ lib.optional (builtins.compareVersions drv.version "8.6" == -1)   ./patches/ghc/hsc2hs-8.4.2.patch
          ++ lib.optional (builtins.compareVersions drv.version "8.6" == -1)   ./patches/ghc/various-8.4.2.patch
@@ -29,36 +31,42 @@
          ++ lib.optional (builtins.compareVersions drv.version "8.6" == -1)   ./patches/ghc/cabal-exe-ext-8.4.2.patch
          ++ lib.optional (builtins.compareVersions drv.version "8.6" == -1)   ./patches/ghc/ghc-8.4.3-Cabal2201-SMP-test-fix.patch
          ++ lib.optional (builtins.compareVersions drv.version "8.6" == -1)   ./patches/ghc/outputtable-assert-8.4.patch
-         ++ lib.optional (builtins.compareVersions drv.version "8.4.3" == 1
-                       && builtins.compareVersions drv.version "8.6" == -1)   ./patches/ghc/ghc-8.4.4-reinstallable-lib-ghc.patch
+         ++ lib.optional (builtins.compareVersions drv.version "8.5" ==  1
+                       && builtins.compareVersions drv.version "8.6.4" == -1) ./patches/ghc/MR148--T16104-GhcPlugins.patch
+         ++ lib.optional (builtins.compareVersions drv.version "8.6.4" == -1) ./patches/ghc/MR95--ghc-pkg-deadlock-fix.patch
+
+         # Patches for which we only know a lower bound.
+         ++ lib.optional (builtins.compareVersions drv.version "8.5" ==  1)
+          ./patches/ghc/iserv-proxy-cleanup.patch                             # https://gitlab.haskell.org/ghc/ghc/merge_requests/250  -- merged; ghc-8.8.1
+         ++ lib.optional (builtins.compareVersions drv.version "8.2" ==  1)
+          ./patches/ghc/MR545--ghc-pkg-databases.patch                        # https://gitlab.haskell.org/ghc/ghc/merge_requests/545  -- merged; ghc-8.8.1
+         ++ lib.optional (builtins.compareVersions drv.version "8.5" ==  1)
+          ./patches/ghc/outputtable-assert-8.6.patch
+         ++ lib.optional (builtins.compareVersions drv.version "8.5" ==  1)
+          ./patches/ghc/mistuke-ghc-err_clean_up_error_handler-8ab1a89af89848f1713e6849f189de66c0ed7898.diff # this is part of Phyx- revamped io-manager.
+         ++ [
+          ./patches/ghc/ghc-add-keepCAFs-to-rts.patch                         # https://gitlab.haskell.org/ghc/ghc/merge_requests/950  -- open
+          ./patches/ghc/lowercase-8.6.patch                                   # https://gitlab.haskell.org/ghc/ghc/merge_requests/949  -- merged; ghc-8.8.1
+          ./patches/ghc/dll-loader-8.4.2.patch                                # https://gitlab.haskell.org/ghc/ghc/merge_requests/949  -- open
+          ./patches/ghc/0001-Stop-the-linker-panic.patch                      # https://phabricator.haskell.org/D5012                  -- merged; ghc-8.8.1
+          ./patches/ghc/ghc-8.4.3-Cabal2201-no-hackage-tests.patch            # ?
+          ./patches/ghc/ghc-8.4.3-Cabal2201-allow-test-wrapper.patch          # https://github.com/haskell/cabal/pulls/5995            -- merged; cabal-3.0.0 (ghc-8.8.1)
+          ./patches/ghc/ghc-8.4.3-Cabal2201-response-file-support.patch       # https://github.com/haskell/cabal/pulls/5996            -- merged; cabal-3.0.0 (ghc-8.8.1)
+          ./patches/ghc/ghc-8.6-Cabal-fix-datadir.patch                       # https://github.com/haskell/cabal/issues/5862
+          ./patches/ghc/MR196--ghc-pkg-shut-up.patch                          # https://gitlab.haskell.org/ghc/ghc/merge_requests/196  -- merged; ghc-8.8.1
+          ./patches/ghc/MR948--32bit-cross-th.patch                           # https://gitlab.haskell.org/ghc/ghc/merge_requests/948  -- open
+         ]
+
+         # Patches for specific ghc versions.
+         ++ lib.optional (builtins.compareVersions drv.version "8.6.3" == 0)  ./patches/ghc/T16057--ghci-doa-on-windows.patch
          ++ lib.optional (builtins.compareVersions drv.version "8.6.3" == 0)  ./patches/ghc/ghc-8.6.3-reinstallable-lib-ghc.patch
          ++ lib.optional (builtins.compareVersions drv.version "8.6.4" == 0)  ./patches/ghc/ghc-8.6.4-reinstallable-lib-ghc.patch
          ++ lib.optional (builtins.compareVersions drv.version "8.6.5" == 0)  ./patches/ghc/ghc-8.6.5-reinstallable-lib-ghc.patch
-         ++ lib.optional (builtins.compareVersions drv.version "8.5" ==  1)   ./patches/ghc/outputtable-assert-8.6.patch
-         ++ lib.optional (builtins.compareVersions drv.version "8.5" ==  1)   ./patches/ghc/mistuke-ghc-err_clean_up_error_handler-8ab1a89af89848f1713e6849f189de66c0ed7898.diff
-         # this might be fixed in 8.6.4 (if a release is cut), or 8.8
-         ++ lib.optional (builtins.compareVersions drv.version "8.5" ==  1
-                       && builtins.compareVersions drv.version "8.6.4" == -1) ./patches/ghc/MR148--T16104-GhcPlugins.patch
-         ++ lib.optional (builtins.compareVersions drv.version "8.5" ==  1)   ./patches/ghc/iserv-proxy-cleanup.patch
-         ++ lib.optional (builtins.compareVersions drv.version "8.2" ==  1)   ./patches/ghc/MR545--ghc-pkg-databases.patch
-         ++ lib.optional (builtins.compareVersions drv.version "8.6.4" == -1) ./patches/ghc/MR95--ghc-pkg-deadlock-fix.patch
          ++ lib.optional (builtins.compareVersions drv.version "8.6.4" == 0)  ./patches/ghc/ghc-8.6.4-reenable-th-qq-in-stage1.patch
          ++ lib.optional (builtins.compareVersions drv.version "8.6.5" == 0)  ./patches/ghc/ghc-8.6.4-reenable-th-qq-in-stage1.patch
          ++ lib.optional (builtins.compareVersions drv.version "8.6.4" == 0)  ./patches/ghc/ghc-8.6.4-better-plusSimplCountErrors.patch
-         ++ [
-          ./patches/ghc/ghc-add-keepCAFs-to-rts.patch
-          ./patches/ghc/lowercase-8.6.patch
-          ./patches/ghc/dll-loader-8.4.2.patch
-          ./patches/ghc/0001-Stop-the-linker-panic.patch
-          ./patches/ghc/ghc-8.4.3-Cabal2201-no-hackage-tests.patch
-          ./patches/ghc/ghc-8.4.3-Cabal2201-allow-test-wrapper.patch
-          ./patches/ghc/ghc-8.4.3-Cabal2201-response-file-support.patch
-          ./patches/ghc/ghc-8.6-Cabal-fix-datadir.patch
-          ./patches/ghc/MR196--ghc-pkg-shut-up.patch
-         ];
-        postPatch = (drv.postPath or "") + ''
-        autoreconf
-        '';
+         ;
+        postPatch = (drv.postPatch or "") + "\n" + "autoreconf";
       };
   in rec {
    # use the pre-built rocksdb.
@@ -92,15 +100,13 @@
      configureFlags = with ps.stdenv; (drv.configureFlags or []) ++ lib.optional hostPlatform.isWindows "--enable-static --disable-shared";
    });
 
-    haskell = lib.recursiveUpdate ps.haskell {
-      compiler.ghc842 = (ps.haskell.compiler.ghc842.override ghcPkgOverrides).overrideAttrs ghcDrvOverrides;
-      compiler.ghc843 = (ps.haskell.compiler.ghc843.override ghcPkgOverrides).overrideAttrs ghcDrvOverrides;
-      compiler.ghc844 = (ps.haskell.compiler.ghc844.override ghcPkgOverrides).overrideAttrs ghcDrvOverrides;
-      compiler.ghc861 = (ps.haskell.compiler.ghc861.override ghcPkgOverrides).overrideAttrs ghcDrvOverrides;
-      compiler.ghc862 = (ps.haskell.compiler.ghc862.override ghcPkgOverrides).overrideAttrs ghcDrvOverrides;
-      compiler.ghc863 = (ps.haskell.compiler.ghc863.override ghcPkgOverrides).overrideAttrs ghcDrvOverrides;
-      compiler.ghc864 = (ps.haskell.compiler.ghc864.override ghcPkgOverrides).overrideAttrs ghcDrvOverrides;
-      compiler.ghc865 = (ps.haskell.compiler.ghc865.override ghcPkgOverrides).overrideAttrs ghcDrvOverrides;
-    };
+   haskell = lib.recursiveUpdate ps.haskell {
+       compiler = lib.mapAttrs (_name: compiler: (compiler.override ghcPkgOverrides).overrideAttrs ghcDrvOverrides)
+         # these patches (ghcPkgOverrides and ghcDrvOverrides) only apply to vanilla source ghcs. Not ghcjs or binary distributions.
+         # we also ignore ghc82. And are only concerned with ghc84+
+         (lib.filterAttrs
+           (n: _value: !(ps.stdenv.targetPlatform.isGhcjs or false) # we want to apply this only to non-ghcjs ones. As we do some ghc <- ghcjs mapping for ghcjs.
+                       && lib.hasPrefix "ghc" n && !lib.hasPrefix "ghc82" n && !lib.hasPrefix "ghcjs" n && !lib.hasSuffix "Binary" n) ps.haskell.compiler);
+       };
   };
 }

--- a/config.nix
+++ b/config.nix
@@ -17,33 +17,32 @@
         enableShared = ps.stdenv.targetPlatform == ps.stdenv.hostPlatform;
         enableIntegerSimple = false;
       };
-    ghcDrvOverrides = drv: y{
+    ghcDrvOverrides = drv: let
+      # Returns true iff this derivation's version is strictly older than ver.
+      versionOlder = ver: builtins.compareVersions ver drv.version == 1;
+      # Returns true iff this derivation's verion is greater than or equal to ver.
+      versionAtLeast = ver: !versionOlder ver;
+    in {
         dontStrip = true;
         hardeningDisable = (drv.hardeningDisable or []) ++ [ "stackprotector" "format" ];
         patches = (drv.patches or [])
          # Patches for which we know they have been merged into a public release already
-         ++ lib.optional (builtins.compareVersions drv.version "8.4.3" == 1
-                       && builtins.compareVersions drv.version "8.6" == -1)   ./patches/ghc/ghc-8.4.4-reinstallable-lib-ghc.patch
-         ++ lib.optional (builtins.compareVersions drv.version "8.6" == -1)   ./patches/ghc/move-iserv-8.4.2.patch
-         ++ lib.optional (builtins.compareVersions drv.version "8.6" == -1)   ./patches/ghc/hsc2hs-8.4.2.patch
-         ++ lib.optional (builtins.compareVersions drv.version "8.6" == -1)   ./patches/ghc/various-8.4.2.patch
-         ++ lib.optional (builtins.compareVersions drv.version "8.6" == -1)   ./patches/ghc/lowercase-8.4.2.patch
-         ++ lib.optional (builtins.compareVersions drv.version "8.6" == -1)   ./patches/ghc/cabal-exe-ext-8.4.2.patch
-         ++ lib.optional (builtins.compareVersions drv.version "8.6" == -1)   ./patches/ghc/ghc-8.4.3-Cabal2201-SMP-test-fix.patch
-         ++ lib.optional (builtins.compareVersions drv.version "8.6" == -1)   ./patches/ghc/outputtable-assert-8.4.patch
-         ++ lib.optional (builtins.compareVersions drv.version "8.5" ==  1
-                       && builtins.compareVersions drv.version "8.6.4" == -1) ./patches/ghc/MR148--T16104-GhcPlugins.patch
-         ++ lib.optional (builtins.compareVersions drv.version "8.6.4" == -1) ./patches/ghc/MR95--ghc-pkg-deadlock-fix.patch
+         ++ lib.optional (versionAtLeast "8.4.4" && versionOlder "8.6")   ./patches/ghc/ghc-8.4.4-reinstallable-lib-ghc.patch
+         ++ lib.optional (versionOlder "8.6")                             ./patches/ghc/move-iserv-8.4.2.patch
+         ++ lib.optional (versionOlder "8.6")                             ./patches/ghc/hsc2hs-8.4.2.patch
+         ++ lib.optional (versionOlder "8.6")                             ./patches/ghc/various-8.4.2.patch
+         ++ lib.optional (versionOlder "8.6")                             ./patches/ghc/lowercase-8.4.2.patch
+         ++ lib.optional (versionOlder "8.6")                             ./patches/ghc/cabal-exe-ext-8.4.2.patch
+         ++ lib.optional (versionOlder "8.6")                             ./patches/ghc/ghc-8.4.3-Cabal2201-SMP-test-fix.patch
+         ++ lib.optional (versionOlder "8.6")                             ./patches/ghc/outputtable-assert-8.4.patch
+         ++ lib.optional (versionAtLeast "8.6" && versionOlder "8.6.5")   ./patches/ghc/MR148--T16104-GhcPlugins.patch
+         ++ lib.optional (versionOlder "8.6.5")                           ./patches/ghc/MR95--ghc-pkg-deadlock-fix.patch
 
          # Patches for which we only know a lower bound.
-         ++ lib.optional (builtins.compareVersions drv.version "8.5" ==  1)
-          ./patches/ghc/iserv-proxy-cleanup.patch                             # https://gitlab.haskell.org/ghc/ghc/merge_requests/250  -- merged; ghc-8.8.1
-         ++ lib.optional (builtins.compareVersions drv.version "8.2" ==  1)
-          ./patches/ghc/MR545--ghc-pkg-databases.patch                        # https://gitlab.haskell.org/ghc/ghc/merge_requests/545  -- merged; ghc-8.8.1
-         ++ lib.optional (builtins.compareVersions drv.version "8.5" ==  1)
-          ./patches/ghc/outputtable-assert-8.6.patch
-         ++ lib.optional (builtins.compareVersions drv.version "8.5" ==  1)
-          ./patches/ghc/mistuke-ghc-err_clean_up_error_handler-8ab1a89af89848f1713e6849f189de66c0ed7898.diff # this is part of Phyx- revamped io-manager.
+         ++ lib.optional (versionAtLeast "8.6")                           ./patches/ghc/iserv-proxy-cleanup.patch                             # https://gitlab.haskell.org/ghc/ghc/merge_requests/250  -- merged; ghc-8.8.1
+         ++ lib.optional (versionAtLeast "8.2")                           ./patches/ghc/MR545--ghc-pkg-databases.patch                        # https://gitlab.haskell.org/ghc/ghc/merge_requests/545  -- merged; ghc-8.8.1
+         ++ lib.optional (versionAtLeast "8.6")                           ./patches/ghc/outputtable-assert-8.6.patch
+         ++ lib.optional (versionAtLeast "8.6")                           ./patches/ghc/mistuke-ghc-err_clean_up_error_handler-8ab1a89af89848f1713e6849f189de66c0ed7898.diff # this is part of Phyx- revamped io-manager.
          ++ [
           ./patches/ghc/ghc-add-keepCAFs-to-rts.patch                         # https://gitlab.haskell.org/ghc/ghc/merge_requests/950  -- open
           ./patches/ghc/lowercase-8.6.patch                                   # https://gitlab.haskell.org/ghc/ghc/merge_requests/949  -- merged; ghc-8.8.1
@@ -58,14 +57,15 @@
          ]
 
          # Patches for specific ghc versions.
-         ++ lib.optional (builtins.compareVersions drv.version "8.6.3" == 0)  ./patches/ghc/T16057--ghci-doa-on-windows.patch
-         ++ lib.optional (builtins.compareVersions drv.version "8.6.3" == 0)  ./patches/ghc/ghc-8.6.3-reinstallable-lib-ghc.patch
-         ++ lib.optional (builtins.compareVersions drv.version "8.6.4" == 0)  ./patches/ghc/ghc-8.6.4-reinstallable-lib-ghc.patch
-         ++ lib.optional (builtins.compareVersions drv.version "8.6.5" == 0)  ./patches/ghc/ghc-8.6.5-reinstallable-lib-ghc.patch
-         ++ lib.optional (builtins.compareVersions drv.version "8.6.4" == 0)  ./patches/ghc/ghc-8.6.4-reenable-th-qq-in-stage1.patch
-         ++ lib.optional (builtins.compareVersions drv.version "8.6.5" == 0)  ./patches/ghc/ghc-8.6.4-reenable-th-qq-in-stage1.patch
-         ++ lib.optional (builtins.compareVersions drv.version "8.6.4" == 0)  ./patches/ghc/ghc-8.6.4-better-plusSimplCountErrors.patch
+         ++ lib.optional (drv.version == "8.6.3")                         ./patches/ghc/T16057--ghci-doa-on-windows.patch
+         ++ lib.optional (drv.version == "8.6.3")                         ./patches/ghc/ghc-8.6.3-reinstallable-lib-ghc.patch
+         ++ lib.optional (drv.version == "8.6.4")                         ./patches/ghc/ghc-8.6.4-reinstallable-lib-ghc.patch
+         ++ lib.optional (drv.version == "8.6.5")                         ./patches/ghc/ghc-8.6.5-reinstallable-lib-ghc.patch
+         ++ lib.optional (drv.version == "8.6.4")                         ./patches/ghc/ghc-8.6.4-reenable-th-qq-in-stage1.patch
+         ++ lib.optional (drv.version == "8.6.5")                         ./patches/ghc/ghc-8.6.4-reenable-th-qq-in-stage1.patch
+         ++ lib.optional (drv.version == "8.6.4")                         ./patches/ghc/ghc-8.6.4-better-plusSimplCountErrors.patch
          ;
+        # Run autoconf again, because an .ac file may have been patched
         postPatch = (drv.postPatch or "") + "\n" + "autoreconf";
       };
   in rec {
@@ -100,13 +100,24 @@
      configureFlags = with ps.stdenv; (drv.configureFlags or []) ++ lib.optional hostPlatform.isWindows "--enable-static --disable-shared";
    });
 
-   haskell = lib.recursiveUpdate ps.haskell {
-       compiler = lib.mapAttrs (_name: compiler: (compiler.override ghcPkgOverrides).overrideAttrs ghcDrvOverrides)
-         # these patches (ghcPkgOverrides and ghcDrvOverrides) only apply to vanilla source ghcs. Not ghcjs or binary distributions.
-         # we also ignore ghc82. And are only concerned with ghc84+
-         (lib.filterAttrs
-           (n: _value: !(ps.stdenv.targetPlatform.isGhcjs or false) # we want to apply this only to non-ghcjs ones. As we do some ghc <- ghcjs mapping for ghcjs.
-                       && lib.hasPrefix "ghc" n && !lib.hasPrefix "ghc82" n && !lib.hasPrefix "ghcjs" n && !lib.hasSuffix "Binary" n) ps.haskell.compiler);
-       };
+   haskell = let
+     # These patches (ghcPkgOverrides and ghcDrvOverrides) only apply to vanilla source ghcs.
+     # Not ghcjs or binary distributions.
+     # We also ignore ghc82. And are only concerned with ghc84+
+     # we want to apply this only to non-ghcjs ones.
+     # As we do some ghc <- ghcjs mapping for ghcjs.
+     needsPatches = name:
+       !(ps.stdenv.targetPlatform.isGhcjs or false)
+       && lib.hasPrefix "ghc" name
+       && !lib.hasPrefix "ghc82" name
+       && !lib.hasPrefix "ghcjs" name
+       && !lib.hasSuffix "Binary" name;
+     overrideCompiler = compiler:
+       (compiler.override ghcPkgOverrides).overrideAttrs ghcDrvOverrides;
+   in
+     lib.recursiveUpdate ps.haskell {
+       compiler = lib.mapAttrs (_name: overrideCompiler)
+         (lib.filterAttrs (name: _value: needsPatches name) ps.haskell.compiler);
+     };
   };
 }

--- a/patches/ghc/MR948--32bit-cross-th.patch
+++ b/patches/ghc/MR948--32bit-cross-th.patch
@@ -1,0 +1,143 @@
+From ece40a78cfa9295f76237cd2b2aae57cff079084 Mon Sep 17 00:00:00 2001
+From: Luite Stegeman <stegeman@gmail.com>
+Date: Mon, 8 Jan 2018 08:42:30 +0000
+Subject: [PATCH] fix Template Haskell cross compilation on 64 bit compiler
+ with 32 bit target
+
+---
+ compiler/deSugar/DsMeta.hs                               | 5 ++++-
+ compiler/hsSyn/Convert.hs                                | 4 ++--
+ compiler/typecheck/TcSplice.hs                           | 7 ++++---
+ libraries/template-haskell/Language/Haskell/TH/PprLib.hs | 6 +++---
+ libraries/template-haskell/Language/Haskell/TH/Syntax.hs | 8 ++++----
+ 5 files changed, 17 insertions(+), 13 deletions(-)
+
+diff --git a/compiler/deSugar/DsMeta.hs b/compiler/deSugar/DsMeta.hs
+index 5de954ae7d..09a4fecbd5 100644
+--- a/compiler/deSugar/DsMeta.hs
++++ b/compiler/deSugar/DsMeta.hs
+@@ -1947,7 +1947,7 @@ globalVar name
+         ; rep2 mk_varg [pkg,mod,occ] }
+   | otherwise
+   = do  { MkC occ <- nameLit name
+-        ; MkC uni <- coreIntLit (getKey (getUnique name))
++        ; MkC uni <- coreIntegerLit (toInteger $ getKey (getUnique name))
+         ; rep2 mkNameLName [occ,uni] }
+   where
+       mod = ASSERT( isExternalName name) nameModule name
+@@ -2744,6 +2744,9 @@ coreIntLit :: Int -> DsM (Core Int)
+ coreIntLit i = do dflags <- getDynFlags
+                   return (MkC (mkIntExprInt dflags i))
+ 
++coreIntegerLit :: Integer -> DsM (Core Integer)
++coreIntegerLit i = fmap MkC (mkIntegerExpr i)
++
+ coreVar :: Id -> Core TH.Name   -- The Id has type Name
+ coreVar id = MkC (Var id)
+ 
+diff --git a/compiler/hsSyn/Convert.hs b/compiler/hsSyn/Convert.hs
+index 77ffebe021..cb660df6d2 100644
+--- a/compiler/hsSyn/Convert.hs
++++ b/compiler/hsSyn/Convert.hs
+@@ -1831,8 +1831,8 @@ thRdrName loc ctxt_ns th_occ th_name
+   = case th_name of
+      TH.NameG th_ns pkg mod -> thOrigRdrName th_occ th_ns pkg mod
+      TH.NameQ mod  -> (mkRdrQual  $! mk_mod mod) $! occ
+-     TH.NameL uniq -> nameRdrName $! (((Name.mkInternalName $! mk_uniq uniq) $! occ) loc)
+-     TH.NameU uniq -> nameRdrName $! (((Name.mkSystemNameAt $! mk_uniq uniq) $! occ) loc)
++     TH.NameL uniq -> nameRdrName $! (((Name.mkInternalName $! mk_uniq (fromInteger uniq)) $! occ) loc)
++     TH.NameU uniq -> nameRdrName $! (((Name.mkSystemNameAt $! mk_uniq (fromInteger uniq)) $! occ) loc)
+      TH.NameS | Just name <- isBuiltInOcc_maybe occ -> nameRdrName $! name
+               | otherwise                           -> mkRdrUnqual $! occ
+               -- We check for built-in syntax here, because the TH
+diff --git a/compiler/typecheck/TcSplice.hs b/compiler/typecheck/TcSplice.hs
+index 845e2029ed..3434b68615 100644
+--- a/compiler/typecheck/TcSplice.hs
++++ b/compiler/typecheck/TcSplice.hs
+@@ -922,7 +922,7 @@ To call runQ in the Tc monad, we need to make TcM an instance of Quasi:
+ 
+ instance TH.Quasi TcM where
+   qNewName s = do { u <- newUnique
+-                  ; let i = getKey u
++                  ; let i = toInteger (getKey u)
+                   ; return (TH.mkNameU s i) }
+ 
+   -- 'msg' is forced to ensure exceptions don't escape,
+@@ -1947,8 +1947,9 @@ reify_tc_app tc tys
+ ------------------------------
+ reifyName :: NamedThing n => n -> TH.Name
+ reifyName thing
+-  | isExternalName name = mk_varg pkg_str mod_str occ_str
+-  | otherwise           = TH.mkNameU occ_str (getKey (getUnique name))
++  | isExternalName name
++              = mk_varg pkg_str mod_str occ_str
++  | otherwise = TH.mkNameU occ_str (toInteger $ getKey (getUnique name))
+         -- Many of the things we reify have local bindings, and
+         -- NameL's aren't supposed to appear in binding positions, so
+         -- we use NameU.  When/if we start to reify nested things, that
+diff --git a/libraries/template-haskell/Language/Haskell/TH/PprLib.hs b/libraries/template-haskell/Language/Haskell/TH/PprLib.hs
+index 7e05d05d83..ac0679a93e 100644
+--- a/libraries/template-haskell/Language/Haskell/TH/PprLib.hs
++++ b/libraries/template-haskell/Language/Haskell/TH/PprLib.hs
+@@ -36,14 +36,14 @@ module Language.Haskell.TH.PprLib (
+ 
+ 
+ import Language.Haskell.TH.Syntax
+-    (Name(..), showName', NameFlavour(..), NameIs(..))
++    (Uniq, Name(..), showName', NameFlavour(..), NameIs(..))
+ import qualified Text.PrettyPrint as HPJ
+ import Control.Monad (liftM, liftM2, ap)
+ import Language.Haskell.TH.Lib.Map ( Map )
+ import qualified Language.Haskell.TH.Lib.Map as Map ( lookup, insert, empty )
+ import Prelude hiding ((<>))
+ 
+-infixl 6 <> 
++infixl 6 <>
+ infixl 6 <+>
+ infixl 5 $$, $+$
+ 
+@@ -117,7 +117,7 @@ punctuate :: Doc -> [Doc] -> [Doc]
+ -- ---------------------------------------------------------------------------
+ -- The "implementation"
+ 
+-type State = (Map Name Name, Int)
++type State = (Map Name Name, Uniq)
+ data PprM a = PprM { runPprM :: State -> (a, State) }
+ 
+ pprName :: Name -> Doc
+diff --git a/libraries/template-haskell/Language/Haskell/TH/Syntax.hs b/libraries/template-haskell/Language/Haskell/TH/Syntax.hs
+index 14b9de263c..4ee11e68f4 100644
+--- a/libraries/template-haskell/Language/Haskell/TH/Syntax.hs
++++ b/libraries/template-haskell/Language/Haskell/TH/Syntax.hs
+@@ -155,7 +155,7 @@ badIO op = do   { qReport True ("Can't do `" ++ op ++ "' in the IO monad")
+                 ; fail "Template Haskell failure" }
+ 
+ -- Global variable to generate unique symbols
+-counter :: IORef Int
++counter :: IORef Uniq
+ {-# NOINLINE counter #-}
+ counter = unsafePerformIO (newIORef 0)
+ 
+@@ -1299,8 +1299,8 @@ instance Ord Name where
+ data NameFlavour
+   = NameS           -- ^ An unqualified name; dynamically bound
+   | NameQ ModName   -- ^ A qualified name; dynamically bound
+-  | NameU !Int      -- ^ A unique local name
+-  | NameL !Int      -- ^ Local name bound outside of the TH AST
++  | NameU !Uniq     -- ^ A unique local name
++  | NameL !Uniq     -- ^ Local name bound outside of the TH AST
+   | NameG NameSpace PkgName ModName -- ^ Global name bound outside of the TH AST:
+                 -- An original name (occurrences only, not binders)
+                 -- Need the namespace too to be sure which
+@@ -1313,7 +1313,7 @@ data NameSpace = VarName        -- ^ Variables
+                                 -- in the same name space for now.
+                deriving( Eq, Ord, Show, Data, Generic )
+ 
+-type Uniq = Int
++type Uniq = Integer
+ 
+ -- | The name without its module prefix.
+ --
+-- 
+2.19.2
+


### PR DESCRIPTION
This tries to cleanup all our ghc patches, and adds the relevant
upstream information.  We also add one more patch relevant for
32bit cross compilation (ghcjs).