### PR TITLE
Remove Protocol field from cardano-db-sync configs

### DIFF
--- a/cardano-lib/default.nix
+++ b/cardano-lib/default.nix
@@ -25,7 +25,7 @@ let
   defaultExplorerLogConfig = import ./explorer-log-config.nix;
   mkExplorerConfig = name: nodeConfig: lib.filterAttrs (k: v: v != null) {
     NetworkName = name;
-    inherit (nodeConfig) Protocol RequiresNetworkMagic;
+    inherit (nodeConfig) RequiresNetworkMagic;
     NodeConfigFile = "${__toFile "config-${toString name}.json" (__toJSON nodeConfig)}";
   };
   defaultProxyLogConfig = import ./proxy-log-config.nix;


### PR DESCRIPTION
The `Protocol` field is no longer consumed from `cardano-db-sync`'s own configs and is now read from `nodeConfig`.