### PR TITLE
cardanoLib: add mithril signer template config (only useful for preview/preprod for now)

### DIFF
--- a/cardano-lib/default.nix
+++ b/cardano-lib/default.nix
@@ -82,7 +82,14 @@ let
     wallet:
       relays: [[{ host: ${relay} }]]
   '';
-  environments = {
+  environments = lib.mapAttrs (name: env: {
+    # default derived configs:
+    nodeConfig = defaultLogConfig // env.networkConfig;
+    consensusProtocol = env.networkConfig.Protocol;
+    submitApiConfig = mkSubmitApiConfig name environments.${name}.nodeConfig;
+    dbSyncConfig = mkDbSyncConfig name environments.${name}.nodeConfig;
+    explorerConfig = mkExplorerConfig name environments.${name}.nodeConfig;
+  } // env) {
     mainnet = rec {
       useByronWallet = true;
       private = false;
@@ -101,11 +108,6 @@ let
       edgePort = 3001;
       confKey = "mainnet_full";
       networkConfig = import ./mainnet-config.nix;
-      nodeConfig = defaultLogConfig // networkConfig;
-      consensusProtocol = networkConfig.Protocol;
-      submitApiConfig = mkSubmitApiConfig "mainnet" nodeConfig;
-      dbSyncConfig = mkDbSyncConfig "mainnet" nodeConfig;
-      explorerConfig = mkExplorerConfig "mainnet" nodeConfig;
       usePeersFromLedgerAfterSlot = 84916732;
     };
 
@@ -121,11 +123,6 @@ let
       edgeNodes = [];
       edgePort = 3001;
       networkConfig = import ./shelley_qa-config.nix;
-      nodeConfig = defaultLogConfig // networkConfig;
-      consensusProtocol = networkConfig.Protocol;
-      submitApiConfig = mkSubmitApiConfig "shelley_qa" nodeConfig;
-      dbSyncConfig = mkDbSyncConfig "shelley_qa" nodeConfig;
-      explorerConfig = mkExplorerConfig "shelley_qa" nodeConfig;
       usePeersFromLedgerAfterSlot = 23574838;
     };
 
@@ -140,11 +137,6 @@ let
       edgeNodes = [];
       edgePort = 3001;
       networkConfig = import ./p2p-config.nix;
-      consensusProtocol = networkConfig.Protocol;
-      nodeConfig = defaultLogConfig // networkConfig;
-      submitApiConfig = mkSubmitApiConfig "p2p" nodeConfig;
-      dbSyncConfig = mkDbSyncConfig "p2p" nodeConfig;
-      explorerConfig = mkExplorerConfig "p2p" nodeConfig;
       usePeersFromLedgerAfterSlot = 14680;
     };
 
@@ -164,11 +156,6 @@ let
       ];
       edgePort = 30000;
       networkConfig = import ./preprod-config.nix;
-      consensusProtocol = networkConfig.Protocol;
-      nodeConfig = defaultLogConfig // networkConfig;
-      submitApiConfig = mkSubmitApiConfig "preprod" nodeConfig;
-      dbSyncConfig = mkDbSyncConfig "preprod" nodeConfig;
-      explorerConfig = mkExplorerConfig "preprod" nodeConfig;
       usePeersFromLedgerAfterSlot = 4642000;
     };
 
@@ -188,11 +175,6 @@ let
       ];
       edgePort = 30002;
       networkConfig = import ./preview-config.nix;
-      consensusProtocol = networkConfig.Protocol;
-      nodeConfig = defaultLogConfig // networkConfig;
-      submitApiConfig = mkSubmitApiConfig "preview" nodeConfig;
-      dbSyncConfig = mkDbSyncConfig "preview" nodeConfig;
-      explorerConfig = mkExplorerConfig "preview" nodeConfig;
       usePeersFromLedgerAfterSlot = 322000;
     };
 
@@ -212,11 +194,6 @@ let
       ];
       edgePort = 30004;
       networkConfig = import ./sanchonet-config.nix;
-      consensusProtocol = networkConfig.Protocol;
-      nodeConfig = defaultLogConfig // networkConfig;
-      submitApiConfig = mkSubmitApiConfig "sanchonet" nodeConfig;
-      dbSyncConfig = mkDbSyncConfig "sanchonet" nodeConfig;
-      explorerConfig = mkExplorerConfig "sanchonet" nodeConfig;
       usePeersFromLedgerAfterSlot = 32000;
     };
 
@@ -236,11 +213,6 @@ let
       ];
       edgePort = 30007;
       networkConfig = import ./private-config.nix;
-      consensusProtocol = networkConfig.Protocol;
-      nodeConfig = defaultLogConfig // networkConfig;
-      submitApiConfig = mkSubmitApiConfig "private" nodeConfig;
-      dbSyncConfig = mkDbSyncConfig "private" nodeConfig;
-      explorerConfig = mkExplorerConfig "private" nodeConfig;
       usePeersFromLedgerAfterSlot = 32000;
     };
   };


### PR DESCRIPTION
First commit is a small refactoring to get ride of some boilerplate.

Second commit add generation of `preprod-mithril-signer-config.json`:
```json
{
  "aggregator_endpoint": "https://aggregator.release-preprod.api.mithril.network/aggregator",
  "era_reader_adapter_params": "{\"address\":\"addr_test1qpkyv2ws0deszm67t840sdnruqgr492n80g3y96xw3p2ksk6suj5musy6w8lsg3yjd09cnpgctc2qh386rtxphxt248qr0npnx\",\"verification_key\":\"5b35352c3232382c3134342c38372c3133382c3133362c34382c382c31342c3138372c38352c3134382c39372c3233322c3235352c3232392c33382c3234342c3234372c3230342c3139382c31332c33312c3232322c32352c3136342c35322c3130322c39312c3132302c3230382c3134375d\"}",
  "era_reader_adapter_type": "cardano-chain",
  "network": "preprod",
  "network_magic": 1,
  "run_interval": 60000,
  "store_retention_limit": 5
}
```
and `preview-mithril-signer-config.json`:
```json
{
  "aggregator_endpoint": "https://aggregator.pre-release-preview.api.mithril.network/aggregator",
  "era_reader_adapter_params": "{\"address\":\"addr_test1qrv5xfwh043mlc3vk5d97s4nmhxu7cmleyssvhx37gkfyejfe8d38v3vsfgetjafgrsdc49krug8wf04h5rmtengtejqlxrksk\",\"verification_key\":\"5b35352c3232382c3134342c38372c3133382c3133362c34382c382c31342c3138372c38352c3134382c39372c3233322c3235352c3232392c33382c3234342c3234372c3230342c3139382c31332c33312c3232322c32352c3136342c35322c3130322c39312c3132302c3230382c3134375d\"}",
  "era_reader_adapter_type": "cardano-chain",
  "network": "preview",
  "network_magic": 2,
  "run_interval": 60000,
  "store_retention_limit": 5
}
```
(cf. https://ci.iog.io/build/57119/download/1/index.html)