### PR TITLE
Drop `mingw_w64_headers` from `unix-time`

### DIFF
--- a/nix-tools-iohk-module.nix
+++ b/nix-tools-iohk-module.nix
@@ -92,7 +92,7 @@ in {
   } 
   # Fix dependencies and case-sensitive filesystem builds for unix-time.
   // pkgs.lib.optionalAttrs pkgs.stdenv.hostPlatform.isWindows {
-    unix-time.components.library.libs = with pkgs.windows; [ mingw_w64_headers mingw_w64_pthreads ];
+    unix-time.components.library.libs = with pkgs.windows; [ mingw_w64_pthreads ];
     unix-time.postUnpack = "substituteInPlace */cbits/win_patch.h --replace Windows.h windows.h";
   }
   ;


### PR DESCRIPTION
With `mingw_w64_headers` does not provide any libraries (or `/lib`) folder for
that.  Having `mingw_w64_headers` as a dependency in `unix-time` will populate
the library search paths.

While specifying an invalid search path is not necessarily problematic, `remote-iserv.exe`
chokes on it, as it tries to create the folder to lazy copy over the library on demand.  With
nix we can't write into the store (doh!) and as such this causes failures.

We may want to implement a mode in which `remote-iserv` knows that it and ghc live on
the same file system.