### PR TITLE
Add cached stack builds to skeleton projects

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -11,9 +11,9 @@ steps:
     agents:
       system: x86_64-linux
 
-#  - label: ":pipeline: Skeleton project pipelines"
-#    command:
-#      - 'buildkite-agent pipeline upload skeleton/.buildkite/pipeline.yml'
-#      - 'buildkite-agent pipeline upload skeleton/.buildkite/nightly.yml'
-#    agents:
-#      system: x86_64-linux
+  - label: ":pipeline: Skeleton project pipelines"
+    command:
+      - 'buildkite-agent pipeline upload skeleton/.buildkite/pipeline.yml'
+      - 'buildkite-agent pipeline upload skeleton/.buildkite/nightly.yml'
+    agents:
+      system: x86_64-linux

--- a/default.nix
+++ b/default.nix
@@ -50,6 +50,7 @@ let
     commitIdFromGitRepo = pkgs.callPackage ./commit-id.nix {};
 
     # Development tools
+    haskellBuildUtils = import ./utils/default.nix { pkgs = pkgsDefault; };
     cache-s3 = pkgsDefault.callPackage ./pkgs/cache-s3.nix {};
     stack-hpc-coveralls = pkgsDefault.haskellPackages.callPackage ./pkgs/stack-hpc-coveralls.nix {};
     hlint = pkgsDefault.haskellPackages.callPackage ./pkgs/hlint.nix {};
@@ -126,6 +127,6 @@ let
 
 in {
   inherit tests nix-tools stack2nix jemallocOverlay rust-packages cardanoLib;
-  inherit (commonLib) pkgs haskellPackages fetchNixpkgs maybeEnv cleanSourceHaskell getPkgs nixpkgs commitIdFromGitRepo getPackages cache-s3 stack-hpc-coveralls hlint stylish-haskell openapi-spec-validator cardano-repo-tool check-hydra check-nix-tools;
+  inherit (commonLib) pkgs haskellPackages fetchNixpkgs maybeEnv cleanSourceHaskell getPkgs nixpkgs commitIdFromGitRepo getPackages cache-s3 stack-hpc-coveralls hlint stylish-haskell openapi-spec-validator cardano-repo-tool check-hydra check-nix-tools haskellBuildUtils;
   release-lib = ./lib/release-lib.nix;
 }

--- a/skeleton/.buildkite/default.nix
+++ b/skeleton/.buildkite/default.nix
@@ -1,22 +1,11 @@
 { iohkSkeletonPackages ? import ../default.nix {}
 , pkgs ? iohkSkeletonPackages.pkgs
-, buildTools ? with pkgs; [ git gnumake ]
+, iohkLib ? iohkSkeletonPackages.iohkLib
 }:
 
-with pkgs.lib;
-with pkgs;
-
-let
-  baseTools = [ stack gnused coreutils nix gnutar gzip ];
-  deps = ps: [ps.turtle ps.safe ps.transformers];
-
-  stackRebuild = runCommand "stack-rebuild" {} ''
-    ${haskellPackages.ghcWithPackages deps}/bin/ghc -o $out ${./rebuild.hs}
-  '';
-
-in
-  writeScript "stack-rebuild-wrapped" ''
-    #!${stdenv.shell}
-    export PATH=${lib.makeBinPath (baseTools ++ buildTools)}
-    exec ${stackRebuild} "$@"
-  ''
+iohkLib.haskellBuildUtils.stackRebuild {
+  script = ./rebuild.hs;
+  buildTools = [];
+  libs = ps: [];
+  shell = import ../nix/stack-shell.nix {};
+}

--- a/skeleton/.buildkite/pipeline.yml
+++ b/skeleton/.buildkite/pipeline.yml
@@ -5,6 +5,11 @@
 # iohk-nix.
 # TODO: remove all the "cd skeleton" lines
 
+env:
+  BUILD_DIR: "/build/iohk-skeleton"
+  STACK_ROOT: "/build/iohk-skeleton.stack"
+  CACHE_DIR: "/cache/iohk-skeleton"
+
 steps:
   - label: Check Hydra evaluation of release.nix
     commands:
@@ -33,3 +38,15 @@ steps:
       - "./check-lint-fuzz.sh"
     agents:
       system: x86_64-linux
+
+  # Imperative build steps
+  - label: Stack build
+    commands:
+      - ".buildkite/set-skeleton-pin.sh && cd skeleton"  # TODO: remove this line
+      - "nix-build .buildkite/default.nix -o sr"
+      - "./sr/bin/rebuild --build-dir=$BUILD_DIR --cache-dir=$CACHE_DIR"
+    agents:
+      system: x86_64-linux
+    timeout_in_minutes: 60
+    artifact_paths:
+      - "/build/iohk-skeleton/.stack-work/logs/iohk-skeleton*.log"

--- a/skeleton/nix/.stack.nix/canonical-json.nix
+++ b/skeleton/nix/.stack.nix/canonical-json.nix
@@ -1,4 +1,43 @@
-{ system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
+let
+  buildDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (build dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  sysDepError = pkg:
+    builtins.throw ''
+      The Nixpkgs package set does not contain the package: ${pkg} (system dependency).
+      
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      '';
+  pkgConfDepError = pkg:
+    builtins.throw ''
+      The pkg-conf packages does not contain the package: ${pkg} (pkg-conf dependency).
+      
+      You may need to augment the pkg-conf package mapping in haskell.nix so that it can be found.
+      '';
+  exeDepError = pkg:
+    builtins.throw ''
+      The local executable components do not include the component: ${pkg} (executable dependency).
+      '';
+  legacyExeDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (executable dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  buildToolDepError = pkg:
+    builtins.throw ''
+      Neither the Haskell package set or the Nixpkgs package set contain the package: ${pkg} (build tool dependency).
+      
+      If this is a system dependency:
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      
+      If this is a Haskell dependency:
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
   {
     flags = {};
     package = {
@@ -13,43 +52,47 @@
       synopsis = "Canonical JSON for signing and hashing JSON values";
       description = "An implementation of Canonical JSON.\n\n<http://wiki.laptop.org/go/Canonical_JSON>\n\nThe \\\"canonical JSON\\\" format is designed to provide\nrepeatable hashes of JSON-encoded data. It is designed\nfor applications that need to hash, sign or authenitcate\nJSON data structures, including embedded signatures.\n\nCanonical JSON is parsable with any full JSON parser, and\nit allows whitespace for pretty-printed human readable\npresentation, but it can be put into a canonical form\nwhich then has a stable serialised representation and\nthus a stable hash.";
       buildType = "Simple";
+      isLocal = true;
       };
     components = {
       "library" = {
         depends = [
-          (hsPkgs.base)
-          (hsPkgs.bytestring)
-          (hsPkgs.containers)
-          (hsPkgs.deepseq)
-          (hsPkgs.parsec)
-          (hsPkgs.pretty)
+          (hsPkgs."base" or (buildDepError "base"))
+          (hsPkgs."bytestring" or (buildDepError "bytestring"))
+          (hsPkgs."containers" or (buildDepError "containers"))
+          (hsPkgs."deepseq" or (buildDepError "deepseq"))
+          (hsPkgs."parsec" or (buildDepError "parsec"))
+          (hsPkgs."pretty" or (buildDepError "pretty"))
           ];
+        buildable = true;
         };
       tests = {
         "tests" = {
           depends = [
-            (hsPkgs.base)
-            (hsPkgs.bytestring)
-            (hsPkgs.canonical-json)
-            (hsPkgs.containers)
-            (hsPkgs.aeson)
-            (hsPkgs.vector)
-            (hsPkgs.unordered-containers)
-            (hsPkgs.QuickCheck)
-            (hsPkgs.tasty)
-            (hsPkgs.tasty-quickcheck)
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."bytestring" or (buildDepError "bytestring"))
+            (hsPkgs."canonical-json" or (buildDepError "canonical-json"))
+            (hsPkgs."containers" or (buildDepError "containers"))
+            (hsPkgs."aeson" or (buildDepError "aeson"))
+            (hsPkgs."vector" or (buildDepError "vector"))
+            (hsPkgs."unordered-containers" or (buildDepError "unordered-containers"))
+            (hsPkgs."QuickCheck" or (buildDepError "QuickCheck"))
+            (hsPkgs."tasty" or (buildDepError "tasty"))
+            (hsPkgs."tasty-quickcheck" or (buildDepError "tasty-quickcheck"))
             ];
+          buildable = true;
           };
         };
       benchmarks = {
         "parse-bench" = {
           depends = [
-            (hsPkgs.base)
-            (hsPkgs.bytestring)
-            (hsPkgs.canonical-json)
-            (hsPkgs.containers)
-            (hsPkgs.criterion)
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."bytestring" or (buildDepError "bytestring"))
+            (hsPkgs."canonical-json" or (buildDepError "canonical-json"))
+            (hsPkgs."containers" or (buildDepError "containers"))
+            (hsPkgs."criterion" or (buildDepError "criterion"))
             ];
+          buildable = true;
           };
         };
       };

--- a/skeleton/nix/.stack.nix/cardano-binary-test.nix
+++ b/skeleton/nix/.stack.nix/cardano-binary-test.nix
@@ -1,4 +1,43 @@
-{ system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
+let
+  buildDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (build dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  sysDepError = pkg:
+    builtins.throw ''
+      The Nixpkgs package set does not contain the package: ${pkg} (system dependency).
+      
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      '';
+  pkgConfDepError = pkg:
+    builtins.throw ''
+      The pkg-conf packages does not contain the package: ${pkg} (pkg-conf dependency).
+      
+      You may need to augment the pkg-conf package mapping in haskell.nix so that it can be found.
+      '';
+  exeDepError = pkg:
+    builtins.throw ''
+      The local executable components do not include the component: ${pkg} (executable dependency).
+      '';
+  legacyExeDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (executable dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  buildToolDepError = pkg:
+    builtins.throw ''
+      Neither the Haskell package set or the Nixpkgs package set contain the package: ${pkg} (build tool dependency).
+      
+      If this is a system dependency:
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      
+      If this is a Haskell dependency:
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
   {
     flags = { development = false; };
     package = {
@@ -13,26 +52,28 @@
       synopsis = "Test helpers from cardano-binary exposed to other packages";
       description = "Test helpers from cardano-binary exposed to other packages";
       buildType = "Simple";
+      isLocal = true;
       };
     components = {
       "library" = {
         depends = [
-          (hsPkgs.base)
-          (hsPkgs.bytestring)
-          (hsPkgs.cardano-binary)
-          (hsPkgs.cardano-prelude)
-          (hsPkgs.cardano-prelude-test)
-          (hsPkgs.cborg)
-          (hsPkgs.containers)
-          (hsPkgs.formatting)
-          (hsPkgs.hedgehog)
-          (hsPkgs.hspec)
-          (hsPkgs.pretty-show)
-          (hsPkgs.QuickCheck)
-          (hsPkgs.quickcheck-instances)
-          (hsPkgs.text)
-          (hsPkgs.vector)
+          (hsPkgs."base" or (buildDepError "base"))
+          (hsPkgs."bytestring" or (buildDepError "bytestring"))
+          (hsPkgs."cardano-binary" or (buildDepError "cardano-binary"))
+          (hsPkgs."cardano-prelude" or (buildDepError "cardano-prelude"))
+          (hsPkgs."cardano-prelude-test" or (buildDepError "cardano-prelude-test"))
+          (hsPkgs."cborg" or (buildDepError "cborg"))
+          (hsPkgs."containers" or (buildDepError "containers"))
+          (hsPkgs."formatting" or (buildDepError "formatting"))
+          (hsPkgs."hedgehog" or (buildDepError "hedgehog"))
+          (hsPkgs."hspec" or (buildDepError "hspec"))
+          (hsPkgs."pretty-show" or (buildDepError "pretty-show"))
+          (hsPkgs."QuickCheck" or (buildDepError "QuickCheck"))
+          (hsPkgs."quickcheck-instances" or (buildDepError "quickcheck-instances"))
+          (hsPkgs."text" or (buildDepError "text"))
+          (hsPkgs."vector" or (buildDepError "vector"))
           ];
+        buildable = true;
         };
       };
     } // {

--- a/skeleton/nix/.stack.nix/cardano-binary.nix
+++ b/skeleton/nix/.stack.nix/cardano-binary.nix
@@ -1,4 +1,43 @@
-{ system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
+let
+  buildDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (build dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  sysDepError = pkg:
+    builtins.throw ''
+      The Nixpkgs package set does not contain the package: ${pkg} (system dependency).
+      
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      '';
+  pkgConfDepError = pkg:
+    builtins.throw ''
+      The pkg-conf packages does not contain the package: ${pkg} (pkg-conf dependency).
+      
+      You may need to augment the pkg-conf package mapping in haskell.nix so that it can be found.
+      '';
+  exeDepError = pkg:
+    builtins.throw ''
+      The local executable components do not include the component: ${pkg} (executable dependency).
+      '';
+  legacyExeDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (executable dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  buildToolDepError = pkg:
+    builtins.throw ''
+      Neither the Haskell package set or the Nixpkgs package set contain the package: ${pkg} (build tool dependency).
+      
+      If this is a system dependency:
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      
+      If this is a Haskell dependency:
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
   {
     flags = { development = false; };
     package = {
@@ -13,46 +52,49 @@
       synopsis = "Binary serialization for Cardano";
       description = "This package includes the binary serialization format for Cardano";
       buildType = "Simple";
+      isLocal = true;
       };
     components = {
       "library" = {
         depends = [
-          (hsPkgs.base)
-          (hsPkgs.aeson)
-          (hsPkgs.bytestring)
-          (hsPkgs.cardano-prelude)
-          (hsPkgs.cborg)
-          (hsPkgs.containers)
-          (hsPkgs.digest)
-          (hsPkgs.formatting)
-          (hsPkgs.recursion-schemes)
-          (hsPkgs.safe-exceptions)
-          (hsPkgs.tagged)
-          (hsPkgs.text)
-          (hsPkgs.time)
-          (hsPkgs.vector)
+          (hsPkgs."base" or (buildDepError "base"))
+          (hsPkgs."aeson" or (buildDepError "aeson"))
+          (hsPkgs."bytestring" or (buildDepError "bytestring"))
+          (hsPkgs."cardano-prelude" or (buildDepError "cardano-prelude"))
+          (hsPkgs."cborg" or (buildDepError "cborg"))
+          (hsPkgs."containers" or (buildDepError "containers"))
+          (hsPkgs."digest" or (buildDepError "digest"))
+          (hsPkgs."formatting" or (buildDepError "formatting"))
+          (hsPkgs."recursion-schemes" or (buildDepError "recursion-schemes"))
+          (hsPkgs."safe-exceptions" or (buildDepError "safe-exceptions"))
+          (hsPkgs."tagged" or (buildDepError "tagged"))
+          (hsPkgs."text" or (buildDepError "text"))
+          (hsPkgs."time" or (buildDepError "time"))
+          (hsPkgs."vector" or (buildDepError "vector"))
           ];
+        buildable = true;
         };
       tests = {
         "test" = {
           depends = [
-            (hsPkgs.base)
-            (hsPkgs.bytestring)
-            (hsPkgs.cardano-binary)
-            (hsPkgs.cardano-prelude)
-            (hsPkgs.cardano-prelude-test)
-            (hsPkgs.cborg)
-            (hsPkgs.containers)
-            (hsPkgs.formatting)
-            (hsPkgs.hedgehog)
-            (hsPkgs.hspec)
-            (hsPkgs.pretty-show)
-            (hsPkgs.QuickCheck)
-            (hsPkgs.quickcheck-instances)
-            (hsPkgs.tagged)
-            (hsPkgs.text)
-            (hsPkgs.vector)
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."bytestring" or (buildDepError "bytestring"))
+            (hsPkgs."cardano-binary" or (buildDepError "cardano-binary"))
+            (hsPkgs."cardano-prelude" or (buildDepError "cardano-prelude"))
+            (hsPkgs."cardano-prelude-test" or (buildDepError "cardano-prelude-test"))
+            (hsPkgs."cborg" or (buildDepError "cborg"))
+            (hsPkgs."containers" or (buildDepError "containers"))
+            (hsPkgs."formatting" or (buildDepError "formatting"))
+            (hsPkgs."hedgehog" or (buildDepError "hedgehog"))
+            (hsPkgs."hspec" or (buildDepError "hspec"))
+            (hsPkgs."pretty-show" or (buildDepError "pretty-show"))
+            (hsPkgs."QuickCheck" or (buildDepError "QuickCheck"))
+            (hsPkgs."quickcheck-instances" or (buildDepError "quickcheck-instances"))
+            (hsPkgs."tagged" or (buildDepError "tagged"))
+            (hsPkgs."text" or (buildDepError "text"))
+            (hsPkgs."vector" or (buildDepError "vector"))
             ];
+          buildable = true;
           };
         };
       };

--- a/skeleton/nix/.stack.nix/cardano-crypto.nix
+++ b/skeleton/nix/.stack.nix/cardano-crypto.nix
@@ -1,4 +1,43 @@
-{ system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
+let
+  buildDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (build dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  sysDepError = pkg:
+    builtins.throw ''
+      The Nixpkgs package set does not contain the package: ${pkg} (system dependency).
+      
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      '';
+  pkgConfDepError = pkg:
+    builtins.throw ''
+      The pkg-conf packages does not contain the package: ${pkg} (pkg-conf dependency).
+      
+      You may need to augment the pkg-conf package mapping in haskell.nix so that it can be found.
+      '';
+  exeDepError = pkg:
+    builtins.throw ''
+      The local executable components do not include the component: ${pkg} (executable dependency).
+      '';
+  legacyExeDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (executable dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  buildToolDepError = pkg:
+    builtins.throw ''
+      Neither the Haskell package set or the Nixpkgs package set contain the package: ${pkg} (build tool dependency).
+      
+      If this is a system dependency:
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      
+      If this is a Haskell dependency:
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
   {
     flags = { golden-tests = false; golden-tests-exe = false; };
     package = {
@@ -13,69 +52,75 @@
       synopsis = "Cryptography primitives for cardano";
       description = "";
       buildType = "Simple";
+      isLocal = true;
       };
     components = {
       "library" = {
         depends = [
-          (hsPkgs.base)
-          (hsPkgs.memory)
-          (hsPkgs.deepseq)
-          (hsPkgs.bytestring)
-          (hsPkgs.basement)
-          (hsPkgs.foundation)
-          (hsPkgs.cryptonite)
-          (hsPkgs.cryptonite-openssl)
-          (hsPkgs.hashable)
-          (hsPkgs.integer-gmp)
+          (hsPkgs."base" or (buildDepError "base"))
+          (hsPkgs."memory" or (buildDepError "memory"))
+          (hsPkgs."deepseq" or (buildDepError "deepseq"))
+          (hsPkgs."bytestring" or (buildDepError "bytestring"))
+          (hsPkgs."basement" or (buildDepError "basement"))
+          (hsPkgs."foundation" or (buildDepError "foundation"))
+          (hsPkgs."cryptonite" or (buildDepError "cryptonite"))
+          (hsPkgs."cryptonite-openssl" or (buildDepError "cryptonite-openssl"))
+          (hsPkgs."hashable" or (buildDepError "hashable"))
+          (hsPkgs."integer-gmp" or (buildDepError "integer-gmp"))
           ];
+        buildable = true;
         };
       exes = {
         "golden-tests" = {
           depends = [
-            (hsPkgs.base)
-            (hsPkgs.basement)
-            (hsPkgs.foundation)
-            (hsPkgs.memory)
-            (hsPkgs.bytestring)
-            (hsPkgs.cryptonite)
-            (hsPkgs.cardano-crypto)
-            ] ++ (pkgs.lib).optional (flags.golden-tests-exe) (hsPkgs.inspector);
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."basement" or (buildDepError "basement"))
+            (hsPkgs."foundation" or (buildDepError "foundation"))
+            (hsPkgs."memory" or (buildDepError "memory"))
+            (hsPkgs."bytestring" or (buildDepError "bytestring"))
+            (hsPkgs."cryptonite" or (buildDepError "cryptonite"))
+            (hsPkgs."cardano-crypto" or (buildDepError "cardano-crypto"))
+            ] ++ (pkgs.lib).optional (flags.golden-tests-exe) (hsPkgs."inspector" or (buildDepError "inspector"));
+          buildable = if flags.golden-tests-exe then true else false;
           };
         };
       tests = {
         "cardano-crypto-test" = {
           depends = [
-            (hsPkgs.base)
-            (hsPkgs.bytestring)
-            (hsPkgs.memory)
-            (hsPkgs.cryptonite)
-            (hsPkgs.cardano-crypto)
-            (hsPkgs.basement)
-            (hsPkgs.foundation)
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."bytestring" or (buildDepError "bytestring"))
+            (hsPkgs."memory" or (buildDepError "memory"))
+            (hsPkgs."cryptonite" or (buildDepError "cryptonite"))
+            (hsPkgs."cardano-crypto" or (buildDepError "cardano-crypto"))
+            (hsPkgs."basement" or (buildDepError "basement"))
+            (hsPkgs."foundation" or (buildDepError "foundation"))
             ];
+          buildable = true;
           };
         "cardano-crypto-golden-tests" = {
           depends = [
-            (hsPkgs.base)
-            (hsPkgs.basement)
-            (hsPkgs.foundation)
-            (hsPkgs.memory)
-            (hsPkgs.bytestring)
-            (hsPkgs.cryptonite)
-            (hsPkgs.cardano-crypto)
-            ] ++ (pkgs.lib).optional (flags.golden-tests) (hsPkgs.inspector);
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."basement" or (buildDepError "basement"))
+            (hsPkgs."foundation" or (buildDepError "foundation"))
+            (hsPkgs."memory" or (buildDepError "memory"))
+            (hsPkgs."bytestring" or (buildDepError "bytestring"))
+            (hsPkgs."cryptonite" or (buildDepError "cryptonite"))
+            (hsPkgs."cardano-crypto" or (buildDepError "cardano-crypto"))
+            ] ++ (pkgs.lib).optional (flags.golden-tests) (hsPkgs."inspector" or (buildDepError "inspector"));
+          buildable = if flags.golden-tests then true else false;
           };
         };
       benchmarks = {
         "cardano-crypto-bench" = {
           depends = [
-            (hsPkgs.base)
-            (hsPkgs.bytestring)
-            (hsPkgs.memory)
-            (hsPkgs.cryptonite)
-            (hsPkgs.cardano-crypto)
-            (hsPkgs.gauge)
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."bytestring" or (buildDepError "bytestring"))
+            (hsPkgs."memory" or (buildDepError "memory"))
+            (hsPkgs."cryptonite" or (buildDepError "cryptonite"))
+            (hsPkgs."cardano-crypto" or (buildDepError "cardano-crypto"))
+            (hsPkgs."gauge" or (buildDepError "gauge"))
             ];
+          buildable = true;
           };
         };
       };

--- a/skeleton/nix/.stack.nix/cardano-prelude-test.nix
+++ b/skeleton/nix/.stack.nix/cardano-prelude-test.nix
@@ -1,4 +1,43 @@
-{ system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
+let
+  buildDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (build dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  sysDepError = pkg:
+    builtins.throw ''
+      The Nixpkgs package set does not contain the package: ${pkg} (system dependency).
+      
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      '';
+  pkgConfDepError = pkg:
+    builtins.throw ''
+      The pkg-conf packages does not contain the package: ${pkg} (pkg-conf dependency).
+      
+      You may need to augment the pkg-conf package mapping in haskell.nix so that it can be found.
+      '';
+  exeDepError = pkg:
+    builtins.throw ''
+      The local executable components do not include the component: ${pkg} (executable dependency).
+      '';
+  legacyExeDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (executable dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  buildToolDepError = pkg:
+    builtins.throw ''
+      Neither the Haskell package set or the Nixpkgs package set contain the package: ${pkg} (build tool dependency).
+      
+      If this is a system dependency:
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      
+      If this is a Haskell dependency:
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
   {
     flags = { development = false; };
     package = {
@@ -13,30 +52,32 @@
       synopsis = "Utility types and functions for testing Cardano";
       description = "Utility types and functions for testing Cardano";
       buildType = "Simple";
+      isLocal = true;
       };
     components = {
       "library" = {
         depends = [
-          (hsPkgs.base)
-          (hsPkgs.aeson)
-          (hsPkgs.aeson-pretty)
-          (hsPkgs.attoparsec)
-          (hsPkgs.base16-bytestring)
-          (hsPkgs.bytestring)
-          (hsPkgs.canonical-json)
-          (hsPkgs.cardano-prelude)
-          (hsPkgs.containers)
-          (hsPkgs.cryptonite)
-          (hsPkgs.formatting)
-          (hsPkgs.hedgehog)
-          (hsPkgs.hspec)
-          (hsPkgs.pretty-show)
-          (hsPkgs.QuickCheck)
-          (hsPkgs.quickcheck-instances)
-          (hsPkgs.text)
-          (hsPkgs.template-haskell)
-          (hsPkgs.time)
+          (hsPkgs."base" or (buildDepError "base"))
+          (hsPkgs."aeson" or (buildDepError "aeson"))
+          (hsPkgs."aeson-pretty" or (buildDepError "aeson-pretty"))
+          (hsPkgs."attoparsec" or (buildDepError "attoparsec"))
+          (hsPkgs."base16-bytestring" or (buildDepError "base16-bytestring"))
+          (hsPkgs."bytestring" or (buildDepError "bytestring"))
+          (hsPkgs."canonical-json" or (buildDepError "canonical-json"))
+          (hsPkgs."cardano-prelude" or (buildDepError "cardano-prelude"))
+          (hsPkgs."containers" or (buildDepError "containers"))
+          (hsPkgs."cryptonite" or (buildDepError "cryptonite"))
+          (hsPkgs."formatting" or (buildDepError "formatting"))
+          (hsPkgs."hedgehog" or (buildDepError "hedgehog"))
+          (hsPkgs."hspec" or (buildDepError "hspec"))
+          (hsPkgs."pretty-show" or (buildDepError "pretty-show"))
+          (hsPkgs."QuickCheck" or (buildDepError "QuickCheck"))
+          (hsPkgs."quickcheck-instances" or (buildDepError "quickcheck-instances"))
+          (hsPkgs."text" or (buildDepError "text"))
+          (hsPkgs."template-haskell" or (buildDepError "template-haskell"))
+          (hsPkgs."time" or (buildDepError "time"))
           ];
+        buildable = true;
         };
       };
     } // {

--- a/skeleton/nix/.stack.nix/cardano-prelude.nix
+++ b/skeleton/nix/.stack.nix/cardano-prelude.nix
@@ -1,4 +1,43 @@
-{ system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
+let
+  buildDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (build dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  sysDepError = pkg:
+    builtins.throw ''
+      The Nixpkgs package set does not contain the package: ${pkg} (system dependency).
+      
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      '';
+  pkgConfDepError = pkg:
+    builtins.throw ''
+      The pkg-conf packages does not contain the package: ${pkg} (pkg-conf dependency).
+      
+      You may need to augment the pkg-conf package mapping in haskell.nix so that it can be found.
+      '';
+  exeDepError = pkg:
+    builtins.throw ''
+      The local executable components do not include the component: ${pkg} (executable dependency).
+      '';
+  legacyExeDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (executable dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  buildToolDepError = pkg:
+    builtins.throw ''
+      Neither the Haskell package set or the Nixpkgs package set contain the package: ${pkg} (build tool dependency).
+      
+      If this is a system dependency:
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      
+      If this is a Haskell dependency:
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
   {
     flags = { development = false; };
     package = {
@@ -13,56 +52,59 @@
       synopsis = "A Prelude replacement for the Cardano project";
       description = "A Prelude replacement for the Cardano project";
       buildType = "Simple";
+      isLocal = true;
       };
     components = {
       "library" = {
         depends = [
-          (hsPkgs.base)
-          (hsPkgs.aeson)
-          (hsPkgs.array)
-          (hsPkgs.base16-bytestring)
-          (hsPkgs.bytestring)
-          (hsPkgs.canonical-json)
-          (hsPkgs.cborg)
-          (hsPkgs.containers)
-          (hsPkgs.formatting)
-          (hsPkgs.ghc-heap)
-          (hsPkgs.ghc-prim)
-          (hsPkgs.hashable)
-          (hsPkgs.integer-gmp)
-          (hsPkgs.mtl)
-          (hsPkgs.nonempty-containers)
-          (hsPkgs.protolude)
-          (hsPkgs.tagged)
-          (hsPkgs.text)
-          (hsPkgs.time)
-          (hsPkgs.vector)
+          (hsPkgs."base" or (buildDepError "base"))
+          (hsPkgs."aeson" or (buildDepError "aeson"))
+          (hsPkgs."array" or (buildDepError "array"))
+          (hsPkgs."base16-bytestring" or (buildDepError "base16-bytestring"))
+          (hsPkgs."bytestring" or (buildDepError "bytestring"))
+          (hsPkgs."canonical-json" or (buildDepError "canonical-json"))
+          (hsPkgs."cborg" or (buildDepError "cborg"))
+          (hsPkgs."containers" or (buildDepError "containers"))
+          (hsPkgs."formatting" or (buildDepError "formatting"))
+          (hsPkgs."ghc-heap" or (buildDepError "ghc-heap"))
+          (hsPkgs."ghc-prim" or (buildDepError "ghc-prim"))
+          (hsPkgs."hashable" or (buildDepError "hashable"))
+          (hsPkgs."integer-gmp" or (buildDepError "integer-gmp"))
+          (hsPkgs."mtl" or (buildDepError "mtl"))
+          (hsPkgs."nonempty-containers" or (buildDepError "nonempty-containers"))
+          (hsPkgs."protolude" or (buildDepError "protolude"))
+          (hsPkgs."tagged" or (buildDepError "tagged"))
+          (hsPkgs."text" or (buildDepError "text"))
+          (hsPkgs."time" or (buildDepError "time"))
+          (hsPkgs."vector" or (buildDepError "vector"))
           ];
+        buildable = true;
         };
       tests = {
         "cardano-prelude-test" = {
           depends = [
-            (hsPkgs.base)
-            (hsPkgs.aeson)
-            (hsPkgs.aeson-pretty)
-            (hsPkgs.attoparsec)
-            (hsPkgs.base16-bytestring)
-            (hsPkgs.bytestring)
-            (hsPkgs.canonical-json)
-            (hsPkgs.cardano-prelude)
-            (hsPkgs.containers)
-            (hsPkgs.cryptonite)
-            (hsPkgs.formatting)
-            (hsPkgs.ghc-heap)
-            (hsPkgs.hedgehog)
-            (hsPkgs.hspec)
-            (hsPkgs.pretty-show)
-            (hsPkgs.QuickCheck)
-            (hsPkgs.quickcheck-instances)
-            (hsPkgs.text)
-            (hsPkgs.template-haskell)
-            (hsPkgs.time)
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."aeson" or (buildDepError "aeson"))
+            (hsPkgs."aeson-pretty" or (buildDepError "aeson-pretty"))
+            (hsPkgs."attoparsec" or (buildDepError "attoparsec"))
+            (hsPkgs."base16-bytestring" or (buildDepError "base16-bytestring"))
+            (hsPkgs."bytestring" or (buildDepError "bytestring"))
+            (hsPkgs."canonical-json" or (buildDepError "canonical-json"))
+            (hsPkgs."cardano-prelude" or (buildDepError "cardano-prelude"))
+            (hsPkgs."containers" or (buildDepError "containers"))
+            (hsPkgs."cryptonite" or (buildDepError "cryptonite"))
+            (hsPkgs."formatting" or (buildDepError "formatting"))
+            (hsPkgs."ghc-heap" or (buildDepError "ghc-heap"))
+            (hsPkgs."hedgehog" or (buildDepError "hedgehog"))
+            (hsPkgs."hspec" or (buildDepError "hspec"))
+            (hsPkgs."pretty-show" or (buildDepError "pretty-show"))
+            (hsPkgs."QuickCheck" or (buildDepError "QuickCheck"))
+            (hsPkgs."quickcheck-instances" or (buildDepError "quickcheck-instances"))
+            (hsPkgs."text" or (buildDepError "text"))
+            (hsPkgs."template-haskell" or (buildDepError "template-haskell"))
+            (hsPkgs."time" or (buildDepError "time"))
             ];
+          buildable = true;
           };
         };
       };

--- a/skeleton/nix/.stack.nix/cborg.nix
+++ b/skeleton/nix/.stack.nix/cborg.nix
@@ -1,4 +1,43 @@
-{ system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
+let
+  buildDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (build dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  sysDepError = pkg:
+    builtins.throw ''
+      The Nixpkgs package set does not contain the package: ${pkg} (system dependency).
+      
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      '';
+  pkgConfDepError = pkg:
+    builtins.throw ''
+      The pkg-conf packages does not contain the package: ${pkg} (pkg-conf dependency).
+      
+      You may need to augment the pkg-conf package mapping in haskell.nix so that it can be found.
+      '';
+  exeDepError = pkg:
+    builtins.throw ''
+      The local executable components do not include the component: ${pkg} (executable dependency).
+      '';
+  legacyExeDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (executable dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  buildToolDepError = pkg:
+    builtins.throw ''
+      Neither the Haskell package set or the Nixpkgs package set contain the package: ${pkg} (build tool dependency).
+      
+      If this is a system dependency:
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      
+      If this is a Haskell dependency:
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
   {
     flags = { optimize-gmp = true; };
     package = {
@@ -13,45 +52,48 @@
       synopsis = "Concise Binary Object Representation";
       description = "This package (formerly @binary-serialise-cbor@) provides an efficient\nimplementation of the Concise Binary Object Representation (CBOR), as\nspecified by [RFC 7049](https://tools.ietf.org/html/rfc7049).\n\nIf you are looking for a library for serialisation of Haskell values,\nhave a look at the [serialise](/package/serialise) package, which is\nbuilt upon this library.\n\nAn implementation of the standard bijection between CBOR and JSON is provided\nby the [cborg-json](/package/cborg-json) package. Also see [cbor-tool](/package/cbor-tool)\nfor a convenient command-line utility for working with CBOR data.";
       buildType = "Simple";
+      isLocal = true;
       };
     components = {
       "library" = {
         depends = ([
-          (hsPkgs.array)
-          (hsPkgs.base)
-          (hsPkgs.bytestring)
-          (hsPkgs.containers)
-          (hsPkgs.deepseq)
-          (hsPkgs.ghc-prim)
-          (hsPkgs.half)
-          (hsPkgs.primitive)
-          (hsPkgs.text)
-          ] ++ (pkgs.lib).optional (flags.optimize-gmp) (hsPkgs.integer-gmp)) ++ (pkgs.lib).optionals (!(compiler.isGhc && (compiler.version).ge "8.0")) [
-          (hsPkgs.fail)
-          (hsPkgs.semigroups)
+          (hsPkgs."array" or (buildDepError "array"))
+          (hsPkgs."base" or (buildDepError "base"))
+          (hsPkgs."bytestring" or (buildDepError "bytestring"))
+          (hsPkgs."containers" or (buildDepError "containers"))
+          (hsPkgs."deepseq" or (buildDepError "deepseq"))
+          (hsPkgs."ghc-prim" or (buildDepError "ghc-prim"))
+          (hsPkgs."half" or (buildDepError "half"))
+          (hsPkgs."primitive" or (buildDepError "primitive"))
+          (hsPkgs."text" or (buildDepError "text"))
+          ] ++ (pkgs.lib).optional (flags.optimize-gmp) (hsPkgs."integer-gmp" or (buildDepError "integer-gmp"))) ++ (pkgs.lib).optionals (!(compiler.isGhc && (compiler.version).ge "8.0")) [
+          (hsPkgs."fail" or (buildDepError "fail"))
+          (hsPkgs."semigroups" or (buildDepError "semigroups"))
           ];
+        buildable = true;
         };
       tests = {
         "tests" = {
           depends = [
-            (hsPkgs.array)
-            (hsPkgs.base)
-            (hsPkgs.bytestring)
-            (hsPkgs.text)
-            (hsPkgs.cborg)
-            (hsPkgs.aeson)
-            (hsPkgs.base64-bytestring)
-            (hsPkgs.base16-bytestring)
-            (hsPkgs.deepseq)
-            (hsPkgs.fail)
-            (hsPkgs.half)
-            (hsPkgs.QuickCheck)
-            (hsPkgs.scientific)
-            (hsPkgs.tasty)
-            (hsPkgs.tasty-hunit)
-            (hsPkgs.tasty-quickcheck)
-            (hsPkgs.vector)
+            (hsPkgs."array" or (buildDepError "array"))
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."bytestring" or (buildDepError "bytestring"))
+            (hsPkgs."text" or (buildDepError "text"))
+            (hsPkgs."cborg" or (buildDepError "cborg"))
+            (hsPkgs."aeson" or (buildDepError "aeson"))
+            (hsPkgs."base64-bytestring" or (buildDepError "base64-bytestring"))
+            (hsPkgs."base16-bytestring" or (buildDepError "base16-bytestring"))
+            (hsPkgs."deepseq" or (buildDepError "deepseq"))
+            (hsPkgs."fail" or (buildDepError "fail"))
+            (hsPkgs."half" or (buildDepError "half"))
+            (hsPkgs."QuickCheck" or (buildDepError "QuickCheck"))
+            (hsPkgs."scientific" or (buildDepError "scientific"))
+            (hsPkgs."tasty" or (buildDepError "tasty"))
+            (hsPkgs."tasty-hunit" or (buildDepError "tasty-hunit"))
+            (hsPkgs."tasty-quickcheck" or (buildDepError "tasty-quickcheck"))
+            (hsPkgs."vector" or (buildDepError "vector"))
             ];
+          buildable = true;
           };
         };
       };

--- a/skeleton/nix/.stack.nix/contra-tracer.nix
+++ b/skeleton/nix/.stack.nix/contra-tracer.nix
@@ -1,4 +1,43 @@
-{ system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
+let
+  buildDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (build dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  sysDepError = pkg:
+    builtins.throw ''
+      The Nixpkgs package set does not contain the package: ${pkg} (system dependency).
+      
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      '';
+  pkgConfDepError = pkg:
+    builtins.throw ''
+      The pkg-conf packages does not contain the package: ${pkg} (pkg-conf dependency).
+      
+      You may need to augment the pkg-conf package mapping in haskell.nix so that it can be found.
+      '';
+  exeDepError = pkg:
+    builtins.throw ''
+      The local executable components do not include the component: ${pkg} (executable dependency).
+      '';
+  legacyExeDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (executable dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  buildToolDepError = pkg:
+    builtins.throw ''
+      Neither the Haskell package set or the Nixpkgs package set contain the package: ${pkg} (build tool dependency).
+      
+      If this is a system dependency:
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      
+      If this is a Haskell dependency:
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
   {
     flags = {};
     package = {
@@ -13,12 +52,14 @@
       synopsis = "A simple interface for logging, tracing or monitoring.";
       description = "";
       buildType = "Simple";
+      isLocal = true;
       };
     components = {
       "library" = {
         depends = [
-          (hsPkgs.base)
-          ] ++ (pkgs.lib).optional (compiler.isGhc && (compiler.version).lt "8.5") (hsPkgs.contravariant);
+          (hsPkgs."base" or (buildDepError "base"))
+          ] ++ (pkgs.lib).optional (compiler.isGhc && (compiler.version).lt "8.5") (hsPkgs."contravariant" or (buildDepError "contravariant"));
+        buildable = true;
         };
       };
     } // {

--- a/skeleton/nix/.stack.nix/default.nix
+++ b/skeleton/nix/.stack.nix/default.nix
@@ -6,7 +6,6 @@
         "hedgehog" = (((hackage.hedgehog)."1.0").revisions).default;
         "micro-recursion-schemes" = (((hackage.micro-recursion-schemes)."5.0.2.2").revisions).default;
         "streaming-binary" = (((hackage.streaming-binary)."0.3.0.1").revisions).default;
-        } // {
         iohk-skeleton = ./iohk-skeleton.nix;
         cardano-prelude = ./cardano-prelude.nix;
         cardano-prelude-test = ./cardano-prelude-test.nix;
@@ -22,5 +21,23 @@
       compiler.nix-name = "ghc865";
       };
   resolver = "lts-13.26";
+  modules = [
+    ({ lib, ... }:
+      {
+        packages = {
+          "iohk-monitoring" = {
+            flags = {
+              "disable-examples" = lib.mkOverride 900 true;
+              "disable-ekg" = lib.mkOverride 900 true;
+              "disable-systemd" = lib.mkOverride 900 true;
+              "disable-prometheus" = lib.mkOverride 900 true;
+              "disable-gui" = lib.mkOverride 900 true;
+              "disable-graylog" = lib.mkOverride 900 true;
+              };
+            };
+          };
+        })
+    { packages = {}; }
+    ];
   compiler = "ghc-8.6.5";
   }

--- a/skeleton/nix/.stack.nix/iohk-monitoring.nix
+++ b/skeleton/nix/.stack.nix/iohk-monitoring.nix
@@ -1,4 +1,43 @@
-{ system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
+let
+  buildDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (build dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  sysDepError = pkg:
+    builtins.throw ''
+      The Nixpkgs package set does not contain the package: ${pkg} (system dependency).
+      
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      '';
+  pkgConfDepError = pkg:
+    builtins.throw ''
+      The pkg-conf packages does not contain the package: ${pkg} (pkg-conf dependency).
+      
+      You may need to augment the pkg-conf package mapping in haskell.nix so that it can be found.
+      '';
+  exeDepError = pkg:
+    builtins.throw ''
+      The local executable components do not include the component: ${pkg} (executable dependency).
+      '';
+  legacyExeDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (executable dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  buildToolDepError = pkg:
+    builtins.throw ''
+      Neither the Haskell package set or the Nixpkgs package set contain the package: ${pkg} (build tool dependency).
+      
+      If this is a system dependency:
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      
+      If this is a Haskell dependency:
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
   {
     flags = {
       disable-aggregation = false;
@@ -24,130 +63,138 @@
       synopsis = "logging, benchmarking and monitoring framework";
       description = "";
       buildType = "Simple";
+      isLocal = true;
       };
     components = {
       "library" = {
         depends = ((((([
-          (hsPkgs.base)
-          (hsPkgs.contra-tracer)
-          (hsPkgs.aeson)
-          (hsPkgs.array)
-          (hsPkgs.async)
-          (hsPkgs.async-timer)
-          (hsPkgs.attoparsec)
-          (hsPkgs.auto-update)
-          (hsPkgs.bytestring)
-          (hsPkgs.clock)
-          (hsPkgs.containers)
-          (hsPkgs.contravariant)
-          (hsPkgs.directory)
-          (hsPkgs.filepath)
-          (hsPkgs.katip)
-          (hsPkgs.lens)
-          (hsPkgs.mtl)
-          (hsPkgs.safe)
-          (hsPkgs.safe-exceptions)
-          (hsPkgs.scientific)
-          (hsPkgs.stm)
-          (hsPkgs.template-haskell)
-          (hsPkgs.text)
-          (hsPkgs.time)
-          (hsPkgs.time-units)
-          (hsPkgs.transformers)
-          (hsPkgs.unordered-containers)
-          (hsPkgs.vector)
-          (hsPkgs.yaml)
-          (hsPkgs.libyaml)
+          (hsPkgs."base" or (buildDepError "base"))
+          (hsPkgs."contra-tracer" or (buildDepError "contra-tracer"))
+          (hsPkgs."aeson" or (buildDepError "aeson"))
+          (hsPkgs."array" or (buildDepError "array"))
+          (hsPkgs."async" or (buildDepError "async"))
+          (hsPkgs."async-timer" or (buildDepError "async-timer"))
+          (hsPkgs."attoparsec" or (buildDepError "attoparsec"))
+          (hsPkgs."auto-update" or (buildDepError "auto-update"))
+          (hsPkgs."bytestring" or (buildDepError "bytestring"))
+          (hsPkgs."clock" or (buildDepError "clock"))
+          (hsPkgs."containers" or (buildDepError "containers"))
+          (hsPkgs."contravariant" or (buildDepError "contravariant"))
+          (hsPkgs."directory" or (buildDepError "directory"))
+          (hsPkgs."filepath" or (buildDepError "filepath"))
+          (hsPkgs."katip" or (buildDepError "katip"))
+          (hsPkgs."lens" or (buildDepError "lens"))
+          (hsPkgs."mtl" or (buildDepError "mtl"))
+          (hsPkgs."safe" or (buildDepError "safe"))
+          (hsPkgs."safe-exceptions" or (buildDepError "safe-exceptions"))
+          (hsPkgs."scientific" or (buildDepError "scientific"))
+          (hsPkgs."stm" or (buildDepError "stm"))
+          (hsPkgs."template-haskell" or (buildDepError "template-haskell"))
+          (hsPkgs."text" or (buildDepError "text"))
+          (hsPkgs."time" or (buildDepError "time"))
+          (hsPkgs."time-units" or (buildDepError "time-units"))
+          (hsPkgs."transformers" or (buildDepError "transformers"))
+          (hsPkgs."unordered-containers" or (buildDepError "unordered-containers"))
+          (hsPkgs."vector" or (buildDepError "vector"))
+          (hsPkgs."yaml" or (buildDepError "yaml"))
+          (hsPkgs."libyaml" or (buildDepError "libyaml"))
           ] ++ (pkgs.lib).optionals (!flags.disable-ekg) [
-          (hsPkgs.ekg)
-          (hsPkgs.ekg-core)
+          (hsPkgs."ekg" or (buildDepError "ekg"))
+          (hsPkgs."ekg-core" or (buildDepError "ekg-core"))
           ]) ++ (pkgs.lib).optionals (!flags.disable-ekg && !flags.disable-prometheus) [
-          (hsPkgs.ekg-prometheus-adapter)
-          (hsPkgs.prometheus)
-          (hsPkgs.warp)
-          ]) ++ (pkgs.lib).optional (!flags.disable-graylog) (hsPkgs.network)) ++ (pkgs.lib).optional (!flags.disable-gui) (hsPkgs.threepenny-gui)) ++ (if system.isWindows
-          then [ (hsPkgs.Win32) ]
+          (hsPkgs."ekg-prometheus-adapter" or (buildDepError "ekg-prometheus-adapter"))
+          (hsPkgs."prometheus" or (buildDepError "prometheus"))
+          (hsPkgs."warp" or (buildDepError "warp"))
+          ]) ++ (pkgs.lib).optional (!flags.disable-graylog) (hsPkgs."network" or (buildDepError "network"))) ++ (pkgs.lib).optional (!flags.disable-gui) (hsPkgs."threepenny-gui" or (buildDepError "threepenny-gui"))) ++ (if system.isWindows
+          then [ (hsPkgs."Win32" or (buildDepError "Win32")) ]
           else [
-            (hsPkgs.unix)
+            (hsPkgs."unix" or (buildDepError "unix"))
             ])) ++ (pkgs.lib).optionals (system.isLinux && !flags.disable-systemd) [
-          (hsPkgs.hsyslog)
-          (hsPkgs.libsystemd-journal)
+          (hsPkgs."hsyslog" or (buildDepError "hsyslog"))
+          (hsPkgs."libsystemd-journal" or (buildDepError "libsystemd-journal"))
           ];
+        buildable = true;
         };
       exes = {
         "example-simple" = {
           depends = [
-            (hsPkgs.base)
-            (hsPkgs.iohk-monitoring)
-            (hsPkgs.async)
-            (hsPkgs.bytestring)
-            (hsPkgs.mtl)
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."iohk-monitoring" or (buildDepError "iohk-monitoring"))
+            (hsPkgs."async" or (buildDepError "async"))
+            (hsPkgs."bytestring" or (buildDepError "bytestring"))
+            (hsPkgs."mtl" or (buildDepError "mtl"))
             ] ++ (if system.isWindows
-            then [ (hsPkgs.Win32) ]
-            else [ (hsPkgs.unix) ]);
+            then [ (hsPkgs."Win32" or (buildDepError "Win32")) ]
+            else [ (hsPkgs."unix" or (buildDepError "unix")) ]);
+          buildable = if flags.disable-examples then false else true;
           };
         "example-complex" = {
           depends = ([
-            (hsPkgs.base)
-            (hsPkgs.iohk-monitoring)
-            (hsPkgs.async)
-            (hsPkgs.bytestring)
-            (hsPkgs.mtl)
-            (hsPkgs.random)
-            (hsPkgs.text)
-            (hsPkgs.unordered-containers)
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."iohk-monitoring" or (buildDepError "iohk-monitoring"))
+            (hsPkgs."async" or (buildDepError "async"))
+            (hsPkgs."bytestring" or (buildDepError "bytestring"))
+            (hsPkgs."mtl" or (buildDepError "mtl"))
+            (hsPkgs."random" or (buildDepError "random"))
+            (hsPkgs."text" or (buildDepError "text"))
+            (hsPkgs."unordered-containers" or (buildDepError "unordered-containers"))
             ] ++ (if system.isWindows
-            then [ (hsPkgs.Win32) ]
+            then [ (hsPkgs."Win32" or (buildDepError "Win32")) ]
             else [
-              (hsPkgs.unix)
-              ])) ++ (pkgs.lib).optional (system.isLinux) (hsPkgs.download);
+              (hsPkgs."unix" or (buildDepError "unix"))
+              ])) ++ (pkgs.lib).optional (system.isLinux) (hsPkgs."download" or (buildDepError "download"));
+          buildable = if flags.disable-examples then false else true;
           };
         "example-performance" = {
           depends = [
-            (hsPkgs.base)
-            (hsPkgs.iohk-monitoring)
-            (hsPkgs.async)
-            (hsPkgs.criterion)
-            (hsPkgs.text)
-            (hsPkgs.unordered-containers)
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."iohk-monitoring" or (buildDepError "iohk-monitoring"))
+            (hsPkgs."async" or (buildDepError "async"))
+            (hsPkgs."criterion" or (buildDepError "criterion"))
+            (hsPkgs."text" or (buildDepError "text"))
+            (hsPkgs."unordered-containers" or (buildDepError "unordered-containers"))
             ];
+          buildable = if flags.disable-examples || !flags.performance-test-queue
+            then false
+            else true;
           };
         };
       tests = {
         "tests" = {
           depends = [
-            (hsPkgs.base)
-            (hsPkgs.contra-tracer)
-            (hsPkgs.iohk-monitoring)
-            (hsPkgs.aeson)
-            (hsPkgs.array)
-            (hsPkgs.async)
-            (hsPkgs.bytestring)
-            (hsPkgs.clock)
-            (hsPkgs.containers)
-            (hsPkgs.directory)
-            (hsPkgs.filepath)
-            (hsPkgs.mtl)
-            (hsPkgs.process)
-            (hsPkgs.QuickCheck)
-            (hsPkgs.random)
-            (hsPkgs.semigroups)
-            (hsPkgs.split)
-            (hsPkgs.stm)
-            (hsPkgs.tasty)
-            (hsPkgs.tasty-hunit)
-            (hsPkgs.tasty-quickcheck)
-            (hsPkgs.temporary)
-            (hsPkgs.text)
-            (hsPkgs.time)
-            (hsPkgs.time-units)
-            (hsPkgs.transformers)
-            (hsPkgs.unordered-containers)
-            (hsPkgs.vector)
-            (hsPkgs.void)
-            (hsPkgs.yaml)
-            (hsPkgs.libyaml)
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."contra-tracer" or (buildDepError "contra-tracer"))
+            (hsPkgs."iohk-monitoring" or (buildDepError "iohk-monitoring"))
+            (hsPkgs."aeson" or (buildDepError "aeson"))
+            (hsPkgs."array" or (buildDepError "array"))
+            (hsPkgs."async" or (buildDepError "async"))
+            (hsPkgs."bytestring" or (buildDepError "bytestring"))
+            (hsPkgs."clock" or (buildDepError "clock"))
+            (hsPkgs."containers" or (buildDepError "containers"))
+            (hsPkgs."directory" or (buildDepError "directory"))
+            (hsPkgs."filepath" or (buildDepError "filepath"))
+            (hsPkgs."mtl" or (buildDepError "mtl"))
+            (hsPkgs."process" or (buildDepError "process"))
+            (hsPkgs."QuickCheck" or (buildDepError "QuickCheck"))
+            (hsPkgs."random" or (buildDepError "random"))
+            (hsPkgs."semigroups" or (buildDepError "semigroups"))
+            (hsPkgs."split" or (buildDepError "split"))
+            (hsPkgs."stm" or (buildDepError "stm"))
+            (hsPkgs."tasty" or (buildDepError "tasty"))
+            (hsPkgs."tasty-hunit" or (buildDepError "tasty-hunit"))
+            (hsPkgs."tasty-quickcheck" or (buildDepError "tasty-quickcheck"))
+            (hsPkgs."temporary" or (buildDepError "temporary"))
+            (hsPkgs."text" or (buildDepError "text"))
+            (hsPkgs."time" or (buildDepError "time"))
+            (hsPkgs."time-units" or (buildDepError "time-units"))
+            (hsPkgs."transformers" or (buildDepError "transformers"))
+            (hsPkgs."unordered-containers" or (buildDepError "unordered-containers"))
+            (hsPkgs."vector" or (buildDepError "vector"))
+            (hsPkgs."void" or (buildDepError "void"))
+            (hsPkgs."yaml" or (buildDepError "yaml"))
+            (hsPkgs."libyaml" or (buildDepError "libyaml"))
             ];
+          buildable = true;
           };
         };
       };

--- a/skeleton/nix/.stack.nix/iohk-skeleton.nix
+++ b/skeleton/nix/.stack.nix/iohk-skeleton.nix
@@ -1,4 +1,43 @@
-{ system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
+let
+  buildDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (build dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  sysDepError = pkg:
+    builtins.throw ''
+      The Nixpkgs package set does not contain the package: ${pkg} (system dependency).
+      
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      '';
+  pkgConfDepError = pkg:
+    builtins.throw ''
+      The pkg-conf packages does not contain the package: ${pkg} (pkg-conf dependency).
+      
+      You may need to augment the pkg-conf package mapping in haskell.nix so that it can be found.
+      '';
+  exeDepError = pkg:
+    builtins.throw ''
+      The local executable components do not include the component: ${pkg} (executable dependency).
+      '';
+  legacyExeDepError = pkg:
+    builtins.throw ''
+      The Haskell package set does not contain the package: ${pkg} (executable dependency).
+      
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+  buildToolDepError = pkg:
+    builtins.throw ''
+      Neither the Haskell package set or the Nixpkgs package set contain the package: ${pkg} (build tool dependency).
+      
+      If this is a system dependency:
+      You may need to augment the system package mapping in haskell.nix so that it can be found.
+      
+      If this is a Haskell dependency:
+      If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
+      '';
+in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
   {
     flags = { development = false; };
     package = {
@@ -13,37 +52,47 @@
       synopsis = "Template project with reference CI setup";
       description = "";
       buildType = "Simple";
+      isLocal = true;
       };
     components = {
-      "library" = { depends = [ (hsPkgs.base) (hsPkgs.cardano-prelude) ]; };
+      "library" = {
+        depends = [
+          (hsPkgs."base" or (buildDepError "base"))
+          (hsPkgs."cardano-prelude" or (buildDepError "cardano-prelude"))
+          ];
+        buildable = true;
+        };
       exes = {
         "iohk-skeleton" = {
           depends = [
-            (hsPkgs.base)
-            (hsPkgs.cardano-prelude)
-            (hsPkgs.iohk-skeleton)
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."cardano-prelude" or (buildDepError "cardano-prelude"))
+            (hsPkgs."iohk-skeleton" or (buildDepError "iohk-skeleton"))
             ];
+          buildable = true;
           };
         };
       tests = {
         "unit" = {
           depends = [
-            (hsPkgs.base)
-            (hsPkgs.cardano-prelude)
-            (hsPkgs.iohk-skeleton)
-            (hsPkgs.hspec)
-            (hsPkgs.text)
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."cardano-prelude" or (buildDepError "cardano-prelude"))
+            (hsPkgs."iohk-skeleton" or (buildDepError "iohk-skeleton"))
+            (hsPkgs."hspec" or (buildDepError "hspec"))
+            (hsPkgs."text" or (buildDepError "text"))
             ];
+          buildable = true;
           };
         };
       benchmarks = {
         "iohk-skeleton-bench" = {
           depends = [
-            (hsPkgs.base)
-            (hsPkgs.cardano-prelude)
-            (hsPkgs.criterion)
-            (hsPkgs.iohk-skeleton)
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."cardano-prelude" or (buildDepError "cardano-prelude"))
+            (hsPkgs."criterion" or (buildDepError "criterion"))
+            (hsPkgs."iohk-skeleton" or (buildDepError "iohk-skeleton"))
             ];
+          buildable = true;
           };
         };
       };

--- a/skeleton/nix/iohk-common.nix
+++ b/skeleton/nix/iohk-common.nix
@@ -6,6 +6,7 @@ import (
   in if try.success
   then builtins.trace "using host <iohk_nix>" try.value
   else
+    if builtins.pathExists ../../skeleton then ../../default.nix else  # TODO: Remove this line
     let
       spec = builtins.fromJSON (builtins.readFile ./iohk-nix-src.json);
       fetchArgs = {

--- a/skeleton/release.nix
+++ b/skeleton/release.nix
@@ -23,15 +23,11 @@
 , scrubJobs ? true
 
 # Import IOHK common nix lib
-# TODO: remove line below, and uncomment the next line
-, iohkLib ? import ../default.nix {}
-#, iohkLib ? import ./nix/iohk-common.nix {}
+, iohkLib ? import ./nix/iohk-common.nix {}
 }:
 
 with (import iohkLib.release-lib) {
-  # TODO: remove line below, and uncomment the next line
-  inherit (import ../default.nix {}) pkgs;
-  # inherit (import ./nix/iohk-common.nix {}) pkgs;
+  inherit (import ./nix/iohk-common.nix {}) pkgs;
 
   inherit supportedSystems supportedCrossSystems scrubJobs projectArgs;
   packageSet = import iohk-skeleton;

--- a/utils/.gitignore
+++ b/utils/.gitignore
@@ -1,0 +1,2 @@
+dist-newstyle
+.stack-work

--- a/utils/Setup.hs
+++ b/utils/Setup.hs
@@ -1,0 +1,2 @@
+import Distribution.Simple
+main = defaultMain

--- a/utils/default.nix
+++ b/utils/default.nix
@@ -1,0 +1,39 @@
+{ iohkLib ? import ../. {}
+, pkgs ? iohkLib.pkgs
+}:
+
+with pkgs;
+
+rec {
+  # The utils derivation.
+  package = haskellPackages.callCabal2nix "iohk-nix-utils" ./. {};
+
+  # A function for building a script that can run in CI.
+  # The given script path, which is Haskell file will be able to
+  # import the CommonBuild module.
+  stackRebuild =
+   { script           # path to .hs file for building
+   , buildTools ? []  # extra programs to add to PATH
+   , libs ? (ps: [])  # selector function for extra haskell libraries
+   , shell ? null     # shell derivation to keep gc-rooted during build 
+   }:
+   let
+      buildTools' = [
+        gnused coreutils git nix gnumake gnutar gzip lz4
+        stack iohkLib.stack-hpc-coveralls
+        haskellPackages.weeder
+      ] ++ buildTools;
+      libs' = ps: libs ps ++ [ package ];
+      ghc' = haskellPackages.ghcWithPackages libs';
+
+   in runCommand "stack-rebuild" {
+        buildInputs = [ ghc' makeWrapper ];
+    } ''
+      mkdir -p $out/bin
+      ghc -Wall -threaded -o $out/bin/rebuild ${script}
+      wrapProgram $out/bin/rebuild \
+        --set PATH "${lib.makeBinPath buildTools'}" \
+        --set NO_GC_STACK_SHELL "${toString shell}"
+    '';
+}
+

--- a/utils/iohk-nix-utils.cabal
+++ b/utils/iohk-nix-utils.cabal
@@ -1,0 +1,62 @@
+cabal-version:       2.2
+name:                iohk-nix-utils
+version:             0.1.0.0
+license:             Apache-2.0
+author:              IOHK Devops
+maintainer:          devops@iohk.io
+copyright:           2019 IOHK
+category:            Development
+
+library
+  build-depends:       base
+                     , async
+                     , bytestring
+                     , extra
+                     , foldl
+                     , optparse-applicative
+                     , safe
+                     , system-filepath
+                     , text
+                     , transformers
+                     , turtle
+  ghc-options:       -Wall
+  default-language:  Haskell2010
+  exposed-modules:   CommonBuild
+  hs-source-dirs:    lib
+
+executable rebuild
+  buildable:           False
+  main-is:             rebuild.hs
+  build-depends:       iohk-nix-utils
+                     , async
+                     , base
+                     , extra
+                     , foldl
+                     , optparse-applicative
+                     , safe
+                     , system-filepath
+                     , text
+                     , transformers
+                     , turtle
+  ghc-options:       -Wall
+  default-language:  Haskell2010
+
+executable set-git-rev
+  main-is:             set-git-rev.hs
+  build-depends:       base
+                     , bytestring
+                     , deepseq
+                     , file-embed
+  default-language:    Haskell2010
+  -- https://github.com/NixOS/nixpkgs/issues/46814
+  if os(darwin)
+     ghc-options:      -liconv
+
+executable rewrite-libs
+  main-is:             rewrite-libs.hs
+  build-depends:       base
+                     , turtle
+                     , megaparsec
+                     , text
+                     , directory
+  default-language:    Haskell2010

--- a/utils/lib/CommonBuild.hs
+++ b/utils/lib/CommonBuild.hs
@@ -1,0 +1,431 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+-- |
+-- Copyright: © 2018-2019 IOHK
+-- License: Apache-2.0
+--
+-- Functions for building projects with Stack under Buildkite.
+
+module CommonBuild
+  (
+  -- * Re-export
+    module Turtle
+  , module Prelude
+  -- * Build directory
+  , setupBuildDirectory
+  , cleanBuildDirectory
+  -- * Buildkite
+  , BuildkiteEnv(..)
+  , getBuildkiteEnv
+  , onDefaultBranch
+  , isBorsBuild
+  -- * Weeder
+  , weederStep
+  -- * Coverage
+  , uploadCoverageStep
+  , findTix
+  -- * Stack caching
+  , CICacheConfig(..)
+  , getCacheConfig
+  , cacheGetStep
+  , cachePutStep
+  , cleanupCacheStep
+  , purgeCacheStep
+  -- * Running stuff
+  , DryRun(..)
+  , run
+  , whenRun
+  , whenRun'
+  -- * Utils
+  , needRead
+  , want
+  , timeout
+  , doMaybe
+  ) where
+
+import Prelude hiding
+    ( FilePath )
+
+import Options.Applicative
+import Turtle hiding
+    ( arg, match, opt, option, skip )
+
+import Control.Concurrent.Async
+    ( race )
+import Control.Exception
+    ( IOException, catch )
+import Control.Monad
+    ( filterM, forM_ )
+import Control.Monad.Extra
+    ( whenM )
+import Control.Monad.Trans.Class
+    ( lift )
+import Control.Monad.Trans.Maybe
+    ( MaybeT (..) )
+import Data.ByteString
+    ( ByteString )
+import Data.Char
+    ( isSpace )
+import Data.Maybe
+    ( mapMaybe, maybeToList )
+import Safe
+    ( headMay, readMay )
+
+import qualified Control.Foldl as Fold
+import qualified Data.Text as T
+import qualified Filesystem.Path.CurrentOS as FP
+import qualified Turtle.Bytes as TB
+
+data DryRun = Run | DryRun deriving (Show, Eq)
+
+-- | Stack with caching needs a build directory that is the same across
+-- all BuildKite agents. The build directory option can be used to
+-- ensure this is the case.
+setupBuildDirectory :: DryRun -> FilePath -> IO ()
+setupBuildDirectory dryRun buildDir = do
+    removeDirectory dryRun buildDir
+    src <- pwd
+    printf ("Copying source tree "%fp%" -> "%fp%"\n") src buildDir
+    whenRun dryRun $ do
+        cptree src buildDir
+        cd buildDir
+
+-- | Remove certain files which get cached but could cause problems for subsequent
+-- builds.
+cleanBuildDirectory :: FilePath -> IO ()
+cleanBuildDirectory buildDir = findTix buildDir >>= mapM_ rm
+
+----------------------------------------------------------------------------
+-- Buildkite
+-- https://buildkite.com/docs/pipelines/environment-variables
+
+-- | A selection of relevant pipeline and build information from Buildkite.
+data BuildkiteEnv = BuildkiteEnv
+    { bkBuildNum      :: Int
+    -- ^ The Buildkite build number.
+    , bkPipeline      :: Text
+    -- ^ The pipeline slug on Buildkite as used in URLs.
+    , bkBranch        :: Text
+    -- ^ The branch being built.
+    , bkBaseBranch    :: Maybe Text
+    -- ^ The base branch that the pull request is targeting, if this
+    -- build is for a pull request.
+    , bkDefaultBranch :: Text
+    -- ^ The default branch for the pipeline (e.g. master).
+    , bkTag           :: Maybe Text
+    -- ^ The name of the tag being built, if this build was triggered from a tag.
+    } deriving (Show)
+
+-- | Fetch build parameters from the environment.
+getBuildkiteEnv :: IO (Maybe BuildkiteEnv)
+getBuildkiteEnv = runMaybeT $ do
+    bkBuildNum      <- MaybeT $ needRead "BUILDKITE_BUILD_NUMBER"
+    bkPipeline      <- MaybeT $ need "BUILDKITE_PIPELINE_SLUG"
+    bkBranch        <- MaybeT $ need "BUILDKITE_BRANCH"
+    bkBaseBranch    <- lift   $ want "BUILDKITE_PULL_REQUEST_BASE_BRANCH"
+    bkDefaultBranch <- MaybeT $ need "BUILDKITE_PIPELINE_DEFAULT_BRANCH"
+    bkTag           <- lift   $ want "BUILDKITE_TAG"
+    pure BuildkiteEnv {..}
+
+-- | Whether we are building the repo's default branch.
+onDefaultBranch :: BuildkiteEnv -> Bool
+onDefaultBranch BuildkiteEnv{..} = bkBranch == bkDefaultBranch
+
+-- | Whether we are building for Bors, based on the branch name.
+isBorsBuild :: BuildkiteEnv -> Bool
+isBorsBuild bk = "bors/" `T.isPrefixOf` bkBranch bk
+
+----------------------------------------------------------------------------
+-- Weeder - uses contents of .stack-work to determine unused dependencies
+
+weederStep :: DryRun -> IO ExitCode
+weederStep dryRun = do
+    echo "--- Weeder"
+    run dryRun "weeder" []
+
+----------------------------------------------------------------------------
+-- Stack Haskell Program Coverage and upload to Coveralls
+
+-- | Upload coverage information to coveralls.
+uploadCoverageStep :: Text -> DryRun -> IO ()
+uploadCoverageStep tokenVar dryRun = do
+    echo "--- Upload Test Coverage"
+    need tokenVar >>= \case
+        Nothing -> do
+            eprintf ("Environment variable "%s%" not set.\n") tokenVar
+            eprintf "Not uploading coverage information.\n"
+        Just repoToken ->
+            (findTix "lib" >>= generate) .&&. upload repoToken >>= \case
+                ExitSuccess -> echo "Coverage information upload successful."
+                ExitFailure _ -> echo "Coverage information upload failed."
+  where
+    generate tixFiles = run dryRun "stack"
+        ([ "hpc"
+        , "report"
+        , "--all"
+        ] ++ map (format fp) tixFiles)
+    upload repoToken = do
+        let shcArgs = ["combined", "custom"]
+        logCommand "shc" shcArgs
+        whenRun' dryRun ExitSuccess $
+            proc "shc" (["--repo-token", repoToken] ++ shcArgs) empty
+
+findTix :: FilePath -> IO [FilePath]
+findTix dir = fold (find (suffix ".tix") dir) Fold.list
+
+----------------------------------------------------------------------------
+-- Stack root and .stack-work caching.
+--
+-- This will only operate when the @STACK_ROOT@ environment variable is set.
+--
+-- It also needs to be running under Buildkite with a project cache location
+-- supplied.
+
+-- | Information required for caching the stack root and @.stack-work@
+-- directories.
+data CICacheConfig = CICacheConfig
+    { ccCacheDir  :: FilePath
+    -- ^ Per-project directory to store cache files.
+    , ccStackRoot :: FilePath
+    -- ^ Absolute location of the @.stack@ directory.
+    , ccBranches  :: [Text]
+    -- ^ A list of branches to source caches from. The branches will be tried in
+    -- order until one is found. When saving caches, the first branch in the list
+    -- is used.
+    } deriving (Show)
+
+-- | Sets up the 'CICacheConfig' info, or provides a reason why caching can't be
+-- done.
+getCacheConfig :: Maybe BuildkiteEnv -> Maybe FilePath -> IO (Either Text CICacheConfig)
+getCacheConfig Nothing _ =
+    pure (Left "BUILDKITE_* environment variables are not set")
+getCacheConfig _ Nothing =
+    pure (Left "--cache-dir argument was not provided")
+getCacheConfig (Just bk) (Just ccCacheDir) =
+    (fmap FP.fromText <$> need "STACK_ROOT") >>= \case
+        Just ccStackRoot ->
+            pure (Right CICacheConfig{ccBranches=cacheBranches bk,..})
+        Nothing ->
+            pure (Left "STACK_ROOT environment variable is not set")
+
+-- | Create the list of branches to source caches from.
+--   1. Build branch;
+--   2. PR base branch;
+--   3. Repo default branch.
+cacheBranches :: BuildkiteEnv -> [Text]
+cacheBranches BuildkiteEnv{..} =
+    [bkBranch] ++ maybeToList bkBaseBranch ++ [bkDefaultBranch]
+
+cacheGetStep :: Either Text CICacheConfig -> IO ()
+cacheGetStep cacheConfig = do
+    echo "--- CI Cache Restore"
+    case cacheConfig of
+        Right cfg -> restoreCICache cfg `catch` \(ex :: IOException) ->
+            eprintf ("Failed to download CI cache: "%w%"\nContinuing anyway...\n") ex
+        Left ex ->
+            eprintf ("Not using CI cache because "%s%"\n") ex
+
+cachePutStep :: Either Text CICacheConfig -> IO ()
+cachePutStep cacheConfig = do
+    echo "--- CI Cache Save"
+    case cacheConfig of
+        Right cfg -> saveCICache cfg `catch` \(ex :: IOException) ->
+            eprintf ("Failed to upload CI cache: "%w%"\n") ex
+        Left _ ->
+            printf "CI cache not configured.\n"
+
+getCacheArchive :: MonadIO io => CICacheConfig -> FilePath -> io (Maybe FilePath)
+getCacheArchive CICacheConfig{..} ext = do
+    let caches = mapMaybe (getCacheName ccCacheDir) ccBranches
+    headMay <$> filterM testfile (map (</> ext) caches)
+
+-- | The cache directory for a given branch name. This filepath always has a
+-- trailing slash.
+getCacheName :: FilePath -> Text -> Maybe FilePath
+getCacheName base branch
+    | ".." `T.isInfixOf` branch = Nothing
+    | otherwise = Just (base </> FP.fromText branch </> "")
+
+-- | The filename for a given branch and cache name.
+putCacheName :: CICacheConfig -> FilePath -> Maybe FilePath
+putCacheName CICacheConfig{..} ext =
+    (</> ext) <$> getCacheName ccCacheDir (head ccBranches)
+
+restoreCICache :: CICacheConfig -> IO ()
+restoreCICache cfg = do
+    restoreStackRoot cfg
+    restoreStackWork cfg
+
+saveCICache :: CICacheConfig -> IO ()
+saveCICache cfg = do
+    saveStackRoot cfg
+    saveStackWork cfg
+
+stackRootCache :: FilePath
+stackRootCache = "stack-root.tar.lz4"
+
+stackWorkCache :: FilePath
+stackWorkCache = "stack-work.tar.lz4"
+
+restoreStackRoot :: CICacheConfig -> IO ()
+restoreStackRoot cfg@CICacheConfig{..} =
+    restoreZippedCache stackRootCache cfg $ \tar -> do
+        whenM (testpath ccStackRoot) $ rmtree ccStackRoot
+        mktree ccStackRoot
+        TB.procs "tar" ["-C", "/", "-x"] tar
+
+restoreStackWork :: CICacheConfig -> IO ()
+restoreStackWork cfg =
+    restoreZippedCache stackWorkCache cfg (TB.procs "tar" ["-x"])
+
+restoreZippedCache
+    :: FilePath
+    -> CICacheConfig
+    -> (Shell ByteString -> IO ())
+    -> IO ()
+restoreZippedCache ext cfg act = getCacheArchive cfg ext >>= \case
+    Just tarfile -> do
+        size <- du tarfile
+        printf ("Restoring cache "%fp%" ("%sz%") ... ") tarfile size
+        act $ TB.inproc "lz4cat" ["-d"] (TB.input tarfile)
+        printf "done.\n"
+    Nothing ->
+        printf ("No "%fp%" cache found.\n") ext
+
+saveStackRoot :: CICacheConfig -> IO ()
+saveStackRoot cfg@CICacheConfig{..} = saveZippedCache stackRootCache cfg tar
+  where
+    tar = TB.inproc "tar" ["-C", "/", "-c", format fp ccStackRoot] empty
+
+saveStackWork :: CICacheConfig -> IO ()
+saveStackWork cfg = saveZippedCache stackWorkCache cfg tar
+  where
+    nullTerminate = (<> "\0") . FP.encode
+    dirs = nullTerminate <$> find (ends ".stack-work") "."
+    tar = TB.inproc "tar" ["--null", "-T", "-", "-c"] dirs
+
+saveZippedCache :: FilePath -> CICacheConfig -> Shell ByteString -> IO ()
+saveZippedCache ext cfg@CICacheConfig{..} tar = case putCacheName cfg ext of
+    Just tarfile -> sh $ do
+        printf ("Saving cache "%fp%" ... ") tarfile
+        mktree (directory tarfile)
+        tmp <- using (mktempfile ccCacheDir (format fp ext))
+        TB.output tmp $ TB.inproc "lz4cat" ["-z"] tar
+        mv tmp tarfile
+        du tarfile >>= printf ("wrote "%sz%".\n")
+    Nothing -> printf ("Could not determine "%fp%" cache name.\n") ext
+
+cleanupCacheStep :: DryRun -> Either Text CICacheConfig -> Maybe FilePath -> IO ()
+cleanupCacheStep dryRun cacheConfig buildDir = do
+    echo "--- Cleaning up CI cache"
+    case cacheConfig of
+        Right CICacheConfig{..} -> do
+            whenM (testdir ccCacheDir) $
+                getBranches >>= cleanupCache dryRun ccCacheDir
+            -- Remove the stack root left by the previous build.
+            removeDirectory dryRun ccStackRoot
+            -- Remove the build directory left by the previous build.
+            doMaybe (removeDirectory dryRun) buildDir
+        Left ex ->
+            eprintf ("Not cleaning up CI cache because: "%s%"\n") ex
+
+purgeCacheStep :: DryRun -> Either Text CICacheConfig -> Maybe FilePath -> IO ()
+purgeCacheStep dryRun cacheConfig buildDir = do
+    echo "--- Deleting all CI caches"
+    case cacheConfig of
+        Right CICacheConfig{..} -> do
+            removeDirectory dryRun ccCacheDir
+            removeDirectory dryRun ccStackRoot
+            doMaybe (removeDirectory dryRun) buildDir
+        Left ex ->
+            eprintf ("Not purging CI cache because: "%s%"\n") ex
+
+-- | Remove all files and directories that do not belong to an active branch cache.
+cleanupCache :: DryRun -> FilePath -> [Text] -> IO ()
+cleanupCache dryRun cacheDir activeBranches = do
+    let branchCaches = mapMaybe (getCacheName cacheDir) activeBranches
+        isCache cf = any (\dir -> format fp cf `T.isPrefixOf` format fp dir)
+    files <- fold (lstree cacheDir) (Fold.revList)
+    forM_ files $ \cf -> do
+        st <- stat cf
+        if isDirectory st
+            then unless (isCache cf branchCaches) $ do
+                printf ("Removing directory "%fp%"\n") cf
+                whenRun dryRun $ rmdir cf
+            else unless (directory cf `elem` branchCaches) $ do
+                printf ("Removing file "%fp%"\n") cf
+                whenRun dryRun $ rm cf
+
+removeDirectory :: DryRun -> FilePath -> IO ()
+removeDirectory dryRun dir = whenM (testpath dir) $ do
+    printf ("Removing directory "%fp%".\n") dir
+    whenRun dryRun $ rmtree dir
+
+-- | Ask the origin git remote for its list of branches.
+getBranches :: MonadIO io => io [Text]
+getBranches =
+    T.lines <$> strict (sed branchPat (grep branchPat git))
+  where
+    remote = "origin"
+    git = inproc "git" ["ls-remote", "--heads", remote] empty
+    branchPat = plus alphaNum *> spaces1 *> "refs/heads/" *> plus anyChar
+
+----------------------------------------------------------------------------
+-- Utils
+
+needRead :: (MonadIO io, Read a) => Text -> io (Maybe a)
+needRead v = (>>= readMay) . fmap T.unpack <$> need v
+
+want :: MonadIO io => Text -> io (Maybe Text)
+want = fmap (>>= nullToNothing) . need
+  where
+    nullToNothing "" = Nothing
+    nullToNothing a = Just a
+
+doMaybe :: Monad m => (a -> m ()) -> Maybe a -> m ()
+doMaybe = maybe (pure ())
+
+run :: MonadIO io => DryRun -> Text -> [Text] -> io ExitCode
+run dryRun cmd args = do
+    logCommand cmd args
+    whenRun' dryRun ExitSuccess $ do
+        res <- proc cmd args empty
+        case res of
+            ExitSuccess ->
+                pure ()
+            ExitFailure code ->
+                eprintf
+                    ("error: Command exited with code "%d%"!\nContinuing...\n")
+                    code
+        pure res
+
+logCommand :: MonadIO io => Text -> [Text] -> io ()
+logCommand cmd args = printf (s % " " % s % "\n") cmd args'
+  where
+    args' = T.unwords $ map quote args
+    -- simple quoting, just for logging
+    quote arg | T.any isSpace arg = "'" <> arg <> "'"
+              | otherwise = arg
+
+-- | Runs an action when not in --dry-run mode.
+whenRun :: Applicative m => DryRun -> m a -> m ()
+whenRun dry = whenRun' dry () . void
+
+-- | Runs an action when not in --dry-run mode, with alternative return value.
+whenRun' :: Applicative m => DryRun -> a -> m a -> m a
+whenRun' DryRun a _ = pure a
+whenRun' Run _ ma = ma
+
+-- | Run an action, but cancel it if it doesn't complete within the given number
+-- of minutes.
+timeout :: Int -> IO ExitCode -> IO ExitCode
+timeout mins act = race (sleep (fromIntegral mins * 60)) act >>= \case
+    Right r ->
+        pure r
+    Left () -> do
+        eprintf ("\nTimed out after "%d%" minutes.\n") mins
+        pure (ExitFailure 124)

--- a/utils/rebuild.hs
+++ b/utils/rebuild.hs
@@ -37,7 +37,7 @@ main = do
                 cleanBuildDirectory (fromMaybe "." optBuildDirectory)
             buildResult <- buildStep optDryRun bk
             when (shouldUploadCoverage bk) $
-              uploadCoverageStep "SKELETON_COVERALLS_REPO_TOKEN" optDryRun
+              uploadCoverageStep "CARDANO_WALLET_COVERALLS_REPO_TOKEN" optDryRun
             whenRun optDryRun $ cachePutStep cacheConfig
             void $ weederStep optDryRun
             exitWith buildResult
@@ -74,7 +74,7 @@ parseOpts = execParser opts
   where
     opts = info
         (cmdOpts <**> helper)
-        (fullDesc <> progDesc "Build skeleton with stack in Buildkite")
+        (fullDesc <> progDesc "Build cardano-wallet with stack in Buildkite")
     cmdOpts = (,)
         <$> rebuildOpts
         <*> (cmd <|> pure Build)
@@ -120,7 +120,10 @@ buildStep dryRun bk =
             [ color "always"
             , [ "test" ]
             , [ "--coverage" ]
-            , skip "bad-tests"
+            -- FIXME
+            -- Figure out what's going on with http-bridge cluster setup...
+            -- maybe...
+            , skip "http-bridge-integration"
             , fast opt
             , case qaLevel bk of
                 QuickTest -> skip "integration"

--- a/utils/rewrite-libs.hs
+++ b/utils/rewrite-libs.hs
@@ -1,0 +1,108 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE CPP #-}
+
+-- | Given a binary file on MacOS, rewrite some of the dynamic
+-- libraries to relative paths.
+--
+-- 1. Crawl through the tree of libraries
+-- 2. filter only for libraries not core to MacOS
+-- 3. copy the library to global relative folder
+-- 4. set the new library path for all references
+-- 5. test that --help executes on the binary
+--
+-- This program is originally from the Daedalus installer generator.
+
+module Main where
+
+import           System.Directory (copyFile, getPermissions, setOwnerWritable, setPermissions)
+import           Text.Megaparsec (Parsec, eof, manyTill, parse, someTill)
+import           Text.Megaparsec.Char (eol, spaceChar)
+import           Turtle (procStrict, procs)
+import qualified Data.Text as T
+import           Data.Text (Text)
+import           Data.Void (Void)
+import           Control.Applicative (many)
+import           Data.Maybe (catMaybes)
+import           System.Exit (die, exitFailure, exitSuccess)
+import           System.Environment (getArgs)
+
+#if MIN_VERSION_megaparsec(7,0,0)
+import           Text.Megaparsec (anySingle)
+#else
+import           Text.Megaparsec.Char (anyChar)
+anySingle = anyChar
+#endif
+
+-- Rewrite libs paths and bundle them
+main :: IO ()
+main = do
+  (outDir, progs) <- parseArgs
+  _res <- chain outDir (map T.pack progs)
+  pure ()
+
+parseArgs :: IO (FilePath, [FilePath])
+parseArgs = getArgs >>= \case
+  (outDir:prog:progs) -> pure (outDir, (prog:progs))
+  _ -> die "usage: rewrite-libs OUTDIR PROG [PROGS...]" >> exitFailure
+
+systemLibs :: [Text]
+systemLibs = ["libSystem.B.dylib"]
+
+-- dir: final path of the files
+-- args: libraries to process
+-- returns processed libraries
+chain :: FilePath -> [Text] -> IO [Text]
+chain dir args@(x:xs) = do
+    (_, output) <- procStrict "otool" ["-L", x] mempty
+    case (parse parseOTool (T.unpack x) output) of
+        Left err -> do
+            print err
+            return []
+        Right files -> do
+            -- parse again all libraries pointing to nix store that we haven't processed yet
+            let libs = filter (T.isPrefixOf "/nix/store/") files
+            filtered <- traverse (patchLib x dir) libs
+            chained <- chain dir (xs ++ (filter (\f -> not $ elem f args) $ catMaybes filtered))
+            return $ x : chained
+chain _ [] = return []
+
+
+patchLib :: Text -> FilePath -> Text -> IO (Maybe Text)
+patchLib source dir lib
+    | (filter (\pattern -> T.isSuffixOf pattern lib) systemLibs) /= mempty = do
+        -- if it's a system lib, just point to correct folder and be done
+        print $ "Patching " <> lib <> " as system in " <> source
+        procs "install_name_tool" ["-change", lib, "/usr/lib/" <> (filename lib), (T.pack dir) <> "/" <> (filename source)] mempty
+        return Nothing
+    | otherwise = do
+        -- otherwise, copy it to dist and change where it points
+        print $ "Bundling " <> lib <> " in " <> source
+        -- substitute store path if they are missing
+        procs "nix-store" ["-r", lib] mempty
+        procs "install_name_tool" ["-change", lib, "@executable_path/" <> (filename lib), (T.pack dir) <> "/" <> (filename source)] mempty
+        let dest = dir <> "/" <> (T.unpack $ filename lib)
+        copyFile (T.unpack lib) dest
+        permissions <- getPermissions dest
+        setPermissions dest $ setOwnerWritable True permissions
+        return $ Just lib
+
+filename :: Text -> Text
+filename path = last $ T.splitOn "/" path
+
+-- otool parser
+
+type Parser = Parsec Void Text
+
+parseLibLine :: Parser Text
+parseLibLine = do
+    _ <- many spaceChar
+    path <- someTill anySingle spaceChar
+    _ <- someTill anySingle eol
+    return (T.pack path)
+
+
+parseOTool :: Parser [Text]
+parseOTool = do
+    _ <- manyTill anySingle eol
+    manyTill parseLibLine eof

--- a/utils/set-git-rev.hs
+++ b/utils/set-git-rev.hs
@@ -1,0 +1,58 @@
+{-# LANGUAGE LambdaCase        #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | Stamps a Haskell executable with a git revision.
+-- The target executable must have use "Data.FileEmbed.dummySpace".
+--
+-- This progam is originally from cardano-sl.
+
+module Main where
+
+import           Control.DeepSeq (force)
+import           Control.Exception (ErrorCall (..), handle, evaluate)
+import           Data.ByteString (ByteString)
+import qualified Data.ByteString.Char8 as B8
+import           Data.FileEmbed (injectWith)
+import           Data.List (isInfixOf)
+import           System.Exit (die, exitFailure, exitSuccess)
+import           System.Environment (getArgs)
+
+main :: IO ()
+main = do
+  (hash, progs) <- parseArgs
+  mapM_ (setGitRev hash) progs
+
+setGitRev :: ByteString -> FilePath -> IO ()
+setGitRev hash prog = do
+  putStr $ "Setting gitrev of " <> prog <> " ... "
+  bs <- B8.readFile prog
+  injectWith' "gitrev" hash bs >>= \case
+    Right bs' -> do
+      B8.writeFile prog bs'
+      B8.putStrLn "OK"
+      exitSuccess
+    Left "" -> do
+      B8.putStrLn $ "Failed setting gitrev to \"" <> hash <> "\""
+      exitFailure
+    Left msg | "Size is: \"\"" `isInfixOf` msg -> do
+                 -- Ignore programs without a gitrev injected
+                 B8.putStrLn "File does not have dummySpace."
+                 exitSuccess
+    Left msg -> do
+      putStrLn msg
+      exitFailure
+
+-- | Work around annoying use of error function in file-embed.
+injectWith' :: ByteString -> ByteString -> ByteString -> IO (Either String ByteString)
+injectWith' postfix toInj orig = handle (pure . toLeft) (toRight <$> evaluateNF inj)
+  where
+    inj = injectWith postfix toInj orig
+    toRight (Just a) = Right a
+    toRight Nothing  = Left ""
+    toLeft (ErrorCall msg) = Left msg
+    evaluateNF = evaluate . force
+    
+parseArgs :: IO (ByteString, [FilePath])
+parseArgs = getArgs >>= \case
+  (rev:prog:progs) -> pure (B8.pack rev, (prog:progs))
+  _ -> die "usage: set-git-rev REV PROG [PROGS...]" >> exitFailure

--- a/utils/stack.yaml
+++ b/utils/stack.yaml
@@ -1,0 +1,7 @@
+resolver: lts-13.24
+compiler: ghc-8.6.5
+
+packages:
+- .
+
+# extra-deps:


### PR DESCRIPTION
Continuous testing of build code such as iohk-nix and Haskell.nix is necessary and things break when it isn't done.

This adds back the Buildkite jobs for skeleton.

I took the `rebuild.hs` script from cardano-wallet and put it into a Cabal package. A nix function `haskellBuildUtils.stackRebuild { ... }` provides access to this package for project build scripts.

The iohk-skeleton reference project is updated to use the build library.

The stack build script now has caching, which greatly improves CI performance.

@dnadales has offered to do the heavy lifting and make the build library sensible and suitable for use in multiple projects.
