### PR TITLE
disable clock-patch

### DIFF
--- a/nix-tools-iohk-module.nix
+++ b/nix-tools-iohk-module.nix
@@ -61,7 +61,7 @@ in {
 
     # clock hasn't had a release since 2016(!) that is for three(3) years
     # now.
-    clock.patches              = [ ({ version, revision }: (if version == "0.7.2" then ./patches/clock-0.7.2.patch else null)) ];
+#    clock.patches              = [ ({ version, revision }: (if version == "0.7.2" then ./patches/clock-0.7.2.patch else null)) ];
     # nix calles this package crypto
     cryptonite-openssl.patches = [ ({ version, revision }: if version == "0.7" then ./patches/cryptonite-openssl-0.7.patch else null) ];
 


### PR DESCRIPTION
This is somehow needed for input-output-hk/cardano-sl#4183

I still don't understand why.