### PR TITLE
[WIP] Update haskell.nix

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,10 @@
 Please read these notes when updating your project's `iohk-nix`
 version. There may have been changes which could break your build.
 
+## 2022-02-10
+
+  * Bump `haskell.nix`.
+
 ## 2021-07-22
   * Renamed `libsodium` to `libsodium-vrf` in the crypto overlay. This
     allows much more sharing from the binary caches.

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -14,13 +14,13 @@
     "haskell.nix": {
         "branch": "master",
         "description": "Alternative Haskell Infrastructure for Nixpkgs",
-        "homepage": "https://input-output-hk.github.io/haskell.nix",
-        "owner": "input-output-hk",
+        "homepage": "https://github.com/mlabs-haskell/haskell.nix",
+        "owner": "mlabs-haskell",
         "repo": "haskell.nix",
         "rev": "fd13635f705956a85b8f59dd90b4bdc6a1319d44",
         "sha256": "0lswqqsjw101fwdjnh54z4vvlgcndp988qcg7sa5d71iwdi9j3z5",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/haskell.nix/archive/fd13635f705956a85b8f59dd90b4bdc6a1319d44.tar.gz",
+        "url": "https://github.com/mlabs-haskell/haskell.nix/archive/5740b3ee01ab28d142923847a68dfdcba0aee12f.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs": {
@@ -29,10 +29,10 @@
         "homepage": null,
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b3d86c56c786ad9530f1400adbd4dfac3c42877b",
+        "rev": "34fbb68d2e83586cda5fe8a86fd2557270571507",
         "sha256": "09nslcjdgwwb6j9alxrsnq1wvhifq1nmzl2w02l305j0wsmgdial",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/b3d86c56c786ad9530f1400adbd4dfac3c42877b.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/34fbb68d2e83586cda5fe8a86fd2557270571507.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs-19.09": {


### PR DESCRIPTION
This is necessary for [this issue](https://github.com/input-output-hk/plutus/issues/4233), specifically for the support of Schnorr signatures, as per [this PR](https://github.com/input-output-hk/plutus/pull/4368#issuecomment-1031782137). As all our SECP256k1 support currently goes via `cardano-base` (see [this PR](https://github.com/input-output-hk/cardano-base/pull/252)), we need access to an updated `libsecp256k1`, which has only been added to `nixpkgs-unstable` [recently](https://github.com/NixOS/nixpkgs/pull/158516).

As this currently depends on [this PR](https://github.com/input-output-hk/haskell.nix/pull/1368) landing, I have marked it WIP. Once the `haskell.nix` PR lands, I will update to aim at `haskell.nix` `master` instead of our fork.