### PR TITLE
Update haskell.nix for direct test exe call and use testWrapper

### DIFF
--- a/pins/haskell-nix.json
+++ b/pins/haskell-nix.json
@@ -1,7 +1,7 @@
 {
   "url": "https://github.com/input-output-hk/haskell.nix",
-  "rev": "26c5b7be766b00811738cae1be07d2879841ce18",
-  "date": "2019-06-02T21:13:32+08:00",
-  "sha256": "0k41zyaksf4vp312r1aayafvy6y2lsfvmjkiz2416jl4r9cbv82m",
+  "rev": "83e4c75957ffac247c55636da449aeb4d12f561a",
+  "date": "2019-06-07T16:47:40+01:00",
+  "sha256": "1xmnasw3j7j6fm4dm1xh26jfwfaybj3cv4q2nblbryybnj42qws2",
   "fetchSubmodules": false
 }


### PR DESCRIPTION
This PR pulls in a new version of `haskell.nix` that runs test executables directly rather than through cabal. To replace the `--test-wrapper` option of cabal it provides a `testWrapper` package/component option that is used here with the `wine` wrapper in `mingw_w64.nix`.