### PR TITLE
move haskell-nix stuff out of crypto overlay

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -4,7 +4,7 @@
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs?ref=release-22.11";
 
-    # WARNING: If upstream libsodium version is updated, make sure ed25519's 
+    # WARNING: If upstream libsodium version is updated, make sure ed25519's
     # verification criteria has not changed. See this discussion for more details
     # https://github.com/jedisct1/libsodium/discussions/1260
 
@@ -21,6 +21,7 @@
 
     overlays = {
       crypto = import ./overlays/crypto inputs;
+      haskell-nix-crypto = import ./overlays/haskell-nix-crypto;
       haskell-nix-extra = import ./overlays/haskell-nix-extra;
       cardano-lib = (final: prev: {
         cardanoLib = final.callPackage ./cardano-lib {};

--- a/overlays/crypto/default.nix
+++ b/overlays/crypto/default.nix
@@ -1,4 +1,4 @@
-inputs: final: prev: rec {
+inputs: final: prev: {
   # We pin our own crypto libraries here, so that we have control over
   # the specific revisions we use (assuming a recent enough iohk-nix).
   #
@@ -6,22 +6,10 @@ inputs: final: prev: rec {
   #  flake.nix.  We _do not_ pin the generic libsodium, and rely on
   #  the upstream one provided by what ever nixpkgs pin is used.
   #
-  libsodium-vrf = final.callPackage ./libsodium.nix { inherit inputs; };
-  libblst = final.callPackage ./libblst.nix { inherit inputs; };
-  libsecp256k1 = final.callPackage ./libsecp256k1.nix { inherit inputs; };
-
-  # override the nixpkgs ones which do not have the `lib` prefix.
-  secp256k1 = libsecp256k1;
-}
-# Make these libraries also available to haskell-nix's pkg-config
-# map when solving for dependencies with cabal.
-// prev.lib.optionalAttrs (prev ? haskell-nix) {
-  haskell-nix = prev.haskell-nix // {
-    extraPkgconfigMappings = prev.haskell-nix.extraPkgconfigMappings // {
-      "libblst" = [ "libblst" ];
-      # map libsoidum to our libsodium-vrf, if you include the iohk-nix
-      # crypto overlay, you _do_ want the custom libsoidum.
-      "libsodium" = [ "libsodium-vrf" ];
-    };
-  };
+  libsodium-vrf = final.callPackage ./libsodium.nix { src = inputs.sodium; };
+  libblst = final.callPackage ./libblst.nix { src = inputs.blst; };
+  # we will follow nixpkg upstreams naming scheme where needed. We want to pin
+  # this library, but also don't start dealing with multiple libraries with
+  # different but same names, and then risk that we accidentally diverge.
+  secp256k1 = final.callPackage ./libsecp256k1.nix { src = inputs.secp256k1; };
 }

--- a/overlays/crypto/libblst.nix
+++ b/overlays/crypto/libblst.nix
@@ -1,10 +1,10 @@
-{ stdenv, lib, autoreconfHook, inputs }:
+{ stdenv, lib, autoreconfHook, src }:
 
 stdenv.mkDerivation rec {
   pname = "blst";
-  version = inputs.blst.shortRev;
+  version = src.shortRev;
 
-  src = inputs.blst;
+  inherit src;
 
   buildPhase = ''
     ./build.sh ${lib.optionalString stdenv.targetPlatform.isWindows "flavour=mingw64"}

--- a/overlays/crypto/libsecp256k1.nix
+++ b/overlays/crypto/libsecp256k1.nix
@@ -1,16 +1,19 @@
-{ lib, stdenv, autoreconfHook, inputs }:
+{ lib, stdenv, autoreconfHook, src,
+  enableStatic ? stdenv.hostPlatform.isStatic }:
 
 stdenv.mkDerivation rec {
   pname = "secp256k1";
-  version = inputs.secp256k1.shortRev;
+  version = src.shortRev;
 
-  src = inputs.secp256k1;
+  inherit src;
 
   nativeBuildInputs = [ autoreconfHook ];
 
   configureFlags = [
     "--enable-benchmark=no"
     "--enable-module-recovery"
+  ] ++ lib.optional enableStatic [
+    "--enable-static"
   ];
 
   doCheck = true;

--- a/overlays/crypto/libsodium.nix
+++ b/overlays/crypto/libsodium.nix
@@ -1,10 +1,10 @@
-{ stdenv, lib, autoreconfHook, inputs }:
+{ stdenv, lib, autoreconfHook, src }:
 
 stdenv.mkDerivation rec {
   pname = "libsodium-vrf";
-  version = inputs.sodium.shortRev;
+  version = src.shortRev;
 
-  src = inputs.sodium;
+  inherit src;
 
   nativeBuildInputs = [ autoreconfHook ];
 

--- a/overlays/haskell-nix-crypto/default.nix
+++ b/overlays/haskell-nix-crypto/default.nix
@@ -1,0 +1,16 @@
+# /!\ This overlay depends on both the iohk-nix crypto and the haskell.nix overlays in prev,
+# so must be after them in the list of overlays to nixpkgs.
+final: prev: {
+  # Make libraries from the crypto overlays available to
+  # haskell-nix's pkg-config map when solving for dependencies with cabal.
+  haskell-nix = prev.haskell-nix // {
+    extraPkgconfigMappings = prev.haskell-nix.extraPkgconfigMappings // {
+      "libblst" = [ "libblst" ];
+      # map libsoidum to our libsodium-vrf, if you include the iohk-nix
+      # crypto overlay, you _do_ want the custom libsoidum.
+      "libsodium" = [ "libsodium-vrf" ];
+      # for secp256k1, haskell.nix already has that mapping, thus we don't
+      # need to inject anything extra here.
+    };
+  };
+}


### PR DESCRIPTION
 so that `crypto` can be imported before haskell.nix overlay (though not currently necessary, but could be if we modify nixpkgs in  there in the future), and the new `haskell-nix-crypto` overlay being imported after.