### PR TITLE
Update Haskell.nix and Nixpkgs match latest

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,10 @@
 Please read these notes when updating your project's `iohk-nix`
 version. There may have been changes which could break your build.
 
+## 2020-10-06
+   * Bump Haskell.nix to latest. There are [multiple API changes](https://github.com/input-output-hk/haskell.nix/blob/master/changelog.md) and nix-tools improvements.
+   * Fix locales issue on non-nix systems in `stackNixRegenerate` script.
+
 ## 2020-07-14
    * Bump Haskell.nix to latest. There are [multiple API changes](https://github.com/input-output-hk/haskell.nix/blob/master/changelog.md).
    * Fix `stackNixRegenerate` script for latest Haskell.nix.

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -17,10 +17,10 @@
         "homepage": "https://input-output-hk.github.io/haskell.nix",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "4f875ebe99c5a068b6276809c8e822e40018935d",
-        "sha256": "05kq921cfnfakdlq23pvmzr4fdm2qanadbsnibwgz267hvi41x6n",
+        "rev": "f91d8c7d689d10bbd4a1fa374b2e663ad5b0992e",
+        "sha256": "1gjs4cfghyvpsmzbdjdvk4r3qxhq2zf8qg8njms5ljyia4y5x2nr",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/haskell.nix/archive/4f875ebe99c5a068b6276809c8e822e40018935d.tar.gz",
+        "url": "https://github.com/input-output-hk/haskell.nix/archive/f91d8c7d689d10bbd4a1fa374b2e663ad5b0992e.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "niv": {

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -17,10 +17,10 @@
         "homepage": "https://input-output-hk.github.io/haskell.nix",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "54130f0106576632f6051f409af8e93550ce37bf",
-        "sha256": "09fm68g2cybdn6ana7crizma0qnhgbq3fmhjs4imd101lf1mcy71",
+        "rev": "4f875ebe99c5a068b6276809c8e822e40018935d",
+        "sha256": "05kq921cfnfakdlq23pvmzr4fdm2qanadbsnibwgz267hvi41x6n",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/haskell.nix/archive/54130f0106576632f6051f409af8e93550ce37bf.tar.gz",
+        "url": "https://github.com/input-output-hk/haskell.nix/archive/4f875ebe99c5a068b6276809c8e822e40018935d.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "niv": {
@@ -36,15 +36,15 @@
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs": {
-        "branch": "nixos-20.03",
+        "branch": "nixpkgs-20.03-darwin",
         "description": "Nix Packages collection",
         "homepage": null,
         "owner": "NixOS",
         "repo": "nixpkgs-channels",
-        "rev": "db31e48c5c8d99dcaf4e5883a96181f6ac4ad6f6",
-        "sha256": "1j5j7vbnq2i5zyl8498xrf490jca488iw6hylna3lfwji6rlcaqr",
+        "rev": "732684b720f829056dcb62380c2c17e4d3ebd947",
+        "sha256": "1fyrgpgpn906c96bhm4ad5n4qq27flhnfpiv395iryk3zsyig4dk",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs-channels/archive/db31e48c5c8d99dcaf4e5883a96181f6ac4ad6f6.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs-channels/archive/732684b720f829056dcb62380c2c17e4d3ebd947.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs-19.09": {

--- a/overlays/haskell-nix-extra/nix-tools-regenerate.nix
+++ b/overlays/haskell-nix-extra/nix-tools-regenerate.nix
@@ -22,9 +22,9 @@ in
     export PATH=${(lib.makeBinPath deps) + lib.optionalString stdenv.isDarwin ":/usr/bin"}
     export NIX_PATH=nixpkgs=${path}
     # Needed or stack-to-nix will die on unicode inputs
-    LOCALE_ARCHIVE=${lib.optionalString (stdenv.hostPlatform.libc == "glibc") "${glibcLocales}/lib/locale/locale-archive"};
-    LANG="en_US.UTF-8";
-    LC_ALL="en_US.UTF-8";
+    export LOCALE_ARCHIVE=${lib.optionalString (stdenv.hostPlatform.libc == "glibc") "${glibcLocales}/lib/locale/locale-archive"}
+    export LANG="en_US.UTF-8"
+    export LC_ALL="en_US.UTF-8"
 
     tmp_dest=".stack-to-nix.tmp"
     mkdir -p "$tmp_dest"


### PR DESCRIPTION
We have updated the nixpkgs 20.03 commit that we are using for
haskell.nix CI.  This change would update both haskell.nix and
nixpkgs in this repo to match (should help avoid cache misses on
hydra).