### PR TITLE
alonzo-purple/alonzo-qa: disable development flags

### DIFF
--- a/cardano-lib/alonzo-purple-config.nix
+++ b/cardano-lib/alonzo-purple-config.nix
@@ -30,8 +30,8 @@
   TestMaryHardForkAtEpoch = 3;
   TestAlonzoHardForkAtEpoch = 4;
 
-  TestEnableDevelopmentHardForkEras = true;
-  TestEnableDevelopmentNetworkProtocols = true;
+  TestEnableDevelopmentHardForkEras = false;
+  TestEnableDevelopmentNetworkProtocols = false;
 
   MaxKnownMajorProtocolVersion = 5;
   #### LOGGING Debug

--- a/cardano-lib/alonzo-qa-config.nix
+++ b/cardano-lib/alonzo-qa-config.nix
@@ -30,8 +30,8 @@
   TestMaryHardForkAtEpoch = 3;
   TestAlonzoHardForkAtEpoch = 4;
 
-  TestEnableDevelopmentHardForkEras = true;
-  TestEnableDevelopmentNetworkProtocols = true;
+  TestEnableDevelopmentHardForkEras = false;
+  TestEnableDevelopmentNetworkProtocols = false;
 
   MaxKnownMajorProtocolVersion = 5;
   #### LOGGING Debug


### PR DESCRIPTION
* preparation for upcoming mainnet release
* disables both forks and protocols flags