### PR TITLE
[SRE-133] bump nixpkgs - DO NOT MERGE

### DIFF
--- a/ci.nix
+++ b/ci.nix
@@ -9,5 +9,4 @@ in {
     nixpkgs.recurseIntoAttrs {
       inherit (env.packages) jcli jcli-debug jormungandr jormungandr-debug;
     }) iohk-nix.jormungandrLib.environments);
-  niv = iohk-nix.niv;
 }

--- a/default.nix
+++ b/default.nix
@@ -24,11 +24,9 @@ let
     };
   deprecationWarning = parameter: builtins.trace ''
     WARNING: iohk-nix \"${parameter}\" parameter is deprecated.
-    Please use niv (https://github.com/input-output-hk/niv/) and the \"sourcesOverride\" parameter instead.
+    Please use niv (https://github.com/nmattia/niv/) and the \"sourcesOverride\" parameter instead.
   '';
   sources = defaultSources // sourcesOverride;
-
-  inherit (import defaultSources.niv { pkgs = pkgsDefault; }) niv;
 
   commonLib = rec {
     fetchNixpkgs = throw "Please use niv to pin nixpkgs instead.";
@@ -109,7 +107,6 @@ let
         inherit (pkgs) config system;
         pkgsDefault = pkgs;
       };
-      inherit (iohkNix) niv;
     })];
   };
 
@@ -143,13 +140,15 @@ let
     inherit
       overlays
       sources
-      niv
       shell
       tests
       rust-packages
       haskell-nix-extra-packages
       cardanoLib
       jormungandrLib;
+
+    inherit (pkgsDefault)
+      niv;
 
     inherit (commonLib)
       # package sets

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -23,28 +23,16 @@
         "url": "https://github.com/input-output-hk/haskell.nix/archive/54130f0106576632f6051f409af8e93550ce37bf.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
-    "niv": {
-        "branch": "master",
-        "description": "Easy dependency management for Nix projects",
-        "homepage": "https://github.com/input-output-hk/niv",
-        "owner": "input-output-hk",
-        "repo": "niv",
-        "rev": "f73bf8d584148677b01859677a63191c31911eae",
-        "sha256": "0jlmrx633jvqrqlyhlzpvdrnim128gc81q5psz2lpp2af8p8q9qs",
-        "type": "tarball",
-        "url": "https://github.com/input-output-hk/niv/archive/f73bf8d584148677b01859677a63191c31911eae.tar.gz",
-        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
-    },
     "nixpkgs": {
         "branch": "nixos-20.03",
         "description": "Nix Packages collection",
         "homepage": null,
         "owner": "NixOS",
-        "repo": "nixpkgs-channels",
-        "rev": "db31e48c5c8d99dcaf4e5883a96181f6ac4ad6f6",
-        "sha256": "1j5j7vbnq2i5zyl8498xrf490jca488iw6hylna3lfwji6rlcaqr",
+        "repo": "nixpkgs",
+        "rev": "3a78bb222c585baf3a48740e1887e4fd71e7a35e",
+        "sha256": "05xjj3jdmzi7qmh0hxgc8kmzm919kd94r91dmb8dhjf4fhsjb6fk",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs-channels/archive/db31e48c5c8d99dcaf4e5883a96181f6ac4ad6f6.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/3a78bb222c585baf3a48740e1887e4fd71e7a35e.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs-19.09": {

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -17,10 +17,10 @@
         "homepage": "https://input-output-hk.github.io/haskell.nix",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "54130f0106576632f6051f409af8e93550ce37bf",
-        "sha256": "09fm68g2cybdn6ana7crizma0qnhgbq3fmhjs4imd101lf1mcy71",
+        "rev": "c7c7d6c43af27a632f16e631202eb83ac3c047c3",
+        "sha256": "0xrfl0zwf98cyv6px0awblhff97vjv19a5mdvs6l98769qgh4558",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/haskell.nix/archive/54130f0106576632f6051f409af8e93550ce37bf.tar.gz",
+        "url": "https://github.com/input-output-hk/haskell.nix/archive/c7c7d6c43af27a632f16e631202eb83ac3c047c3.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs": {

--- a/release.nix
+++ b/release.nix
@@ -45,7 +45,6 @@ let
   mappedPkgs = mapTestOn ({
     rust-packages.pkgs.cardano-http-bridge = supportedSystems;
     haskell-nix-extra-packages.stackNixRegenerate = supportedSystems;
-    niv = supportedSystems;
 
     # Development tools
   } // jormungandrPackages);
@@ -64,8 +63,6 @@ fix (self: mappedPkgs // {
       self.forceNewEval
       rust-packages.pkgs.cardano-http-bridge.x86_64-linux
       haskell-nix-extra-packages.stackNixRegenerate.x86_64-linux
-      niv.x86_64-linux
-      niv.x86_64-darwin
     ]) ++ usedJormungandrVersions;
   });
 })

--- a/shell.nix
+++ b/shell.nix
@@ -3,7 +3,7 @@ let
   pkgs = commonLib.pkgs;
   shell = pkgs.stdenv.mkDerivation {
     name = "shell";
-    buildInputs = [ commonLib.niv ];
+    buildInputs = [ pkgs.niv ];
     shellHook = ''
       echo "IOHK NIX" \
       | ${pkgs.figlet}/bin/figlet -f banner -c \


### PR DESCRIPTION
This gives us commit 93a38cd which backports a fix for musl and ld.gold

`nixpkgs` in `iohk-nix` is currently pinned at rev `db31e48` but I believe I need it bump it to current HEAD or at least `93a38cd` to get [the fix](https://github.com/NixOS/nixpkgs/pull/93687) for [this build error](https://hydra.iohk.io/build/3778080/nixlog/1). 