### PR TITLE
Bumped haskell-nix.json

### DIFF
--- a/pins/haskell-nix.json
+++ b/pins/haskell-nix.json
@@ -1,7 +1,7 @@
 {
   "url": "https://github.com/input-output-hk/haskell.nix",
-  "rev": "aa10a0b7de7f0d6e82c7a10bb8cd3ca390821feb",
-  "date": "2019-10-31T12:51:49+08:00",
-  "sha256": "0dd2ina8849ggvny6mf4mxank4aw7zxy74ddx0586hl4g03zbm3z",
+  "rev": "00bdfda351600bec8a69252d766ab1d4a68712e3",
+  "date": "2019-11-08T01:08:31+00:00",
+  "sha256": "05ci3hw4b0f5aqwz18dsajnvxm6jf71cr3qmmsx8py14h1ygadyx",
   "fetchSubmodules": false
 }


### PR DESCRIPTION
This is to fix `cardano-explorer` [build #626](https://buildkite.com/input-output-hk/cardano-explorer/builds/626#0825ca17-7c6f-498c-84cc-02a0c368af08).

@angerman @manveru 