### PR TITLE
Iquerejeta/include blst

### DIFF
--- a/overlays/crypto/blst.nix
+++ b/overlays/crypto/blst.nix
@@ -12,10 +12,8 @@ stdenv.mkDerivation rec {
 
   installPhase = ''
     ./build.sh
-    mkdir -p $out/bin
-    cp ./libblst.a $out/bin/libblst.a
-    chmod +x $out/bin/libblst.a
-    ls $out/bin/
+    mkdir -p $out/lib
+    cp ./libblst.a $out/lib/libblst.a
   '';
 
   enableParallelBuilding = true;

--- a/overlays/crypto/blst.nix
+++ b/overlays/crypto/blst.nix
@@ -11,10 +11,11 @@ stdenv.mkDerivation rec {
   };
 
   installPhase = ''
-    mkdir $out
     ./build.sh
-    install ./libblst.a /usr/local/lib/
-    cp bindings/*.h /usr/local/include/
+    mkdir -p $out/bin
+    cp ./libblst.a $out/bin/libblst.a
+    chmod +x $out/bin/libblst.a
+    ls $out/bin/
   '';
 
   enableParallelBuilding = true;

--- a/overlays/crypto/blst.nix
+++ b/overlays/crypto/blst.nix
@@ -10,10 +10,10 @@ stdenv.mkDerivation rec {
     sha256 = "01m28xxmm1x7riwyax7v9rycwl5isi06h2b2hl4gxnnylkayisn5";
   };
 
+  buildPhase = "./build.sh";
   installPhase = ''
-    ./build.sh
     mkdir -p $out/lib
-    cp ./libblst.a $out/lib/libblst.a
+    cp ./libblst.a $out/lib/
   '';
 
   enableParallelBuilding = true;

--- a/overlays/crypto/blst.nix
+++ b/overlays/crypto/blst.nix
@@ -1,0 +1,28 @@
+{ stdenv, lib, fetchFromGitHub, autoreconfHook }:
+
+stdenv.mkDerivation rec {
+  name = "blst-0.3.10";
+
+  src = fetchFromGitHub {
+    owner = "supranational";
+    repo = "blst";
+    rev = "03b5124029979755c752eec45f3c29674b558446";
+    sha256 = "01m28xxmm1x7riwyax7v9rycwl5isi06h2b2hl4gxnnylkayisn5";
+  };
+
+  installPhase = ''
+    mkdir $out
+    ./build.sh
+  '';
+
+  enableParallelBuilding = true;
+
+  doCheck = true;
+
+  meta = with lib; {
+    description = "Multilingual BLS12-381 signature library";
+    homepage = "https://github.com/supranational/blst";
+    license = licenses.isc;
+    platforms = platforms.all;
+  };
+}

--- a/overlays/crypto/blst.nix
+++ b/overlays/crypto/blst.nix
@@ -13,6 +13,8 @@ stdenv.mkDerivation rec {
   installPhase = ''
     mkdir $out
     ./build.sh
+    install ./libblst.a /usr/local/lib/
+    cp bindings/*.h /usr/local/include/
   '';
 
   enableParallelBuilding = true;

--- a/overlays/crypto/default.nix
+++ b/overlays/crypto/default.nix
@@ -1,3 +1,4 @@
 final: prev: {
   libsodium-vrf = final.callPackage ./libsodium.nix {};
+  blst = final.callPackage ./blst.nix {};
 }


### PR DESCRIPTION
Include the BLST library as part of iohk-nix. This is required for the effort of including BLS12-381 operations in plutus: 
* https://github.com/input-output-hk/cardano-base/pull/266