### PR TITLE
Add package for latest stylish-haskell from github

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -61,6 +61,9 @@ let
     cardano-repo-tool = pkgsDefault.callPackage ./pkgs/cardano-repo-tool.nix {
       haskell = nix-tools.haskell { pkgs = pkgsDefault; };
     };
+    stylish-haskell = pkgsDefault.callPackage ./pkgs/stylish-haskell.nix {
+      haskell = nix-tools.haskell { pkgs = pkgsDefault; };
+    };
 
     # Check scripts
     check-hydra = pkgsDefault.callPackage ./ci/check-hydra.nix {};
@@ -123,6 +126,6 @@ let
 
 in {
   inherit tests nix-tools stack2nix jemallocOverlay rust-packages cardanoLib;
-  inherit (commonLib) pkgs haskellPackages fetchNixpkgs maybeEnv cleanSourceHaskell getPkgs nixpkgs commitIdFromGitRepo getPackages cache-s3 stack-hpc-coveralls hlint openapi-spec-validator cardano-repo-tool check-hydra check-nix-tools;
+  inherit (commonLib) pkgs haskellPackages fetchNixpkgs maybeEnv cleanSourceHaskell getPkgs nixpkgs commitIdFromGitRepo getPackages cache-s3 stack-hpc-coveralls hlint stylish-haskell openapi-spec-validator cardano-repo-tool check-hydra check-nix-tools;
   release-lib = ./lib/release-lib.nix;
 }

--- a/pins/haskell-nix.json
+++ b/pins/haskell-nix.json
@@ -1,7 +1,7 @@
 {
   "url": "https://github.com/input-output-hk/haskell.nix",
-  "rev": "3ae2303b14bdebd00437b0e995af2d0eb21abafe",
-  "date": "2019-08-09T17:46:21+12:00",
-  "sha256": "0dk6541kwfyc5sp5h1vfk6zl4ghln4i2zqkaijbjwv8bnixnm6wl",
+  "rev": "792cf12b8b52d7cdf27936820a5ec4cff9b1b98c",
+  "date": "2019-09-30T01:08:09+00:00",
+  "sha256": "0wr6crbd7l2zhnpr5x8mm4hc8kjwvxb72kicb6ma3ds01wn547xr",
   "fetchSubmodules": false
 }

--- a/pkgs/cardano-repo-tool.nix
+++ b/pkgs/cardano-repo-tool.nix
@@ -8,17 +8,10 @@ let
     sha256 = "1grmqk22q6gyk5qivp8zxklvcd43p10wbvsayy34z4mcg2745qiy";
   };
 
-  # pkgSetCabal = haskell.mkCabalProjectPkgSet {
-  #   plan-pkgs = import (haskell.callCabalProjectToNix {
-  #     inherit src;
-  #     index-state = "2019-08-01T00:00:00Z";
-  #   });
-  # };
-
   pkgSet = haskell.mkStackPkgSet {
-    stack-pkgs = import (haskell.callStackToNix {
+    stack-pkgs = (haskell.importAndFilterProject (haskell.callStackToNix {
       inherit src;
-    });
+    })).pkgs;
     pkg-def-extras = [];
     modules = [{
       packages.cardano-repo-tool.components.exes.cardano-repo-tool = {

--- a/pkgs/stylish-haskell.nix
+++ b/pkgs/stylish-haskell.nix
@@ -1,0 +1,24 @@
+{ lib, runCommand, fetchFromGitHub, haskell }:
+
+let
+  src = fetchFromGitHub {
+    owner = "jaspervdj";
+    repo = "stylish-haskell";
+    rev = "a5d8cd34bcde3ad4698bbe38c9f14f7a1074ef4c";
+    sha256 = "1rrwp3g0ad0viismd1cs55jh9xpnjnadllmwxvg42cypg8axca2q";
+  };
+
+  pkgSet = haskell.mkStackPkgSet {
+    stack-pkgs = (haskell.importAndFilterProject (haskell.callStackToNix {
+      inherit src;
+    })).pkgs;
+    pkg-def-extras = [];
+    modules = [];
+  };
+
+  packages = pkgSet.config.hsPkgs;
+
+  inherit (packages.stylish-haskell.components.exes) stylish-haskell;
+
+in
+  stylish-haskell


### PR DESCRIPTION
The stylish-haskell that comes with nixpkgs 18.09 haskellPackages is a little bit old and missing support for some GHC extensions (e.g. DerivingVia).
