### PR TITLE
[SRE-141] Enable hlint of sub-directories

### DIFF
--- a/tests/hlint.nix
+++ b/tests/hlint.nix
@@ -1,4 +1,4 @@
-{ runCommand, hlint, src, lib, projects }:
+{ runCommand, hlint, src, lib, }:
 
 let
   # just haskell sources and the hlint config file
@@ -12,10 +12,10 @@ let
     );
   };
 in
-runCommand "hlint-check" { inherit projects; buildInputs = [ hlint ]; } ''
+runCommand "hlint-check" { buildInputs = [ hlint ]; } ''
   set +e
   cd ${src'}
-  hlint $projects
+  hlint . --ignore-glob='dist-newstyle/*'
   EXIT_CODE=$?
   if [[ $EXIT_CODE != 0 ]]
   then


### PR DESCRIPTION
Hydra is currently unable to `hlint` projects in sub-directories because it consumes `selectProjectPackages` which only provides a package name which `hlint` then assumes is in the root.

This is an interim workaround.