### PR TITLE
The compiled code will need to run on hostPlatform

### DIFF
--- a/overlays/crypto/libblst.nix
+++ b/overlays/crypto/libblst.nix
@@ -7,9 +7,9 @@ stdenv.mkDerivation rec {
   inherit src;
 
   buildPhase = ''
-    ./build.sh ${lib.optionalString stdenv.targetPlatform.isWindows "flavour=mingw64"}
+    ./build.sh ${lib.optionalString stdenv.hostPlatform.isWindows "flavour=mingw64"}
   '' + ''
-    ./build.sh -shared ${lib.optionalString stdenv.targetPlatform.isWindows "flavour=mingw64"}
+    ./build.sh -shared ${lib.optionalString stdenv.hostPlatform.isWindows "flavour=mingw64"}
   '';
   installPhase = ''
     mkdir -p $out/{lib,include}


### PR DESCRIPTION
I admit I am a dog at cross-compilation but the nixpkgs manual says

> The "host platform" is the platform on which a package will be run. This is the simplest platform to understand, but also the one with the worst name.

When we:

- build blst
- as part of a linux build tool
- that is needed to compile something for mingw64

then blst gets configured with `./build.sh flavour=mingw64\n./build.sh -shared flavour=mingw64` while it's actually built on linux and for linux (where the build tool will run).

Using hostPlatform seems to make this work ok.