### PR TITLE
libsodium-vrf: fix cross build to mingwW64

### DIFF
--- a/overlays/crypto/libsodium.nix
+++ b/overlays/crypto/libsodium.nix
@@ -12,7 +12,11 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ autoreconfHook ];
 
-  configureFlags = [ "--enable-static" ];
+  configureFlags = [ "--enable-static" ]
+    # Fixes a compilation failure: "undefined reference to `__memcpy_chk'". Note
+    # that the more natural approach of adding "stackprotector" to
+    # `hardeningDisable` does not resolve the issue.
+    ++ lib.optional stdenv.hostPlatform.isMinGW "CFLAGS=-fno-stack-protector";
 
   outputs = [ "out" "dev" ];
   separateDebugInfo = stdenv.isLinux && stdenv.hostPlatform.libc != "musl";


### PR DESCRIPTION
Otherwise, when building `pkgsCross.mingwW64.libsodium-vrf`:

```
libsodium-1.0.18-x86_64-w64-mingw> /nix/store/ar3j35s4brxdda418xd48qzh3af6pggb-x86_64-w64-mingw32-binutils-2.39/bin/x86_64-w64-mingw32-ld: crypto_generichash/blake2b/ref/.libs/libsodium_la-blake2b-ref.o: in function `memcpy':
libsodium-1.0.18-x86_64-w64-mingw> /nix/store/6p7r1kxjcv3fgcq0365cnzrycj4s6h7f-x86_64-w64-mingw32-stage-final-gcc-11.3.0/x86_64-w64-mingw32/sys-include/string.h:202: undefined reference to `__memcpy_chk'
libsodium-1.0.18-x86_64-w64-mingw> /nix/store/ar3j35s4brxdda418xd48qzh3af6pggb-x86_64-w64-mingw32-binutils-2.39/bin/x86_64-w64-mingw32-ld: /nix/store/6p7r1kxjcv3fgcq0365cnzrycj4s6h7f-x86_64-w64-mingw32-stage-final-gcc-11.3.0/x86_64-w64-mingw32/sys-include/string.h:202: undefined reference to `__memcpy_chk'
libsodium-1.0.18-x86_64-w64-mingw> /nix/store/ar3j35s4brxdda418xd48qzh3af6pggb-x86_64-w64-mingw32-binutils-2.39/bin/x86_64-w64-mingw32-ld: crypto_vrf/ietfdraft13/.libs/libsodium_la-verify.o: in function `memcpy':
libsodium-1.0.18-x86_64-w64-mingw> /nix/store/6p7r1kxjcv3fgcq0365cnzrycj4s6h7f-x86_64-w64-mingw32-stage-final-gcc-11.3.0/x86_64-w64-mingw32/sys-include/string.h:202: undefined reference to `__memcpy_chk'
```

See https://github.com/NixOS/nixpkgs/pull/171828 for the approach taken.

~I don't know whether disabling the stack protector has security implications for libsodium-vrf.~ Confirmed by @iquerejeta not to be the case.