### PR TITLE
Bump libblst to v0.3.11

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3,17 +3,17 @@
     "blst": {
       "flake": false,
       "locked": {
-        "lastModified": 1656163412,
-        "narHash": "sha256-xero1aTe2v4IhWIJaEDUsVDOfE77dOV5zKeHWntHogY=",
+        "lastModified": 1691598027,
+        "narHash": "sha256-oqljy+ZXJAXEB/fJtmB8rlAr4UXM+Z2OkDa20gpILNA=",
         "owner": "supranational",
         "repo": "blst",
-        "rev": "03b5124029979755c752eec45f3c29674b558446",
+        "rev": "3dd0f804b1819e5d03fb22ca2e6fac105932043a",
         "type": "github"
       },
       "original": {
         "owner": "supranational",
+        "ref": "v0.3.11",
         "repo": "blst",
-        "rev": "03b5124029979755c752eec45f3c29674b558446",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -12,7 +12,7 @@
     # nix flake lock --update-input <sodium|secp256k1|blst>
     sodium = { url = "github:input-output-hk/libsodium?rev=dbb48cce5429cb6585c9034f002568964f1ce567"; flake = false; };
     secp256k1 = { url = "github:bitcoin-core/secp256k1?ref=v0.3.2"; flake = false; };
-    blst = { url = "github:supranational/blst?rev=03b5124029979755c752eec45f3c29674b558446"; flake = false; };
+    blst = { url = "github:supranational/blst?ref=v0.3.11"; flake = false; };
   };
 
   outputs = { self, nixpkgs, ... }@inputs: rec {

--- a/overlays/crypto/libblst.nix
+++ b/overlays/crypto/libblst.nix
@@ -6,10 +6,14 @@ stdenv.mkDerivation rec {
 
   inherit src;
 
+  # note on -D__BLST_PORTABLE__, this should allow us to have MULX, and similar
+  # stuff run-time detected, and as such blst built on newer hardware should still
+  # work on older. Notably Intel before Broadwell, and AMD before Ryzen, do not
+  # support ADX, which means they lack MULX support, which blst uses.
   buildPhase = ''
-    ./build.sh ${lib.optionalString stdenv.hostPlatform.isWindows "flavour=mingw64"}
+    ./build.sh -D__BLST_PORTABLE__ ${lib.optionalString stdenv.hostPlatform.isWindows "flavour=mingw64"}
   '' + lib.optionalString enableShared ''
-    ./build.sh -shared ${lib.optionalString stdenv.hostPlatform.isWindows "flavour=mingw64"}
+    ./build.sh -D__BLST_PORTABLE__ -shared ${lib.optionalString stdenv.hostPlatform.isWindows "flavour=mingw64"}
   '';
   installPhase = ''
     mkdir -p $out/{lib,include}


### PR DESCRIPTION
We now also set `-D__BLST_PORTABLE__` during the build.