### PR TITLE
Fix haskellBuildUtils on macOS

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -50,7 +50,9 @@ let
     commitIdFromGitRepo = pkgs.callPackage ./commit-id.nix {};
 
     # Development tools
-    haskellBuildUtils = import ./utils/default.nix { pkgs = pkgsDefault; };
+    haskellBuildUtils = import ./utils/default.nix {
+      pkgs = import (fetchNixpkgs nixpkgsJsonDefault) { inherit system; };
+    };
     cache-s3 = pkgsDefault.callPackage ./pkgs/cache-s3.nix {};
     stack-hpc-coveralls = pkgsDefault.haskellPackages.callPackage ./pkgs/stack-hpc-coveralls.nix {};
     hlint = pkgsDefault.haskellPackages.callPackage ./pkgs/hlint.nix {};

--- a/release.nix
+++ b/release.nix
@@ -65,5 +65,5 @@ fix (self: mappedPkgs // {
     ];
   });
 } // {
-  #skeleton = skeletonJobset;
+  skeleton = skeletonJobset;
 })

--- a/utils/lib/CommonBuild.hs
+++ b/utils/lib/CommonBuild.hs
@@ -80,6 +80,7 @@ import Safe
     ( headMay, readMay )
 
 import qualified Control.Foldl as Fold
+import qualified Data.ByteString.Char8 as B8
 import qualified Data.Text as T
 import qualified Filesystem.Path.CurrentOS as FP
 import qualified Turtle.Bytes as TB
@@ -352,7 +353,7 @@ saveStackRoot cfg@CICacheConfig{..} = saveZippedCache stackRootCache cfg tar
 saveStackWork :: CICacheConfig -> IO ()
 saveStackWork cfg = saveZippedCache stackWorkCache cfg tar
   where
-    nullTerminate = (<> "\0") . FP.encode
+    nullTerminate = (<> "\0") . B8.pack . encodeString
     dirs = nullTerminate <$> find (ends ".stack-work") "."
     tar = TB.inproc "tar" ["--null", "-T", "-", "-c"] dirs
 


### PR DESCRIPTION
- Adds skeleton back to Hydra jobset (yes, testing is useful)
- Fixes build of haskellBuildUtils for macOS.
