### PR TITLE
Bump haskell.nix

### DIFF
--- a/pins/haskell-nix.json
+++ b/pins/haskell-nix.json
@@ -1,7 +1,7 @@
 {
   "url": "https://github.com/input-output-hk/haskell.nix",
-  "rev": "5d5da229f61d3b18e7397ed1d40ab771d70eaf39",
-  "date": "2019-06-10T01:04:52+00:00",
-  "sha256": "06zbdmp4i1alzqfzh7kqyh7a0k0cvb6bfhy4k5b4d3m5459rzaqm",
+  "rev": "7d94fe2ef5b98a4c14894daabbace8990c82e189",
+  "date": "2019-06-13T14:48:54+10:00",
+  "sha256": "1276km4z24ym05yrzf7i4gs25znl70s8f12wm0kxblspw469kp8v",
   "fetchSubmodules": false
 }


### PR DESCRIPTION
Latest master branch - contains nix-tools bump for `stack.yaml` flags.