### PR TITLE
commitIdFromGitRepoOrZero: handle case where .git does not exist

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -51,10 +51,15 @@ let
     # Example usage: commitIdFromGitRepo ./.git
     commitIdFromGitRepo = pkgs.callPackage ./commit-id.nix {};
     # A variant of the above which provides a default rev, instead of
-    # throwing an exception.
+    # throwing an exception in cases of error.
     commitIdFromGitRepoOrZero = path:
-      let res = builtins.tryEval (commitIdFromGitRepo path);
-      in if res.success then res.value else "0000000000000000000000000000000000000000";
+      let
+        zero = "0000000000000000000000000000000000000000";
+        res = builtins.tryEval (commitIdFromGitRepo path);
+      in
+        if builtins.pathExists path
+          then (if res.success then res.value else zero)
+          else zero;
 
     # Development tools
     haskellBuildUtils = import ./utils/default.nix {


### PR DESCRIPTION
The `./.git` directory does not exist in GitHub tarball downloads for example.

Prevents the error:

    attribute '.git' missing, at /nix/store/56c76cz5dhg7zj028pjj8zkb899zlfwb-source/lib/sources.nix:7:32