### PR TITLE
release-lib: make mkRequired build-version work to force evals

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,11 @@
 Please read these notes when updating your project's `iohk-nix`
 version. There may have been changes which could break your build.
 
+## 2019-10-27
+   * Changes `mkRequired` of `release-lib` to return an attribute set
+     containing `required` and `build-version`
+
+
 ## 2019-07-25
 
    * Added a [skeleton project](./skeleton/README.md) which provides a
@@ -26,7 +31,7 @@ version. There may have been changes which could break your build.
      - nix-tools.packages-tests.x86_64-linux
      - nix-tools.packages-libs.x86_64-darwin
      - nix-tools.x86_64-pc-mingw32-packages-exes.x86_64-linux
-   
+
 ## 2019-04-09
 
    * Started changelog

--- a/lib/release-lib.nix
+++ b/lib/release-lib.nix
@@ -103,9 +103,12 @@ in
       # normally do.
       build-version = pkgs.writeText "version.json" (builtins.toJSON
         (filterAttrs (n: _: n == "version") project // { inherit gitrev; }));
-    in pkgs.releaseTools.aggregate {
-      name = "github-required";
-      meta.description = "All jobs required to pass CI";
-      constituents = constituents ++ [ build-version];
+    in {
+      inherit build-version;
+      required = pkgs.releaseTools.aggregate ({
+        name = "github-required";
+        meta.description = "All jobs required to pass CI";
+        constituents = constituents ++ [ build-version ];
+      });
     };
   }

--- a/skeleton/release.nix
+++ b/skeleton/release.nix
@@ -49,18 +49,13 @@ let
   jobs = {
     native = mapTestOn (packagePlatforms project);
     "${mingwW64.config}" = mapTestOnCross mingwW64 (packagePlatformsCross project);
-  }
-  // {
-    # This aggregate job is what IOHK Hydra uses to update
-    # the CI status in GitHub.
-    required = mkRequiredJob (
+  } // (mkRequiredJob (
       collectTests jobs.native.tests ++
       collectTests jobs.native.benchmarks ++
       # TODO: Add your project executables to this list
       [ jobs.native.iohk-skeleton.x86_64-linux
       ]
-    );
-  }
+    ))
   # Build the shell derivation in Hydra so that all its dependencies
   # are cached.
   // mapTestOn (packagePlatforms { inherit (project) shell; });


### PR DESCRIPTION
This fixes mkRequired to force evals for every revision.