### PR TITLE
cabal/nixWrappers: output warning to stderr

### DIFF
--- a/overlays/utils/default.nix
+++ b/overlays/utils/default.nix
@@ -3,7 +3,7 @@ final: prev: let
 in {
   nixWrapped = writeShellScriptBin "nix" ''
     if [[ "$@" == "flake show"* ]] || [[ "$@" == "flake check"* ]]; then
-      echo 'Temporary override `supported-systems.nix` original content to be able to use `nix flake show|check` on dev machines (workaround for https://github.com/NixOS/nix/issues/4265)'
+      >&2 echo 'Temporary override `supported-systems.nix` original content to be able to use `nix flake show|check` on dev machines (workaround for https://github.com/NixOS/nix/issues/4265)'
       SYSTEMS="$(${git}/bin/git rev-parse --show-toplevel)/supported-systems.nix"
       BACKUP="$(mktemp)"
       mv "$SYSTEMS" "$BACKUP"
@@ -16,7 +16,7 @@ in {
     GC_DONT_GC=1 ${nixFlakes}/bin/nix --experimental-features "nix-command flakes" "$@"
   '';
   cabalWrapped = writeShellScriptBin "cabal" ''
-    echo 'Temporary modify `cabal.project` to use nix builds of `source-repository-package`s (haskell/cabal#5444 and haskell/cabal#6249).'
+    >&2 echo 'Temporary modify `cabal.project` to use nix builds of `source-repository-package`s (haskell/cabal#5444 and haskell/cabal#6249).'
     PROJECT="$(${git}/bin/git rev-parse --show-toplevel)/cabal.project"
     BACKUP="$(mktemp)"
     cp -a "$PROJECT" "$BACKUP"


### PR DESCRIPTION
to not mess-up stdout parsing