### PR TITLE
checkStackProject: Let it work with nixpkgs-unstable

### DIFF
--- a/ci/cabal-project-regenerate/default.nix
+++ b/ci/cabal-project-regenerate/default.nix
@@ -1,5 +1,6 @@
 { stdenv
 , lib
+, runtimeShell
 , writeScript
 , runCommand
 , python37
@@ -26,7 +27,7 @@ let
     nix-prefetch-git
   ];
   checkCabalProject = writeScript "check-cabal-project" ''
-    #!${stdenv.shell}
+    #!${runtimeShell}
     PATH=${lib.makeBinPath checkDeps}
     set -euo pipefail
     cp ./cabal.project ./cabal.project.old

--- a/ci/check-stack-project.nix
+++ b/ci/check-stack-project.nix
@@ -3,16 +3,16 @@
 # run on a PR branch, and there is a SSH key present, it will attempt to push
 # the changes back to the PR.
 
-{ stdenv, writeScript, coreutils, nixStable, git, gawk }:
+{ lib, runtimeShell, writeScript, coreutils, nixStable, git, gawk }:
 
-with stdenv.lib;
+with lib;
 
 writeScript "check-stack-project.sh" ''
-  #!${stdenv.shell}
+  #!${runtimeShell}
 
   set -euo pipefail
 
-  export PATH="${makeBinPath [ stdenv.shellPackage coreutils nixStable git gawk ]}:$PATH"
+  export PATH="${makeBinPath [ runtimeShell coreutils nixStable git gawk ]}:$PATH"
 
   if [ -z "''${BUILDKITE:-}" ]; then
     # Go to top of project repo, unless running under CI.

--- a/overlays/haskell-nix-extra/nix-tools-regenerate.nix
+++ b/overlays/haskell-nix-extra/nix-tools-regenerate.nix
@@ -1,14 +1,14 @@
 # A script for generating the nix haskell package set based on stackage,
 # using the common convention for repo layout.
 
-{ lib, stdenv, path, writeScript, nix-tools, coreutils, findutils, glibcLocales }:
+{ lib, stdenv, runtimeShell, path, writeScript, nix-tools, coreutils, findutils, glibcLocales }:
 
 let
   deps = [ nix-tools coreutils findutils ];
 
 in
   writeScript "nix-tools-regenerate" ''
-    #!${stdenv.shell}
+    #!${runtimeShell}
     #
     # Haskell package set regeneration script.
     #


### PR DESCRIPTION
When using a recent nixpkgs-unstable version, `checkStackProject` fails due to `pkgs.stdenv.lib` being moved to `pkgs.lib`. This fixes that, and also replaces a few `pkgs.stdenv.shell` instances with `pkgs.runtimeShell`.
