### PR TITLE
Bump mainnet block version to 1.0.0

### DIFF
--- a/cardano-lib/configuration.yaml
+++ b/cardano-lib/configuration.yaml
@@ -333,10 +333,10 @@ mainnet_base: &mainnet_base
 
   update: &mainnet_base_update
     applicationName: cardano-sl
-    applicationVersion: 1
+    applicationVersion: 2
     lastKnownBlockVersion:
-      bvMajor: 0
-      bvMinor: 2
+      bvMajor: 1
+      bvMinor: 0
       bvAlt: 0
 
   ssc:

--- a/cardano-lib/mainnet-config.nix
+++ b/cardano-lib/mainnet-config.nix
@@ -25,9 +25,9 @@
   #####    Update Parameters    #####
 
   ApplicationName = "cardano-sl";
-  ApplicationVersion = 1;
-  LastKnownBlockVersion-Major = 0;
-  LastKnownBlockVersion-Minor = 2;
+  ApplicationVersion = 2;
+  LastKnownBlockVersion-Major = 1;
+  LastKnownBlockVersion-Minor = 0;
   LastKnownBlockVersion-Alt = 0;
 
   MemPoolLimitTx = 200;

--- a/skeleton/.buildkite/pipeline.yml
+++ b/skeleton/.buildkite/pipeline.yml
@@ -29,5 +29,6 @@ steps:
     agents:
       system: x86_64-linux
     timeout_in_minutes: 60
+    branches: master
     artifact_paths:
       - "/build/iohk-skeleton/.stack-work/logs/iohk-skeleton*.log"


### PR DESCRIPTION
```
[cardano-sl.node:Notice:ThreadId 1100055] [2020-02-16 03:54:42.87 UTC] Processing of proposal cardano-sl:2 { block v1.0.0, UpId: eb67a51d33de6d96, { script version: no change, slot duration (mcs): no change, block size limit
: no change, header size limit: no change, tx size limit: no change, proposal size limit: no change, mpc threshold: no change, heavyweight delegation threshold: no change, update vote threshold: no change, update proposal th
reshold: no change, update implicit period (slots): no change, softfork rule: no change, tx fee policy: no change, unlock stake epoch: #9999999999999999999 }, tags: [], no attributes } is successful

[cardano-sl.node.us:Notice:ThreadId 335] [2020-02-16 15:54:56.04 UTC] Proposal eb67a51d is confirmed
```