### PR TITLE
Add shelley-unblocked experimental Praos cluster

### DIFF
--- a/cardano-lib/default.nix
+++ b/cardano-lib/default.nix
@@ -142,6 +142,13 @@ let
       signingKey = ./selfnode.key;
       topology = ./selfnode-topology.json;
     };
+    shelley-unblocked = rec {
+      private = false;
+      networkConfig = import ./shelley-unblocked-config.nix;
+      nodeConfig = networkConfig // defaultLogConfig;
+      genesisFile = ./shelley-unblocked-genesis.json;
+      topology = ./selfnode-topology.json;
+    };
     latency-tests = {
       relays = "relays.latency-tests.aws.iohkdev.io";
       edgeNodes = [

--- a/cardano-lib/shelley-unblocked-config.nix
+++ b/cardano-lib/shelley-unblocked-config.nix
@@ -1,0 +1,38 @@
+##########################################################
+###############          Mainnet           ###############
+############### Cardano Node Configuration ###############
+##########################################################
+
+{
+  ##### Locations #####
+
+  GenesisFile = ./shelley-unblocked-genesis.json;
+
+  ##### Core protocol parameters #####
+
+  # This is the instance of the Ouroboros family that we are running.
+  # The node also supports various test and mock instances.
+  # "RealPBFT" is the real (ie not mock) (permissive) OBFT protocol, which
+  # is what we use on mainnet in Byron era.
+  Protocol = "TPraos";
+
+  # The mainnet does not include the network magic into addresses. Testnets do.
+  RequiresNetworkMagic = "RequiresMagic";
+
+  #### LOGGING Debug
+
+  minSeverity = "Debug";
+
+  ##### Update system parameters #####
+
+  # This protocol version number gets used by by block producing nodes as part
+  # part of the system for agreeing on and synchronising protocol updates.
+  LastKnownBlockVersion-Major = 0;
+  LastKnownBlockVersion-Minor = 0;
+  LastKnownBlockVersion-Alt = 0;
+
+  # In the Byron era some software versions are also published on the chain.
+  # We do this only for Byron compatibility now.
+  ApplicationName = "cardano-sl";
+  ApplicationVersion = 0;
+}

--- a/cardano-lib/shelley-unblocked-genesis.json
+++ b/cardano-lib/shelley-unblocked-genesis.json
@@ -1,0 +1,16 @@
+{
+  "StartTime":"1970-01-01T00:00:00Z",
+  "NetworkMagic":42,
+  "ProtocolMagicId":42,   "SlotLength":1,
+  "ActiveSlotsCoeff": 5.0e-2,
+  "DecentralisationParam":1,
+  "SecurityParam":2160,
+  "EpochLength":21600,
+  "SlotsPerKESPeriod":86400,
+  "MaxKESEvolutions":90,
+  "UpdateQuorum":5,   "MaxMajorPV":1000,
+  "MaxBodySize":16384,
+  "MaxHeaderSize":1400,   "GenDelegs":{},
+  "InitialFunds":{},
+  "MaxLovelaceSupply":0
+}


### PR DESCRIPTION
To generate lauch script for two local nodes, using https://github.com/input-output-hk/cardano-node/pull/821 (to be merged):
```
nix build --out-link launch_node_0 -f ./. scripts.shelley-unblocked.node --arg sourcesOverride '{ iohk-nix = ../iohk-nix; }' --arg customConfig '{ edgeHost = "127.0.0.1"; edgePort = 3002; stateDir = "state-node-shelley-unblocked-0"; }'

nix build --out-link launch_node_1 -f ./. scripts.shelley-unblocked.node --arg sourcesOverride '{ iohk-nix = ../iohk-nix; }' --arg customConfig '{ port = 3002; edgeHost = "127.0.0.1"; edgePort = 3001; stateDir = "state-node-shelley-unblocked-1"; }
```
Through currently fails with:
```
[howard:cardano.node.release:Notice:5] [2020-04-20 10:33:39.60 UTC] TPraos
[howard:cardano.node.version:Notice:5] [2020-04-20 10:33:39.60 UTC] 1.10.1
[howard:cardano.node.commit:Notice:5] [2020-04-20 10:33:39.60 UTC] 0000000000000000000000000000000000000000

Shutting down..

cardano-node: Prelude.cycle: empty list%
```