### PR TITLE
allow override of nixpkgs instead of src json

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -5,6 +5,7 @@
 # Set application for getting a specific application nixkgs-src.json
 , application ? ""
 # Override nixpkgs-src.json to a file in your repo
+, nixpkgsOverride ? ""
 , nixpkgsJsonOverride ? ""
 # Modify nixpkgs with overlays
 , nixpkgsOverlays ? []
@@ -24,7 +25,7 @@ let
   commonLib = rec {
     fetchNixpkgs = import ./fetch-tarball-with-override.nix "custom_nixpkgs";
     # equivalent of <nixpkgs> but pinned instead of system
-    nixpkgs = fetchNixpkgs nixpkgsJson;
+    nixpkgs = if nixpkgsOverride != "" then nixpkgsOverride else fetchNixpkgs nixpkgsJson;
     pkgsDefault = import (fetchNixpkgs nixpkgsJsonDefault) {};
     getPkgs = let
       system' = system;


### PR DESCRIPTION
We're experimenting with switching to niv for version tracking of individual repos in iohk-ops. iohk-nix currently only allows you to override nixpkgs rev using a json file iohk nix expects, but we want to override with a path to the source of nixpkgs (generated by niv).