### PR TITLE
skeleton: example src fixes

### DIFF
--- a/skeleton/nix/pkgs.nix
+++ b/skeleton/nix/pkgs.nix
@@ -33,10 +33,10 @@ let
   pkgSet = haskell.mkStackPkgSet {
     inherit stack-pkgs;
     modules = [
-      # Add source filtering to local packages
+      # Add filtered sources to local packages
       {
         packages.iohk-skeleton.src = src;
-        # packages.another-package = src + /another-package;
+        # packages.another-package.src = src + /another-package;
       }
 
       # Add dependencies
@@ -67,8 +67,6 @@ let
       {
         # Cut down iohk-monitoring deps
         # Note that this reflects flags set in stack.yaml.
-        # There is an open ticket to automate this in stack-to-nix.
-        # https://github.com/input-output-hk/haskell.nix/issues/141
         packages.iohk-monitoring.flags = {
           disable-ekg = true;
           disable-examples = true;


### PR DESCRIPTION
These are some fixes that @manveru and @dnadales needed to make for input-output-hk/cardano-ledger-specs#1009.

Note that new versions of Haskell.nix have a
`haskell-nix.haskellLib.cleanGit` filter that provides a `subDir`
filter, which could be used here (thanks @hamishmack). However skeleton is still stuck on an old Haskell.nix version.

It would be useful if the skeleton project were updated to use the latest revision of Haskell.nix, because projects need to upgrade.