### PR TITLE
Add package for openapi-spec-validator

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -47,8 +47,17 @@ let
     cleanSourceHaskell = pkgs.callPackage ./clean-source-haskell.nix {};
     haskellPackages = import ./haskell-packages.nix;
     commitIdFromGitRepo = pkgs.callPackage ./commit-id.nix {};
+
+    # Development tools
     cache-s3 = pkgsDefault.callPackage ./pkgs/cache-s3.nix {};
     stack-hpc-coveralls = pkgsDefault.haskellPackages.callPackage ./pkgs/stack-hpc-coveralls.nix {};
+    openapi-spec-validator = pkgsDefault.python3Packages.callPackage ./pkgs/openapi-spec-validator.nix {
+      # Upstream PR: https://github.com/NixOS/nixpkgs/pull/65244
+      # It requires PyYAML >= 5.1.
+      pyyaml = pkgsDefault.python3Packages.callPackage ./pkgs/pyyaml51.nix {};
+    };
+
+    # Check scripts
     check-hydra = pkgsDefault.callPackage ./ci/check-hydra.nix {};
     check-nix-tools = pkgsDefault.callPackage ./ci/check-nix-tools.nix {};
   };
@@ -107,5 +116,5 @@ let
 
 in {
   inherit tests nix-tools stack2nix jemallocOverlay rust-packages;
-  inherit (commonLib) pkgs haskellPackages fetchNixpkgs maybeEnv cleanSourceHaskell getPkgs nixpkgs commitIdFromGitRepo getPackages cache-s3 stack-hpc-coveralls check-hydra check-nix-tools;
+  inherit (commonLib) pkgs haskellPackages fetchNixpkgs maybeEnv cleanSourceHaskell getPkgs nixpkgs commitIdFromGitRepo getPackages cache-s3 stack-hpc-coveralls openapi-spec-validator check-hydra check-nix-tools;
 }

--- a/pkgs/openapi-spec-validator.nix
+++ b/pkgs/openapi-spec-validator.nix
@@ -1,0 +1,25 @@
+{ lib, buildPythonPackage, pythonOlder, fetchPypi
+, jsonschema, pyyaml, six, pathlib
+, mock, pytest, pytestcov, pytest-flake8, tox }:
+
+buildPythonPackage rec {
+  pname = "openapi-spec-validator";
+  version = "0.2.7";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1sz9ls6a7h056nc5q76w4xl43sr1h9in2f23qwkxazcazr3zpi3p";
+  };
+
+  propagatedBuildInputs = [ jsonschema pyyaml six ]
+    ++ (lib.optionals (pythonOlder "3.4") [ pathlib ]);
+
+  checkInputs = [ mock pytest pytestcov pytest-flake8 tox ];
+
+  meta = with lib; {
+    homepage = https://github.com/p1c2u/openapi-spec-validator;
+    description = "Validates OpenAPI Specs against the OpenAPI 2.0 (aka Swagger) and OpenAPI 3.0.0 specification";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ rvl ];
+  };
+}

--- a/pkgs/pyyaml51.nix
+++ b/pkgs/pyyaml51.nix
@@ -1,0 +1,27 @@
+{ lib, buildPythonPackage, fetchPypi, cython, libyaml, buildPackages }:
+
+buildPythonPackage rec {
+  pname = "PyYAML";
+  version = "5.1";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "436bc774ecf7c103814098159fbb84c2715d25980175292c648f2da143909f95";
+  };
+
+  # force regeneration using Cython
+  postPatch = ''
+    rm ext/_yaml.c
+  '';
+
+  nativeBuildInputs = [ cython buildPackages.stdenv.cc ];
+
+  buildInputs = [ libyaml ];
+
+  meta = with lib; {
+    description = "The next generation YAML parser and emitter for Python";
+    homepage = https://github.com/yaml/pyyaml;
+    license = licenses.mit;
+    maintainers = with maintainers; [ dotlambda ];
+  };
+}

--- a/release.nix
+++ b/release.nix
@@ -30,6 +30,11 @@ let
     # tests.hlint                  = supportedSystems;
     # tests.shellcheck             = supportedSystems;
     # tests.stylishHaskell         = supportedSystems;
+
+    # Development tools
+    cache-s3 = supportedSystems;
+    stack-hpc-coveralls = supportedSystems;
+    openapi-spec-validator = supportedSystems;
  };
 in
 fix (self: mappedPkgs // {


### PR DESCRIPTION
This tool can be used within CI to validate swagger specs.

I have also opened an upstream PR NixOS/nixpkgs#65244.
