### PR TITLE
libsodium-vrf: address `configureFlags` deprecation warning

### DIFF
--- a/overlays/crypto/libsodium.nix
+++ b/overlays/crypto/libsodium.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ autoreconfHook ];
 
-  configureFlags = "--enable-static";
+  configureFlags = [ "--enable-static" ];
 
   outputs = [ "out" "dev" ];
   separateDebugInfo = stdenv.isLinux && stdenv.hostPlatform.libc != "musl";


### PR DESCRIPTION
See https://github.com/NixOS/nixpkgs/commit/6d54fe622d9fb31c7c08c832522bf46ffb79ea27

Before this change, running

```
nix build --impure --expr '(import (builtins.getFlake "github:NixOS/nixpkgs/d6df226") { overlays = (import ./. {}).overlays.crypto; }).libsodium-vrf'
```
yields
```
trace: warning: String 'configureFlags' is deprecated and will be removed in release 23.05. Please use a list of strings. Derivation name: libsodium-1.0.18, file: /home/alexander/git/iog/iohk-nix/overlays/crypto/libsodium.nix
```