### PR TITLE
Order independent haskell-nix-crypto overlay

### DIFF
--- a/overlays/haskell-nix-crypto/default.nix
+++ b/overlays/haskell-nix-crypto/default.nix
@@ -3,8 +3,8 @@
 final: prev: {
   # Make libraries from the crypto overlays available to
   # haskell-nix's pkg-config map when solving for dependencies with cabal.
-  haskell-nix = prev.haskell-nix // {
-    extraPkgconfigMappings = prev.haskell-nix.extraPkgconfigMappings // {
+  haskell-nix = prev.haskell-nix or {} // {
+    extraPkgconfigMappings = prev.haskell-nix.extraPkgconfigMappings or {} // {
       "libblst" = [ "libblst" ];
       # map libsoidum to our libsodium-vrf, if you include the iohk-nix
       # crypto overlay, you _do_ want the custom libsoidum.


### PR DESCRIPTION
Take advantage of https://github.com/input-output-hk/haskell.nix/pull/2043 to allow the haskell-nix-crypto overlay to come before or after the haskell.nix overlays.