### PR TITLE
Add up-to-date niv to haskellPackages + recRecurseIntoAttrs

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -70,10 +70,13 @@ let
        , crossSystem ? crossSystem' }: import nixpkgs (
           let overlays = haskellNixSrc.overlays ++ [
             (import ./overlays/haskell-nix-extra.nix)
-            (_:_: {
+            (_:super: {
               inherit niv sources;
               iohkNix = self;
               pkgsOverlays = overlays;
+              haskellPackages = super.haskellPackages // {
+                inherit niv;
+              };
             })
           ] ++ extraOverlays;
           in {

--- a/overlays/haskell-nix-extra.nix
+++ b/overlays/haskell-nix-extra.nix
@@ -1,11 +1,16 @@
-pkgs: super: {
-  haskell-nix = pkgs.lib.recursiveUpdate super.haskell-nix {
-    haskellLib.extra = with pkgs.haskell-nix.haskellLib; {
+pkgs: super: with pkgs; with lib; {
+  haskell-nix = recursiveUpdate super.haskell-nix {
+    haskellLib.extra = with haskell-nix.haskellLib; rec {
 
-      collectChecks = pkgsSet: (pkgs.lib.mapAttrs (_: package: package.checks) pkgsSet)
+      collectChecks = pkgsSet: (mapAttrs (_: package: package.checks) pkgsSet)
          // { recurseForDerivations = true; };
 
       collectComponents' = group: collectComponents group (_:true);
+
+      recRecurseIntoAttrs = x:
+        if (isAttrs x && !isDerivation x)
+        then recurseIntoAttrs (mapAttrs (n: v: if n == "buildPackages" then v else recRecurseIntoAttrs v) x)
+        else x;
 
     };
   };


### PR DESCRIPTION
 to avoid accidentally getting the old one.