### PR TITLE
Apply correct patches to ghc 8.6.4 (broken by #66)

### DIFF
--- a/config.nix
+++ b/config.nix
@@ -35,7 +35,7 @@
          ++ lib.optional (versionOlder "8.6")                             ./patches/ghc/cabal-exe-ext-8.4.2.patch
          ++ lib.optional (versionOlder "8.6")                             ./patches/ghc/ghc-8.4.3-Cabal2201-SMP-test-fix.patch
          ++ lib.optional (versionOlder "8.6")                             ./patches/ghc/outputtable-assert-8.4.patch
-         ++ lib.optional (versionAtLeast "8.6" && versionOlder "8.6.5")   ./patches/ghc/MR148--T16104-GhcPlugins.patch
+         ++ lib.optional (versionAtLeast "8.6" && versionOlder "8.6.4")   ./patches/ghc/MR148--T16104-GhcPlugins.patch
          ++ lib.optional (versionOlder "8.6.5")                           ./patches/ghc/MR95--ghc-pkg-deadlock-fix.patch
 
          # Patches for which we only know a lower bound.

--- a/config.nix
+++ b/config.nix
@@ -36,7 +36,7 @@
          ++ lib.optional (versionOlder "8.6")                             ./patches/ghc/ghc-8.4.3-Cabal2201-SMP-test-fix.patch
          ++ lib.optional (versionOlder "8.6")                             ./patches/ghc/outputtable-assert-8.4.patch
          ++ lib.optional (versionAtLeast "8.6" && versionOlder "8.6.4")   ./patches/ghc/MR148--T16104-GhcPlugins.patch
-         ++ lib.optional (versionOlder "8.6.5")                           ./patches/ghc/MR95--ghc-pkg-deadlock-fix.patch
+         ++ lib.optional (versionOlder "8.6.4")                           ./patches/ghc/MR95--ghc-pkg-deadlock-fix.patch
 
          # Patches for which we only know a lower bound.
          ++ lib.optional (versionAtLeast "8.6")                           ./patches/ghc/iserv-proxy-cleanup.patch                             # https://gitlab.haskell.org/ghc/ghc/merge_requests/250  -- merged; ghc-8.8.1


### PR DESCRIPTION
It looks like #66 unintentionally changed the upper bound for the
`MR148--T16104-GhcPlugins.patch` from 8.6.4 to 8.6.5