### PR TITLE
Reduce closure size of regenerate script

### DIFF
--- a/nix-tools-regenerate.nix
+++ b/nix-tools-regenerate.nix
@@ -1,11 +1,10 @@
 # A script for generating the nix haskell package set based on stackage,
 # using the common convention for repo layout.
 
-{ lib, stdenv, path, writeScript, nix-tools, coreutils, findutils, gawk
-, nix, nix-prefetch-scripts }:
+{ lib, stdenv, path, writeScript, nix-tools, coreutils, findutils }:
 
 let
-  deps = [ nix-tools coreutils gawk nix nix-prefetch-scripts findutils ];
+  deps = [ nix-tools coreutils findutils ];
 
 in
   writeScript "nix-tools-regenerate" ''


### PR DESCRIPTION
See also: input-output-hk/haskell.nix#178

Tested by running and inspecting the regen script:

    NIX_PATH=iohk_nix=$HOME/iohk/iohk-nix nix-build nix/iohk-common.nix -A nix-tools.regeneratePackages -o regen
    du -scm $(nix-store -qR regen) | sort -n | tail -n25

It makes a difference of about 100MB. If we could kick gcc out of the nix-tools closure, that would make a significant difference.
