### PR TITLE
add edgeHost params pointing at new nodes

### DIFF
--- a/cardano-lib/default.nix
+++ b/cardano-lib/default.nix
@@ -4,7 +4,7 @@ let
     hostAddr ? "127.0.0.1"
   , port ? 3001
   , edgeHost ? "127.0.0.1"
-  , edgePort ? 7777
+  , edgePort ? if edgeHost == "127.0.0.1" then 7777 else 3001
   , nodeId ? 0
   , valency ? 1
   }:
@@ -29,6 +29,7 @@ let
   environments = {
     mainnet = {
       relays = "relays.cardano-mainnet.iohk.io";
+      edgeHost = "18.185.45.45";
       confKey = "mainnet_full";
       genesisFile = ./mainnet-genesis.json;
       genesisHash = "5f20df933584822601f9e3f8c024eb5eb252fe8cefb24d1317dc3d432e940ebb";
@@ -36,6 +37,7 @@ let
     };
     staging = {
       relays = "relays.awstest.iohkdev.io";
+      edgeHost = "3.123.95.181";
       confKey = "mainnet_dryrun_full";
       genesisFile = ./mainnet-genesis-dryrun-with-stakeholders.json;
       genesisHash = "c6a004d3d178f600cd8caa10abbebe1549bef878f0665aea2903472d5abf7323";
@@ -43,6 +45,7 @@ let
     };
     testnet = {
       relays = "relays.cardano-testnet.iohkdev.io";
+      edgeHost = "18.194.162.74";
       confKey = "testnet_full";
       genesisFile = ./testnet-genesis.json;
       genesisHash = "96fceff972c2c06bd3bb5243c39215333be6d56aaf4823073dca31afe5038471";
@@ -50,6 +53,7 @@ let
     };
     shelley_staging = {
       relays = "relays.shelley-staging.aws.iohkdev.io";
+      edgeHost = "3.120.217.223";
       confKey = "shelley_staging_full";
       genesisFile = ./shelley-staging-genesis.json;
       genesisHash = "82995abf3e0e0f8ab9a6448875536a1cba305f3ddde18cd5ff54c32d7a5978c6";
@@ -57,8 +61,7 @@ let
     };
     shelley_staging_short = {
       relays = "relays.staging-shelley-short.aws.iohkdev.io";
-      #edgeHost = "edge.staging-shelley-short.aws.iohkdev.io";
-      #edgePort = 3001;
+      edgeHost = "3.123.96.194";
       confKey = "shelley_staging_short_full";
       genesisFile = ./shelley-staging-short-genesis.json;
       genesisHash = "a8e01a2325b31349e6f27d48c2e32e3a1ebaac2f8bc094114e780687f1400dda";


### PR DESCRIPTION
This adds endpoints for cardano-node to connect to remote nodes instead of needing to run a local proxy for all supported internal and external environments.