### PR TITLE
Add package for cardano-repo-tool

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -57,6 +57,9 @@ let
       # It requires PyYAML >= 5.1.
       pyyaml = pkgsDefault.python3Packages.callPackage ./pkgs/pyyaml51.nix {};
     };
+    cardano-repo-tool = pkgsDefault.callPackage ./pkgs/cardano-repo-tool.nix {
+      haskell = nix-tools.haskell { pkgs = pkgsDefault; };
+    };
 
     # Check scripts
     check-hydra = pkgsDefault.callPackage ./ci/check-hydra.nix {};
@@ -119,6 +122,6 @@ let
 
 in {
   inherit tests nix-tools stack2nix jemallocOverlay rust-packages cardanoLib;
-  inherit (commonLib) pkgs haskellPackages fetchNixpkgs maybeEnv cleanSourceHaskell getPkgs nixpkgs commitIdFromGitRepo getPackages cache-s3 stack-hpc-coveralls openapi-spec-validator check-hydra check-nix-tools;
+  inherit (commonLib) pkgs haskellPackages fetchNixpkgs maybeEnv cleanSourceHaskell getPkgs nixpkgs commitIdFromGitRepo getPackages cache-s3 stack-hpc-coveralls openapi-spec-validator cardano-repo-tool check-hydra check-nix-tools;
   release-lib = ./lib/release-lib.nix;
 }

--- a/pkgs/cardano-repo-tool.nix
+++ b/pkgs/cardano-repo-tool.nix
@@ -1,0 +1,40 @@
+{ lib, runCommand, fetchFromGitHub, git, makeWrapper, haskell }:
+
+let
+  src = fetchFromGitHub {
+    owner = "input-output-hk";
+    repo = "cardano-repo-tool";
+    rev = "71f21aa44dd491b34a10868a0de02ef43f788437";
+    sha256 = "1grmqk22q6gyk5qivp8zxklvcd43p10wbvsayy34z4mcg2745qiy";
+  };
+
+  # pkgSetCabal = haskell.mkCabalProjectPkgSet {
+  #   plan-pkgs = import (haskell.callCabalProjectToNix {
+  #     inherit src;
+  #     index-state = "2019-08-01T00:00:00Z";
+  #   });
+  # };
+
+  pkgSet = haskell.mkStackPkgSet {
+    stack-pkgs = import (haskell.callStackToNix {
+      inherit src;
+    });
+    pkg-def-extras = [];
+    modules = [{
+      packages.cardano-repo-tool.components.exes.cardano-repo-tool = {
+        build-tools = [ makeWrapper ];
+        postInstall = ''
+          wrapProgram $out/bin/cardano-repo-tool \
+            --prefix PATH : ${git}/bin
+        '';
+      };
+      packages.cardano-repo-tool.components.all.postInstall = lib.mkForce "";
+    }];
+  };
+
+  packages = pkgSet.config.hsPkgs;
+
+  inherit (packages.cardano-repo-tool.components.exes) cardano-repo-tool;
+
+in
+  cardano-repo-tool


### PR DESCRIPTION
So that cardano-repo-tool can be run in CI. @mhuesch was asking.

This is the current master revision.

It uses `callStackToNix` from Haskell.nix.
