### PR TITLE
Update Debian package with epoch 0

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -57,7 +57,7 @@
       mkDebianPkg = prefix: drv: let
         control = pkgs.writeText "control" ''
         Package: ${drv.pname}
-        Version: ${if drv.version == "unstable-2022-02-06" then "2022-02-06-unstable" else drv.version}
+        Version: 0:${drv.version}
         Architecture: amd64
         Maintainer: IOG <engineering@iog.io>
         Description: ${drv.meta.description}


### PR DESCRIPTION
The `Version` field needs to start with a digit. The `Version` format is `[epoch:]upstream_version[-debian_revision]`, as per [Control files and their fields/List of fields/Version](https://www.debian.org/doc/debian-policy/ch-controlfields.html#version)

For Epoch we have
> This is a single (generally small) unsigned integer. It may be omitted, in which case zero is assumed. [...]

hence 0 seems the default anyway.