### PR TITLE
Allow control over default-nix for IFD on hydra

### DIFF
--- a/nix-tools-default.nix
+++ b/nix-tools-default.nix
@@ -19,9 +19,9 @@ let  nix-tools = (if builtins.isFunction nix-tools-pkgs
   inherit pkgs;
   # the iohk-module contains cross compilation specific patches
   inherit (commonLib.nix-tools) iohk-module iohk-extras;
+  };
   # Allow hsPkgs to be returned separately (useful when using
   # callCabalPlanToNix and callStackToNix on Hydra)
-  };
   hsPkgs = nix-tools.hsPkgs or nix-tools;
 in {
     _lib = commonLib;

--- a/nix-tools-default.nix
+++ b/nix-tools-default.nix
@@ -53,7 +53,7 @@ in {
                                   else null) hsPkgs; }
       // { tests = mapAttrs (k: v: if v ? components && length (attrValues v.components.tests) > 0
                                    then v.components.tests
-                                   else null) nix-tools; }
+                                   else null) hsPkgs; }
       // { benchmarks = mapAttrs (k: v: if v ? components && length (attrValues v.components.benchmarks) > 0
                                    then v.components.benchmarks
                                    else null) hsPkgs; }

--- a/nix-tools-default.nix
+++ b/nix-tools-default.nix
@@ -21,8 +21,8 @@ let  nix-tools = (if builtins.isFunction nix-tools-pkgs
   inherit (commonLib.nix-tools) iohk-module iohk-extras;
   # Allow hsPkgs to be returned separately (useful when using
   # callCabalPlanToNix and callStackToNix on Hydra)
+  };
   hsPkgs = nix-tools.hsPkgs or nix-tools;
-};
 in {
     _lib = commonLib;
 


### PR DESCRIPTION
Using callCabalPlanToNix or callStackToNix often results in
timeouts and other eval time errors on hydra that are very difficult
to debug.

We need to be able to ask hydra to build only the `.nix`
files, but not `import` them.

Currently `default-nix` forces the plan to be imported by enumerating
the components it produces.

This change:

* Allows nix-tools-pkgs to be a function to make it possible
  parameterise.
* Allows nix-tools-pkgs to return hsPkgs separately so a the nix
  files can be returned independently.
* Adds nix-tools-raw to get access to nix-tools._raw bypassing the
  enumeration of components.

This change carries the small risk of breaking code that already
includes an `hsPkgs` attribute.