### PR TITLE
Remove `NodeId` from topology

### DIFF
--- a/cardano-lib/default.nix
+++ b/cardano-lib/default.nix
@@ -6,27 +6,19 @@ let
   , edgeHost ? "127.0.0.1"
   , edgeNodes ? []
   , edgePort ? if (edgeNodes != []) then 3001 else (if edgeHost == "127.0.0.1" then 7777 else 3001)
-  , nodeId ? 0
   , valency ? 1
   }:
   let
     mkProducers = map (edgeHost': { addr = edgeHost'; port = edgePort; inherit valency; }) edgeNodes;
-    topology = [
-      {
-        inherit nodeId;
-        nodeAddress = {
-          addr = hostAddr;
-          inherit port;
-        };
-        producers = if (edgeNodes != []) then mkProducers else [
-          {
-            addr = edgeHost;
-            port = edgePort;
-            inherit valency;
-          }
-        ];
-      }
-    ];
+    topology = {
+      Producers = if (edgeNodes != []) then mkProducers else [
+        {
+          addr = edgeHost;
+          port = edgePort;
+          inherit valency;
+        }
+      ];
+    };
   in builtins.toFile "topology.yaml" (builtins.toJSON topology);
 
   defaultLogConfig = import ./generic-log-config.nix;


### PR DESCRIPTION
Proposed topology file change: https://github.com/input-output-hk/cardano-node/issues/314

From:
```
[
  {
     "nodeId":0,
     "nodeAddress":{
        "addr":"127.0.0.1",
        "port":7776
     },
     "producers":[
        {
           "addr":"3.125.75.199",
           "port":3001,
           "valency":1
        },
        {
           "addr":"18.177.103.105",
           "port":3001,
           "valency":1
        },
        {
           "addr":"18.141.0.112",
           "port":3001,
           "valency":1
        },
        {
           "addr":"52.14.58.121",
           "port":3001,
           "valency":1
        }
     ]
  }
]
```
To:
```
{
   "Producers": [
     {
       "addr": "3.125.75.199",
       "port": 3001,
       "valency": 1
     },
     {
       "addr": "18.177.103.105",
       "port": 3001,
       "valency": 1
     },
     {
       "addr": "18.141.0.112",
       "port": 3001,
       "valency": 1
     },
     {
       "addr": "52.14.58.121",
       "port": 3001,
       "valency": 1
     }
   ]
 }
```

