### PR TITLE
Respect recurseForDerivations = false

### DIFF
--- a/overlays/haskell-nix-extra/default.nix
+++ b/overlays/haskell-nix-extra/default.nix
@@ -6,7 +6,7 @@ pkgs: super: with pkgs; with lib; {
          // { recurseForDerivations = true; };
 
       recRecurseIntoAttrs = x:
-        if (isAttrs x && !isDerivation x)
+        if (isAttrs x && !isDerivation x && x.recurseForDerivations or true)
         then recurseIntoAttrs (mapAttrs (n: v: if n == "buildPackages" then v else recRecurseIntoAttrs v) x)
         else x;
 


### PR DESCRIPTION
`recRecurseIntoAttrs` sets `recurseForDerivations = true` everything in
the tree until it finds a derivation, but with the `project` and
`package` attributes added recently to haskell.nix the tree can be
infinite.  For instance you can wind up with something like

native.haskellPackages.contra-tracer.project.hsPkgs.Cabal.project.
hsPkgs.Cabal.components.tests.check-tests.x86_64-linux

To fix this we have added explicit `recurseForDerivations = false`
to the attributes that point back to the `project` and `package`.

However currently `recRecurseIntoAttrs` does not respect that and
turns everything back to `recurseIntoAttrs = true`.

This change updates `recRecurseIntoAttrs` so it will stop whenever it
sees `recurseIntoAttrs = false`.