### PR TITLE
Buildkite: Run skeleton CI with revision of current build, not master

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,20 +1,19 @@
 steps:
-  - label: release.nix
-    command: 'nix-build -A check-hydra && ./result'
-    agents:
-      system: x86_64-linux
-
   - label: 'iohk-nix-src.json'
     command: './.buildkite/pin.sh'
     agents:
       system: x86_64-linux
 
-  - label: ":pipeline: Skeleton project pipeline"
-    command: "buildkite-agent pipeline upload skeleton/.buildkite/pipeline.yml"
+  - wait
+
+  - label: release.nix
+    command: 'nix-build -A check-hydra && ./result'
     agents:
       system: x86_64-linux
 
-  - label: ":pipeline: Skeleton nightly project pipeline"
-    command: "buildkite-agent pipeline upload skeleton/.buildkite/nightly.yml"
+  - label: ":pipeline: Skeleton project pipelines"
+    command:
+      - 'buildkite-agent pipeline upload skeleton/.buildkite/pipeline.yml'
+      - 'buildkite-agent pipeline upload skeleton/.buildkite/nightly.yml'
     agents:
       system: x86_64-linux

--- a/.buildkite/set-skeleton-pin.sh
+++ b/.buildkite/set-skeleton-pin.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+echo "--- :pushpin: Get pin from main build"
+buildkite-agent artifact download iohk-nix-src.json skeleton/nix/

--- a/skeleton/.buildkite/nightly.yml
+++ b/skeleton/.buildkite/nightly.yml
@@ -2,8 +2,8 @@
 steps:
   - label: 'Benchmark'
     commands:
-      - "cd skeleton"  # TODO: remove this line
-      - "./.buildkite/bench.sh"
+      - '.buildkite/set-skeleton-pin.sh && cd skeleton'  # TODO: remove this line
+      - '.buildkite/bench.sh'
     timeout_in_minutes: 60
     agents:
       system: x86_64-linux

--- a/skeleton/.buildkite/pipeline.yml
+++ b/skeleton/.buildkite/pipeline.yml
@@ -8,7 +8,7 @@
 steps:
   - label: Check Hydra evaluation of release.nix
     commands:
-      - "cd skeleton"  # TODO: remove this line
+      - ".buildkite/set-skeleton-pin.sh && cd skeleton"  # TODO: remove this line
       - "nix-build -A iohkLib.check-hydra -o check-hydra.sh"
       # TODO: uncomment the following line
       # - "./check-hydra.sh"
@@ -18,9 +18,9 @@ steps:
   # This will ensure that the generated Nix code is kept up to date.
   - label: Check auto-generated Nix
     commands:
-      - "export NIX_PATH=iohk_nix=$PWD:$NIX_PATH"  # TODO: remove this line - is just for iohk-nix
-      - "cd skeleton"  # TODO: remove this line
+      - ".buildkite/set-skeleton-pin.sh && cd skeleton"  # TODO: remove this line
       - "nix-build -A iohkLib.check-nix-tools -o check-nix-tools.sh"
+      - "git checkout -- nix/iohk-nix-src.json"  # TODO: remove this line
       - "./check-nix-tools.sh"
     agents:
       system: x86_64-linux
@@ -28,7 +28,7 @@ steps:
   # TODO: Remove this and define your own build steps.
   - label: Lint the fuzz
     commands:
-      - "cd skeleton"  # TODO: remove this line
+      - ".buildkite/set-skeleton-pin.sh && cd skeleton"  # TODO: remove this line
       - "nix-build -A checks.lint-fuzz -o check-lint-fuzz.sh"
       - "./check-lint-fuzz.sh"
     agents:
@@ -37,7 +37,7 @@ steps:
   # Imperative build steps
   - label: Stack build
     commands:
-      - "cd skeleton"  # TODO: remove this line
+      - ".buildkite/set-skeleton-pin.sh && cd skeleton"  # TODO: remove this line
       - "nix-build .buildkite/default.nix -o stack-rebuild"
       - "./stack-rebuild"
     agents:


### PR DESCRIPTION
Building skeleton against master is confusing and limits the usefulness of CI. This fixes it.