### PR TITLE
stackNixRegenerate: allow passing CLI args through to stack-to-nix

### DIFF
--- a/overlays/haskell-nix-extra/nix-tools-regenerate.nix
+++ b/overlays/haskell-nix-extra/nix-tools-regenerate.nix
@@ -34,7 +34,7 @@ in
     }
     trap cleanup EXIT
 
-    stack-to-nix --output "$tmp_dest/.stack.nix"
+    stack-to-nix --output "$tmp_dest/.stack.nix" "$@"
     (
       cd $tmp_dest/.stack.nix
       mv pkgs.nix default.nix


### PR DESCRIPTION
Need this to temporarily work around https://github.com/input-output-hk/nix-tools/pull/98
