### PR TITLE
nix-shell/cabalWrapped: use separate cabal.project

### DIFF
--- a/overlays/utils/default.nix
+++ b/overlays/utils/default.nix
@@ -16,13 +16,51 @@ in {
     GC_DONT_GC=1 ${nixFlakes}/bin/nix --experimental-features "nix-command flakes" "$@"
   '';
   cabalWrapped = writeShellScriptBin "cabal" ''
-    TOPLEVEL="$(${git}/bin/git rev-parse --show-toplevel)"
-    ORIG_PROJECT="$TOPLEVEL/cabal.project"
-    # Should be in .gitignore:
-    NIXSHELL_PROJECT="$TOPLEVEL/.nix-shell-cabal.project"
-    
-    sed -n '1,/--- 8< ---/ p' $PROJECT > "$NIXSHELL_PROJECT"
-    exec ${final.cabal or final.cabal-install}/bin/cabal --project-file="$NIXSHELL_PROJECT" "$@"
+    set -euo pipefail
+
+    find_up() {
+      while [[ $PWD != / ]] ; do
+        if [[ -e "$1" ]]; then
+          echo "$PWD"
+          return
+        fi
+        cd ..
+      done
+    }
+
+    toplevel=$(find_up "cabal.project")
+
+    if [[ -n "$toplevel" ]]; then
+      cabal_project="$toplevel/cabal.project"
+      nix_shell_cabal_project=$toplevel/.nix-shell-cabal.project
+      extra_cabal_opts=("--project-file=$nix_shell_cabal_project")
+      awk '
+        # Add comment with explanation of file
+        BEGIN {
+          print "-- Generated from '"$cabal_project"' by the wrapper script"
+          print "-- ${placeholder "out"}"
+          print "-- Add this file to your .gitignore\n"
+        }
+
+        # Matches all section starts
+        /^[^ ]/ {
+          # Remember the section name (they can span multiple lines)
+          section = $0
+        }
+        # Matches every line
+        // {
+          # Only print the line if it is not in the section we want to omit
+          if (section != "source-repository-package")
+            print $0
+        }
+      ' "$cabal_project" > "$nix_shell_cabal_project"
+    else
+      extra_cabal_opts=()
+    fi
+
+    cabal=${final.cabal or final.cabal-install}/bin/cabal
+    >&2 echo "$cabal ''${extra_cabal_opts[@]} $@"
+    exec "$cabal" "''${extra_cabal_opts[@]}" "$@"
   '';
 
   hlintCheck = ../../tests/hlint.nix;


### PR DESCRIPTION
to avoid modifying original cabal.project.