### PR TITLE
bump haskell.nix

### DIFF
--- a/pins/haskell-nix.json
+++ b/pins/haskell-nix.json
@@ -1,7 +1,7 @@
 {
   "url": "https://github.com/input-output-hk/haskell.nix",
-  "rev": "2c24da0baa36a6477a1751045d1d7fb2f56b16df",
-  "date": "2019-06-25T11:54:53+02:00",
-  "sha256": "00xgci6sc5v17rs500ndckd52m9r2ws3rh11lcfqqs9lpxaaz73h",
+  "rev": "3a403d20b71e5b57bc95c4ccaccc3184e8dec21a",
+  "date": "2019-06-26T01:07:35+00:00",
+  "sha256": "1vm2zsx56lwhrf7yf29zr6h69bw70pfbwhzanrrfnw0k53bfp0nq",
   "fetchSubmodules": false
 }


### PR DESCRIPTION
This should bump haskell.nix past the commit that references the 3GB hackage.nix repo.