### PR TITLE
Add package for hlint 2.1.11

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -52,6 +52,7 @@ let
     # Development tools
     cache-s3 = pkgsDefault.callPackage ./pkgs/cache-s3.nix {};
     stack-hpc-coveralls = pkgsDefault.haskellPackages.callPackage ./pkgs/stack-hpc-coveralls.nix {};
+    hlint = pkgsDefault.haskellPackages.callPackage ./pkgs/hlint.nix {};
     openapi-spec-validator = pkgsDefault.python3Packages.callPackage ./pkgs/openapi-spec-validator.nix {
       # Upstream PR: https://github.com/NixOS/nixpkgs/pull/65244
       # It requires PyYAML >= 5.1.
@@ -122,6 +123,6 @@ let
 
 in {
   inherit tests nix-tools stack2nix jemallocOverlay rust-packages cardanoLib;
-  inherit (commonLib) pkgs haskellPackages fetchNixpkgs maybeEnv cleanSourceHaskell getPkgs nixpkgs commitIdFromGitRepo getPackages cache-s3 stack-hpc-coveralls openapi-spec-validator cardano-repo-tool check-hydra check-nix-tools;
+  inherit (commonLib) pkgs haskellPackages fetchNixpkgs maybeEnv cleanSourceHaskell getPkgs nixpkgs commitIdFromGitRepo getPackages cache-s3 stack-hpc-coveralls hlint openapi-spec-validator cardano-repo-tool check-hydra check-nix-tools;
   release-lib = ./lib/release-lib.nix;
 }

--- a/pkgs/hlint.nix
+++ b/pkgs/hlint.nix
@@ -1,0 +1,24 @@
+{ mkDerivation, aeson, ansi-terminal, base, bytestring, cmdargs
+, containers, cpphs, data-default, directory, extra, filepath
+, haskell-src-exts, haskell-src-exts-util, hscolour, process
+, refact, stdenv, text, transformers, uniplate
+, unordered-containers, vector, yaml
+}:
+mkDerivation {
+  pname = "hlint";
+  version = "2.1.11";
+  sha256 = "4b590d27ec6da4670deea9de4f52c83048688073b3e6389a74da31d58e30665b";
+  isLibrary = true;
+  isExecutable = true;
+  enableSeparateDataOutput = true;
+  libraryHaskellDepends = [
+    aeson ansi-terminal base bytestring cmdargs containers cpphs
+    data-default directory extra filepath haskell-src-exts
+    haskell-src-exts-util hscolour process refact text transformers
+    uniplate unordered-containers vector yaml
+  ];
+  executableHaskellDepends = [ base ];
+  homepage = "https://github.com/ndmitchell/hlint#readme";
+  description = "Source code suggestions";
+  license = stdenv.lib.licenses.bsd3;
+}


### PR DESCRIPTION
Add the version of hlint which supports the `{-# HLINT #-}` annotation syntax that does not break cross-compiling. Later versions of HLint can't be used because they depend on hackage libraries that are not part of nixpkgs 18.09.