### PR TITLE
Clean up haskell-nix-extra-packages

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,11 @@
 Please read these notes when updating your project's `iohk-nix`
 version. There may have been changes which could break your build.
 
+## 2021-04-29
+   * Removed `haskell-nix-extra-packages` attrset - add
+     `overlays.haskell-nix-extra` to your project's nixpkgs overlays
+     instead.
+
 ## 2021-02-21
    * Reduce build closure size and the amount of code in iohk-nix.
    * Removed `haskell-nix-extra.stack-hpc-coveralls` - use

--- a/changelog.md
+++ b/changelog.md
@@ -3,11 +3,6 @@
 Please read these notes when updating your project's `iohk-nix`
 version. There may have been changes which could break your build.
 
-## 2021-04-29
-   * Removed `haskell-nix-extra-packages` attrset - add
-     `overlays.haskell-nix-extra` to your project's nixpkgs overlays
-     instead.
-
 ## 2021-02-21
    * Reduce build closure size and the amount of code in iohk-nix.
    * Removed `haskell-nix-extra.stack-hpc-coveralls` - use

--- a/default.nix
+++ b/default.nix
@@ -122,20 +122,9 @@ let
     };
   };
 
-  haskell-nix-extra-packages = let
-    haskellNix = (import defaultSources."haskell.nix" { inherit system sourcesOverride; }).nixpkgsArgs;
-    pkgs = import defaultSources.nixpkgs {
-      inherit system crossSystem;
-      config = haskellNix.config // config;
-      overlays = haskellNix.overlays ++ overlays.haskell-nix-extra;
-      };
-    removedWarnings = names: pkgs.lib.genAttrs names
-      (pkg: builtins.trace "WARNING: iohk-nix `haskellBuildUtils.${pkg}` has been removed." null);
-  in {
-    inherit (pkgs)
-      haskellBuildUtils
-      stackNixRegenerate;
-  } // removedWarnings [ "stack-hpc-coveralls" "hpc-coveralls" ];
+  haskell-nix-extra-packages = pkgsDefault.lib.genAttrs
+    [ "stackNixRegenerate" "haskellBuildUtils" "stack-hpc-coveralls" "hpc-coveralls" ]
+    (pkg: throw "ERROR: iohk-nix `haskell-nix-extra-packages.${pkg}` has been removed.");
 
   shell = import ./shell.nix;
 

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -11,18 +11,6 @@
         "url": "https://github.com/input-output-hk/cardano-repo-tool/archive/3a8a14d3f3f18f202fcc6d4ca03c1a3b098bf4f0.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
-    "haskell.nix": {
-        "branch": "master",
-        "description": "Alternative Haskell Infrastructure for Nixpkgs",
-        "homepage": "https://input-output-hk.github.io/haskell.nix",
-        "owner": "input-output-hk",
-        "repo": "haskell.nix",
-        "rev": "b06fdfa06595668b367a8b9298792076c87e4618",
-        "sha256": "19kpvn4fy6d2cz18bbjv3n9gmv6zmccfjkd6dghdifm208qp3xvb",
-        "type": "tarball",
-        "url": "https://github.com/input-output-hk/haskell.nix/archive/b06fdfa06595668b367a8b9298792076c87e4618.tar.gz",
-        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
-    },
     "nixpkgs": {
         "branch": "nixos-unstable",
         "description": "Nix Packages collection",

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -11,6 +11,18 @@
         "url": "https://github.com/input-output-hk/cardano-repo-tool/archive/3a8a14d3f3f18f202fcc6d4ca03c1a3b098bf4f0.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
+    "haskell.nix": {
+        "branch": "master",
+        "description": "Alternative Haskell Infrastructure for Nixpkgs",
+        "homepage": "https://input-output-hk.github.io/haskell.nix",
+        "owner": "input-output-hk",
+        "repo": "haskell.nix",
+        "rev": "66f90fc17682636bfc60b8df47c075cd58599afe",
+        "sha256": "0ikdwdgc3gdjc16qxsjcrqbf2jn97znpdc42zbbnqp90y68zmjb5",
+        "type": "tarball",
+        "url": "https://github.com/input-output-hk/haskell.nix/archive/66f90fc17682636bfc60b8df47c075cd58599afe.tar.gz",
+        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
+    },
     "nixpkgs": {
         "branch": "nixos-unstable",
         "description": "Nix Packages collection",

--- a/overlays/haskell-nix-extra/default.nix
+++ b/overlays/haskell-nix-extra/default.nix
@@ -1,4 +1,7 @@
-final: prev: with final; with lib; {
+let
+  compiler-nix-name = "ghc8104";
+  index-state = "2021-04-29T00:00:00Z";
+in final: prev: with final; with lib; {
   haskell-nix = recursiveUpdate prev.haskell-nix {
     # TODO: remove this haskellLib.extra
     haskellLib.extra = rec {
@@ -17,10 +20,12 @@ final: prev: with final; with lib; {
   };
 
   stackNixRegenerate = pkgs.callPackage ./nix-tools-regenerate.nix {
-    nix-tools = haskell-nix.nix-tools.ghc865;
+    nix-tools = haskell-nix.nix-tools.${compiler-nix-name};
   };
 
-  haskellBuildUtils = pkgs.callPackage ./utils/default.nix {};
+  haskellBuildUtils = pkgs.callPackage ./utils/default.nix {
+    inherit compiler-nix-name index-state;
+  };
 
   rewriteStatic = _: p: if (pkgs.stdenv.hostPlatform.isDarwin) then
     pkgs.runCommandCC p.name {

--- a/overlays/haskell-nix-extra/utils/default.nix
+++ b/overlays/haskell-nix-extra/utils/default.nix
@@ -1,4 +1,5 @@
-{ lib, haskell-nix, symlinkJoin }:
+{ lib, haskell-nix, symlinkJoin
+, compiler-nix-name, index-state }:
 
 let
   project = mkProject {};
@@ -7,8 +8,7 @@ let
       name = "iohk-nix-utils";
       src = ./.;
     };
-    compiler-nix-name = "ghc8104";
-    index-state = "2021-03-15T00:00:00Z";
+    inherit compiler-nix-name index-state;
   } // args);
 in
   symlinkJoin {

--- a/overlays/haskell-nix-extra/utils/default.nix
+++ b/overlays/haskell-nix-extra/utils/default.nix
@@ -1,19 +1,21 @@
 { lib, haskell-nix, symlinkJoin }:
 
 let
-  project = haskell-nix.cabalProject {
-    src = haskell-nix.haskellLib.cleanGit {
-      name = "iohk-nix-utils-src";
+  project = mkProject {};
+  mkProject = args: haskell-nix.cabalProject ({
+    src = haskell-nix.haskellLib.cleanSourceWith {
+      name = "iohk-nix-utils";
       src = ./.;
     };
     compiler-nix-name = "ghc8104";
     index-state = "2021-03-15T00:00:00Z";
-  };
+  } // args);
 in
   symlinkJoin {
     name = "iohk-nix-utils";
     paths = lib.attrValues project.iohk-nix-utils.components.exes;
     passthru = {
+      inherit project mkProject;
       shell = project.shellFor {};
       roots = project.roots;
       package = builtins.trace "WARNING: iohk-nix `haskellBuildUtils.package` has been renamed to `haskellBuildUtils`." null;

--- a/release.nix
+++ b/release.nix
@@ -45,6 +45,7 @@ let
   mappedPkgs = mapTestOn ({
     rust-packages.pkgs.cardano-http-bridge = supportedSystems;
     haskell-nix-extra-packages.stackNixRegenerate = supportedSystems;
+    haskell-nix-extra-packages.haskellBuildUtils = supportedSystems;
 
     # Development tools
   } // jormungandrPackages);
@@ -63,6 +64,7 @@ fix (self: mappedPkgs // {
       self.forceNewEval
       rust-packages.pkgs.cardano-http-bridge.x86_64-linux
       haskell-nix-extra-packages.stackNixRegenerate.x86_64-linux
+      haskell-nix-extra-packages.haskellBuildUtils.x86_64-linux
     ]) ++ usedJormungandrVersions;
   });
 })


### PR DESCRIPTION
Follow-ups from PR #468.

- Removes the `haskell-nix-extra-packages` attrset - it's not needed anywhere and didn't work anyway.
- Expose `project` and `mkProject` attributes of `pkgs.haskellBuildUtils`. This would let downstream users generate materializations, etc, etc.

Tested on input-output-hk/cardano-wallet#2628.