### PR TITLE
hasPrometheus: switch localhost to 127.0.0.1

### DIFF
--- a/cardano-lib/explorer-log-config.nix
+++ b/cardano-lib/explorer-log-config.nix
@@ -27,7 +27,7 @@
   # hasGUI: 12787
 
   # if wanted, the EKG interface is listening on this port:
-  hasPrometheus = [ "localhost" 12698 ];
+  hasPrometheus = [ "127.0.0.1" 12698 ];
 
   # here we set up outputs of logging in 'katip':
   setupScribes = [ {

--- a/cardano-lib/generic-log-config.nix
+++ b/cardano-lib/generic-log-config.nix
@@ -36,7 +36,7 @@
 
   # if wanted, the EKG interface is listening on this port:
   hasEKG = 12788;
-  hasPrometheus = [ "localhost" 12798 ];
+  hasPrometheus = [ "127.0.0.1" 12798 ];
 
   # here we set up outputs of logging in 'katip':
   setupScribes = [ {

--- a/cardano-lib/proxy-log-config.nix
+++ b/cardano-lib/proxy-log-config.nix
@@ -35,7 +35,7 @@
 
   # if wanted, the EKG interface is listening on this port:
   hasEKG = 12788;
-  hasPrometheus = [ "localhost" 12798 ];
+  hasPrometheus = [ "127.0.0.1" 12798 ];
 
   # here we set up outputs of logging in 'katip':
   setupScribes = [ {


### PR DESCRIPTION
This is because docker doesn't have localhost in /etc/hosts. Instead of hacking that in, if we utilize the localhost IP instead, it works as expected.