### PR TITLE
libblst respect enableShared = false also on darwin

### DIFF
--- a/overlays/crypto/libblst.nix
+++ b/overlays/crypto/libblst.nix
@@ -49,7 +49,7 @@ stdenv.mkDerivation rec {
   # wouldn't be found during install.  The alternative would be to work
   # lib.optional stdenv.isDarwin "LDFLAGS=-Wl,-install_name,$(out)/lib/libblst.dylib";
   # into the setup.sh
-  postFixup = lib.optionalString stdenv.isDarwin ''
+  postFixup = lib.optionalString (stdenv.isDarwin && enableShared) ''
     install_name_tool -id $out/lib/libblst.dylib $out/lib/libblst.dylib
   '';
 


### PR DESCRIPTION
Currently we expect the dylib to be there irrespective of enableShared or not. However if enableShared = false, this file does not exist, and it will fail to build.