### PR TITLE
Fix `not subscriptable` on timeout and print true err msg

### DIFF
--- a/ci/hydra-eval-errors/bin/hydra-eval-errors.py
+++ b/ci/hydra-eval-errors/bin/hydra-eval-errors.py
@@ -60,7 +60,7 @@ class HydraEvalMonitor:
                 print(f"Hydra eval not created yet for {commit} - sleeping {retry_time} seconds")
                 retry_count = retry_count + 1
                 sleep(retry_time)
-                if retry_count > retries:
+                if retry_count == retries:
                     print("Retried 1 hour - exiting")
                     errormsg = self.job["errormsg"]
                     print("Errors below may be incomplete")


### PR DESCRIPTION
* Fixes `TypeError: 'NoneType' object is not subscriptable` on 1 hr timeout instead of printing the intended error message