### PR TITLE
add jormungandr packages to jormungandr-lib

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -86,7 +86,7 @@ let
   };
 
   cardanoLib = commonLib.pkgsDefault.callPackage ./cardano-lib {};
-  jormungandrLib = commonLib.pkgsDefault.callPackage ./jormungandr-lib {};
+  jormungandrLib = commonLib.pkgsDefault.callPackage ./jormungandr-lib { inherit rust-packages; };
 
   nix-tools = rec {
     # Programs for generating nix haskell package sets from cabal and


### PR DESCRIPTION
This adds Jormungandr 0.7.1, but also refactors the code a bit to make the version on Hydra be from `jormungandr --full-version` itself.
Now you can reference the exact version you want using for example
* `jormungandrLib.packages.v0_7_1.jormungandr`
* `jormungandrLib.packages.v0_7_1.jcli`
* `jormungandrLib.environments.beta.packages.jormungandr`
* `jormungandrLib.environments.qa.packages.jcli`