### PR TITLE
Add hpc-coveralls fork

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -76,7 +76,7 @@ let
           else zero;
 
     # Development tools
-    inherit (haskell-nix-extra-packages) stack-hpc-coveralls;
+    inherit (haskell-nix-extra-packages) stack-hpc-coveralls hpc-coveralls;
     hlint = upstreamedDeprecation "hlint" pkgsDefault.hlint;
     openapi-spec-validator = upstreamedDeprecation "openapi-spec-validator" pkgsDefault.python37Packages.openapi-spec-validator;
     inherit (import sources.cardano-repo-tool {inherit system;}) cardano-repo-tool;
@@ -134,6 +134,7 @@ let
         haskellBuildUtils
         stackNixRegenerate
         stack-hpc-coveralls
+        hpc-coveralls
       ;
     };
 
@@ -170,6 +171,7 @@ let
 
       # packages
       stack-hpc-coveralls
+      hpc-coveralls
       hlint
       openapi-spec-validator
       cardano-repo-tool

--- a/overlays/haskell-nix-extra/default.nix
+++ b/overlays/haskell-nix-extra/default.nix
@@ -19,4 +19,5 @@ pkgs: super: with pkgs; with lib; {
     inherit pkgs;
   };
   stack-hpc-coveralls = super.haskellPackages.callPackage ./stack-hpc-coveralls.nix {};
+  hpc-coveralls = super.haskellPackages.callPackage ./hpc-coveralls.nix {};
 }

--- a/overlays/haskell-nix-extra/hpc-coveralls.nix
+++ b/overlays/haskell-nix-extra/hpc-coveralls.nix
@@ -1,0 +1,31 @@
+{ mkDerivation, aeson, async, base, bytestring, Cabal, cmdargs
+, containers, curl, directory, directory-tree, fetchgit, hpc, HUnit
+, process, pureMD5, regex-posix, retry, safe, split, stdenv
+, transformers
+}:
+mkDerivation {
+  pname = "hpc-coveralls";
+  version = "1.1.0";
+  src = fetchgit {
+    url = "https://github.com/sevanspowell/hpc-coveralls.git";
+    sha256 = "0qw5x7bhcmma90yp97m1y6si8idapxlbmy62rcnnni2avyi1aski";
+    rev = "c73e59fbd39ad20e3ab0ad050533496ec8512dbe";
+    fetchSubmodules = true;
+  };
+  isLibrary = true;
+  isExecutable = true;
+  libraryHaskellDepends = [
+    aeson base bytestring Cabal cmdargs containers curl directory
+    directory-tree hpc process pureMD5 retry safe split transformers
+  ];
+  executableHaskellDepends = [
+    aeson async base bytestring Cabal cmdargs containers curl directory
+    directory-tree hpc process pureMD5 regex-posix retry safe split
+    transformers
+  ];
+  testHaskellDepends = [ base HUnit ];
+  jailbreak = true;
+  homepage = "https://github.com/guillaume-nargeot/hpc-coveralls";
+  description = "Coveralls.io support for Haskell.";
+  license = stdenv.lib.licenses.bsd3;
+}


### PR DESCRIPTION
- Add a fork of hpc-coveralls to iohk-nix that replaces stack-hpc-coveralls and allows us to stop using stack on our CI/coverage builds.
- I'm adding a fork because I don't think https://github.com/guillaume-nargeot/hpc-coveralls is still actively maintained.