### PR TITLE
#5222 Remove ApplicationName and ApplicationVersion config parameters

### DIFF
--- a/cardano-lib/mainnet-config.nix
+++ b/cardano-lib/mainnet-config.nix
@@ -35,9 +35,4 @@
   LastKnownBlockVersion-Major = 3;
   LastKnownBlockVersion-Minor = 0;
   LastKnownBlockVersion-Alt = 0;
-
-  # In the Byron era some software versions are also published on the chain.
-  # We do this only for Byron compatibility now.
-  ApplicationName = "cardano-sl";
-  ApplicationVersion = 1;
 }

--- a/cardano-lib/p2p-config.nix
+++ b/cardano-lib/p2p-config.nix
@@ -49,9 +49,4 @@
   LastKnownBlockVersion-Major = 3;
   LastKnownBlockVersion-Minor = 1;
   LastKnownBlockVersion-Alt = 0;
-
-  # In the Byron era some software versions are also published on the chain.
-  # We do this only for Byron compatibility now.
-  ApplicationName = "cardano-sl";
-  ApplicationVersion = 0;
 }

--- a/cardano-lib/preprod-config.nix
+++ b/cardano-lib/preprod-config.nix
@@ -37,9 +37,4 @@
   LastKnownBlockVersion-Major = 2;
   LastKnownBlockVersion-Minor = 0;
   LastKnownBlockVersion-Alt = 0;
-
-  # In the Byron era some software versions are also published on the chain.
-  # We do this only for Byron compatibility now.
-  ApplicationName = "cardano-sl";
-  ApplicationVersion = 0;
 }

--- a/cardano-lib/preview-config.nix
+++ b/cardano-lib/preview-config.nix
@@ -33,7 +33,4 @@
   LastKnownBlockVersion-Major = 3;
   LastKnownBlockVersion-Minor = 1;
   LastKnownBlockVersion-Alt = 0;
-
-  ApplicationName = "cardano-sl";
-  ApplicationVersion = 0;
 }

--- a/cardano-lib/shelley_qa-config.nix
+++ b/cardano-lib/shelley_qa-config.nix
@@ -41,9 +41,4 @@
   LastKnownBlockVersion-Major = 3;
   LastKnownBlockVersion-Minor = 1;
   LastKnownBlockVersion-Alt = 0;
-
-  # In the Byron era some software versions are also published on the chain.
-  # We do this only for Byron compatibility now.
-  ApplicationName = "cardano-sl";
-  ApplicationVersion = 0;
 }

--- a/cardano-lib/testnet-config.nix
+++ b/cardano-lib/testnet-config.nix
@@ -35,9 +35,4 @@
   LastKnownBlockVersion-Major = 3;
   LastKnownBlockVersion-Minor = 0;
   LastKnownBlockVersion-Alt = 0;
-
-  # In the Byron era some software versions are also published on the chain.
-  # We do this only for Byron compatibility now.
-  ApplicationName = "cardano-sl";
-  ApplicationVersion = 0;
 }


### PR DESCRIPTION
This is a part of: https://github.com/input-output-hk/cardano-node/issues/5222
This is a prerequisite of https://github.com/input-output-hk/cardano-node/pull/5240 - a removal of ``ApplicationName` and `ApplicationVersion` parameters, which are getting removed from the `cardano-node` configuration.