### PR TITLE
Fix the import call for callStackToNix

### DIFF
--- a/pkgs/cardano-repo-tool.nix
+++ b/pkgs/cardano-repo-tool.nix
@@ -16,9 +16,9 @@ let
   # };
 
   pkgSet = haskell.mkStackPkgSet {
-    stack-pkgs = import (haskell.callStackToNix {
+    stack-pkgs = (haskell.importAndFilterProject (haskell.callStackToNix {
       inherit src;
-    });
+    })).pkgs;
     pkg-def-extras = [];
     modules = [{
       packages.cardano-repo-tool.components.exes.cardano-repo-tool = {


### PR DESCRIPTION
this was introduced in a recent haskell.nix change which tried to align
callCabalProjectToNix and callStackToNix