### PR TITLE
Bring back Haskell-nix.extra for now

### DIFF
--- a/overlays/haskell-nix-extra/default.nix
+++ b/overlays/haskell-nix-extra/default.nix
@@ -3,6 +3,22 @@ let
   index-state = "2021-12-13T00:00:00Z";
 in final: prev: with final; with lib; {
 
+  haskell-nix = recursiveUpdate prev.haskell-nix {
+    # TODO: remove this haskellLib.extra
+    haskellLib.extra = rec {
+      collectChecks =
+        trace ( "Warning: `haskell-nix.haskellLib.extra.collectChecks`"
+              + " is deprecated and will be removed. Please use"
+              + " `haskell-nix.haskellLib.collectChecks'`.")
+        haskell-nix.haskellLib.collectChecks';
+         
+      recRecurseIntoAttrs = x:
+        if (isAttrs x && !isDerivation x && x.recurseForDerivations or true)
+        then recurseIntoAttrs (mapAttrs (n: v: if n == "buildPackages" then v else recRecurseIntoAttrs v) x)
+        else x;
+    };
+  };
+  
   stackNixRegenerate = pkgs.callPackage ./nix-tools-regenerate.nix {
     nix-tools = haskell-nix.nix-tools.${compiler-nix-name};
   };


### PR DESCRIPTION
partially reverts #525

It's still used in surprisingly many places :(

https://github.com/search?q=org%3Ainput-output-hk+%22recRecurseIntoAttrs%22&type=code