### PR TITLE
Use overridden nixpkgs in getPkgs

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -37,7 +37,7 @@ let
        , system ? system'
        , globalConfig ? globalConfig'
        , config ? config'
-       , crossSystem ? crossSystem' }: import (fetchNixpkgs nixpkgsJson) ({
+       , crossSystem ? crossSystem' }: import nixpkgs ({
           overlays = [ jemallocOverlay ] ++ extraOverlays;
           config = globalConfig // config;
           inherit system crossSystem;


### PR DESCRIPTION
I think this was just an oversight: it uses the (potentially overridden)
nixpkgs JSON, but not the nixpkgs source if that is passed instead.