### PR TITLE
Node config bp

### DIFF
--- a/cardano-lib/default.nix
+++ b/cardano-lib/default.nix
@@ -114,6 +114,14 @@ let
     wallet:
       relays: [[{ host: ${relay} }]]
   '';
+
+  # Changes to minimum required node version typically occur with changes to
+  # genesis files across all networks at once.  This defn will be applied to
+  # all networks by default but can be overridden on a per network basis below
+  # as needed.  Any node version string suffixes, such as `-pre`, should be
+  # removed from this string identifier.
+  minNodeVersion = { MinNodeVersion = "8.10.0"; };
+
   environments = lib.mapAttrs (name: env: {
     inherit name;
     # default derived configs:
@@ -156,8 +164,8 @@ let
       ];
       edgePort = 3001;
       confKey = "mainnet_full";
-      networkConfig = import ./mainnet-config.nix;
-      networkConfigBp = import ./mainnet-config-bp.nix;
+      networkConfig = import ./mainnet-config.nix // minNodeVersion;
+      networkConfigBp = import ./mainnet-config-bp.nix // minNodeVersion;
       usePeersFromLedgerAfterSlot = 116812831;
     };
 
@@ -177,8 +185,8 @@ let
         }
       ];
       edgePort = 3001;
-      networkConfig = import ./shelley_qa-config.nix;
-      networkConfigBp = import ./shelley_qa-config-bp.nix;
+      networkConfig = import ./shelley_qa-config.nix // minNodeVersion;
+      networkConfigBp = import ./shelley_qa-config-bp.nix // minNodeVersion;
       usePeersFromLedgerAfterSlot = 19252750;
     };
 
@@ -203,8 +211,8 @@ let
         }
       ];
       edgePort = 3001;
-      networkConfig = import ./preprod-config.nix;
-      networkConfigBp = import ./preprod-config-bp.nix;
+      networkConfig = import ./preprod-config.nix // minNodeVersion;
+      networkConfigBp = import ./preprod-config-bp.nix // minNodeVersion;
       usePeersFromLedgerAfterSlot = 52358331;
     };
 
@@ -229,8 +237,8 @@ let
         }
       ];
       edgePort = 3001;
-      networkConfig = import ./preview-config.nix;
-      networkConfigBp = import ./preview-config-bp.nix;
+      networkConfig = import ./preview-config.nix // minNodeVersion;
+      networkConfigBp = import ./preview-config-bp.nix // minNodeVersion;
       usePeersFromLedgerAfterSlot = 41385503;
     };
 
@@ -255,8 +263,8 @@ let
         }
       ];
       edgePort = 3001;
-      networkConfig = import ./sanchonet-config.nix;
-      networkConfigBp = import ./sanchonet-config-bp.nix;
+      networkConfig = import ./sanchonet-config.nix // minNodeVersion;
+      networkConfigBp = import ./sanchonet-config-bp.nix // minNodeVersion;
       usePeersFromLedgerAfterSlot = 21599922;
     };
 
@@ -275,8 +283,8 @@ let
         }
       ];
       edgePort = 3001;
-      networkConfig = import ./private-config.nix;
-      networkConfigBp = import ./private-config-bp.nix;
+      networkConfig = import ./private-config.nix // minNodeVersion;
+      networkConfigBp = import ./private-config-bp.nix // minNodeVersion;
       usePeersFromLedgerAfterSlot = 10007987;
     };
   };
@@ -295,8 +303,8 @@ let
       edgeNodes = [];
       edgePort = 3001;
       confKey = "testnet_full";
-      networkConfig = import ./testnet-config.nix;
-      networkConfigBp = import ./testnet-config-bp.nix;
+      networkConfig = import ./testnet-config.nix // minNodeVersion;
+      networkConfigBp = import ./testnet-config-bp.nix // minNodeVersion;
       consensusProtocol = networkConfig.Protocol;
       nodeConfig = defaultLogConfig // networkConfig;
       nodeConfigBp = defaultLogConfig // networkConfigBp;

--- a/cardano-lib/mainnet-config-bp.nix
+++ b/cardano-lib/mainnet-config-bp.nix
@@ -1,0 +1,45 @@
+##########################################################
+#######                  Mainnet                  ########
+####### Cardano Node Block Producer Configuration ########
+##########################################################
+
+{
+  ##### Locations #####
+
+  ByronGenesisFile = ./mainnet + "/byron-genesis.json";
+  ByronGenesisHash = "5f20df933584822601f9e3f8c024eb5eb252fe8cefb24d1317dc3d432e940ebb";
+  ShelleyGenesisFile = ./mainnet + "/shelley-genesis.json";
+  ShelleyGenesisHash = "1a3be38bcbb7911969283716ad7aa550250226b76a61fc51cc9a9a35d9276d81";
+  AlonzoGenesisFile = ./mainnet + "/alonzo-genesis.json";
+  AlonzoGenesisHash = "7e94a15f55d1e82d10f09203fa1d40f8eede58fd8066542cf6566008068ed874";
+  ConwayGenesisFile = ./mainnet + "/conway-genesis.json";
+  ConwayGenesisHash = "49ef010ff0d13b090893a919bbc22022038a8b782faa0b1561a256b781672174";
+
+  ##### Core protocol parameters #####
+
+  # This is the instance of the Ouroboros family that we are running.
+  # The node also supports various test and mock instances.
+  # "RealPBFT" is the real (ie not mock) (permissive) OBFT protocol, which
+  # is what we use on mainnet in Byron era.
+  Protocol = "Cardano";
+
+  # The mainnet does not include the network magic into addresses. Testnets do.
+  RequiresNetworkMagic = "RequiresNoMagic";
+  EnableP2P = true;
+  PeerSharing = false;
+  TargetNumberOfActivePeers = 20;
+  TargetNumberOfEstablishedPeers = 50;
+  TargetNumberOfKnownPeers = 100;
+  TargetNumberOfRootPeers = 100;
+  TraceMempool = false;
+
+  MaxKnownMajorProtocolVersion = 2;
+
+  ##### Update system parameters #####
+
+  # This protocol version number gets used by block producing nodes as part
+  # part of the system for agreeing on and synchronising protocol updates.
+  LastKnownBlockVersion-Major = 3;
+  LastKnownBlockVersion-Minor = 0;
+  LastKnownBlockVersion-Alt = 0;
+}

--- a/cardano-lib/mainnet-config.nix
+++ b/cardano-lib/mainnet-config.nix
@@ -26,10 +26,11 @@
   # The mainnet does not include the network magic into addresses. Testnets do.
   RequiresNetworkMagic = "RequiresNoMagic";
   EnableP2P = true;
+  PeerSharing = true;
   TargetNumberOfActivePeers = 20;
   TargetNumberOfEstablishedPeers = 50;
   TargetNumberOfKnownPeers = 100;
-  TargetNumberOfRootPeers = 100;
+  TargetNumberOfRootPeers = 60;
   TraceMempool = false;
 
   MaxKnownMajorProtocolVersion = 2;

--- a/cardano-lib/preprod-config-bp.nix
+++ b/cardano-lib/preprod-config-bp.nix
@@ -1,0 +1,42 @@
+##########################################################
+#######                  Preprod                  ########
+####### Cardano Node Block Producer Configuration ########
+##########################################################
+
+{
+  ##### Locations #####
+
+  ByronGenesisFile = ./preprod + "/byron-genesis.json";
+  ByronGenesisHash = "d4b8de7a11d929a323373cbab6c1a9bdc931beffff11db111cf9d57356ee1937";
+  ShelleyGenesisFile = ./preprod + "/shelley-genesis.json";
+  ShelleyGenesisHash = "162d29c4e1cf6b8a84f2d692e67a3ac6bc7851bc3e6e4afe64d15778bed8bd86";
+  AlonzoGenesisFile = ./preprod + "/alonzo-genesis.json";
+  AlonzoGenesisHash = "7e94a15f55d1e82d10f09203fa1d40f8eede58fd8066542cf6566008068ed874";
+  ConwayGenesisFile = ./preprod + "/conway-genesis.json";
+  ConwayGenesisHash = "49ef010ff0d13b090893a919bbc22022038a8b782faa0b1561a256b781672174";
+
+  ##### Core protocol parameters #####
+
+  # This is the instance of the Ouroboros family that we are running.
+  # The node also supports various test and mock instances.
+  # "RealPBFT" is the real (ie not mock) (permissive) OBFT protocol, which
+  # is what we use on mainnet in Byron era.
+  Protocol = "Cardano";
+
+  # The mainnet does not include the network magic into addresses. Testnets do.
+  RequiresNetworkMagic = "RequiresMagic";
+  EnableP2P = true;
+  PeerSharing = false;
+  TargetNumberOfActivePeers = 20;
+  TargetNumberOfEstablishedPeers = 50;
+  TargetNumberOfKnownPeers = 100;
+  TargetNumberOfRootPeers = 100;
+
+  ##### Update system parameters #####
+
+  # This protocol version number gets used by block producing nodes as part
+  # part of the system for agreeing on and synchronising protocol updates.
+  LastKnownBlockVersion-Major = 2;
+  LastKnownBlockVersion-Minor = 0;
+  LastKnownBlockVersion-Alt = 0;
+}

--- a/cardano-lib/preprod-config.nix
+++ b/cardano-lib/preprod-config.nix
@@ -26,10 +26,11 @@
   # The mainnet does not include the network magic into addresses. Testnets do.
   RequiresNetworkMagic = "RequiresMagic";
   EnableP2P = true;
+  PeerSharing = true;
   TargetNumberOfActivePeers = 20;
   TargetNumberOfEstablishedPeers = 50;
   TargetNumberOfKnownPeers = 100;
-  TargetNumberOfRootPeers = 100;
+  TargetNumberOfRootPeers = 60;
 
   ##### Update system parameters #####
 

--- a/cardano-lib/preview-config-bp.nix
+++ b/cardano-lib/preview-config-bp.nix
@@ -1,0 +1,39 @@
+##########################################################
+#######                  Preview                  ########
+####### Cardano Node Block Producer Configuration ########
+##########################################################
+
+{
+  ##### Locations #####
+
+  ByronGenesisFile = ./preview + "/byron-genesis.json";
+  ByronGenesisHash = "83de1d7302569ad56cf9139a41e2e11346d4cb4a31c00142557b6ab3fa550761";
+  ShelleyGenesisFile = ./preview + "/shelley-genesis.json";
+  ShelleyGenesisHash = "363498d1024f84bb39d3fa9593ce391483cb40d479b87233f868d6e57c3a400d";
+  AlonzoGenesisFile = ./preview + "/alonzo-genesis.json";
+  AlonzoGenesisHash = "7e94a15f55d1e82d10f09203fa1d40f8eede58fd8066542cf6566008068ed874";
+  ConwayGenesisFile = ./preview + "/conway-genesis.json";
+  ConwayGenesisHash = "49ef010ff0d13b090893a919bbc22022038a8b782faa0b1561a256b781672174";
+
+  ### Core protocol parameters #####
+  Protocol = "Cardano";
+  RequiresNetworkMagic = "RequiresMagic";
+  EnableP2P = true;
+  PeerSharing = false;
+  TargetNumberOfActivePeers = 20;
+  TargetNumberOfEstablishedPeers = 50;
+  TargetNumberOfKnownPeers = 100;
+  TargetNumberOfRootPeers = 100;
+  ExperimentalHardForksEnabled = false;
+  ExperimentalProtocolsEnabled = false;
+  TestShelleyHardForkAtEpoch = 0;
+  TestAllegraHardForkAtEpoch = 0;
+  TestAlonzoHardForkAtEpoch = 0;
+  TestMaryHardForkAtEpoch = 0;
+
+  ##### Update system Parameters #####
+
+  LastKnownBlockVersion-Major = 3;
+  LastKnownBlockVersion-Minor = 1;
+  LastKnownBlockVersion-Alt = 0;
+}

--- a/cardano-lib/preview-config.nix
+++ b/cardano-lib/preview-config.nix
@@ -19,10 +19,11 @@
   Protocol = "Cardano";
   RequiresNetworkMagic = "RequiresMagic";
   EnableP2P = true;
+  PeerSharing = true;
   TargetNumberOfActivePeers = 20;
   TargetNumberOfEstablishedPeers = 50;
   TargetNumberOfKnownPeers = 100;
-  TargetNumberOfRootPeers = 100;
+  TargetNumberOfRootPeers = 60;
   ExperimentalHardForksEnabled = false;
   ExperimentalProtocolsEnabled = false;
   TestShelleyHardForkAtEpoch = 0;

--- a/cardano-lib/private-config-bp.nix
+++ b/cardano-lib/private-config-bp.nix
@@ -1,0 +1,38 @@
+##########################################################
+#######                  Private                  ########
+####### Cardano Node Block Producer Configuration ########
+##########################################################
+
+{
+  ##### Locations #####
+
+  ByronGenesisFile = ./private + "/byron-genesis.json";
+  ByronGenesisHash = "1c49093e43757a7f5d55791ee8682d2681e7a291b10dadc663ac1889b3f16984";
+  ShelleyGenesisFile = ./private + "/shelley-genesis.json";
+  ShelleyGenesisHash = "136177de30fc5d431cc80f5789089486c13629e589dd705aa4254f765a84582b";
+  AlonzoGenesisFile = ./private + "/alonzo-genesis.json";
+  AlonzoGenesisHash = "8bedcaea62107d8a79ed5293b0027b3f8706a4bc2422f33380cb1fd01c6fa6ec";
+  ConwayGenesisFile = ./private + "/conway-genesis.json";
+  ConwayGenesisHash = "62f6efbb658ae8725aefc535aaae82a36f2634c1a01ec6994b22d6fd19639beb";
+
+  ### Core protocol parameters #####
+  Protocol = "Cardano";
+  RequiresNetworkMagic = "RequiresMagic";
+  EnableP2P = true;
+  PeerSharing = false;
+  TargetNumberOfActivePeers = 20;
+  TargetNumberOfEstablishedPeers = 50;
+  TargetNumberOfKnownPeers = 100;
+  TargetNumberOfRootPeers = 100;
+  ExperimentalHardForksEnabled = true;
+  ExperimentalProtocolsEnabled = true;
+  TestShelleyHardForkAtEpoch = 0;
+  TestAllegraHardForkAtEpoch = 0;
+  TestAlonzoHardForkAtEpoch = 0;
+  TestMaryHardForkAtEpoch = 0;
+
+  ##### Update system Parameters #####
+  LastKnownBlockVersion-Major = 3;
+  LastKnownBlockVersion-Minor = 1;
+  LastKnownBlockVersion-Alt = 0;
+}

--- a/cardano-lib/private-config.nix
+++ b/cardano-lib/private-config.nix
@@ -19,10 +19,11 @@
   Protocol = "Cardano";
   RequiresNetworkMagic = "RequiresMagic";
   EnableP2P = true;
+  PeerSharing = true;
   TargetNumberOfActivePeers = 20;
   TargetNumberOfEstablishedPeers = 50;
   TargetNumberOfKnownPeers = 100;
-  TargetNumberOfRootPeers = 100;
+  TargetNumberOfRootPeers = 60;
   ExperimentalHardForksEnabled = true;
   ExperimentalProtocolsEnabled = true;
   TestShelleyHardForkAtEpoch = 0;

--- a/cardano-lib/sanchonet-config-bp.nix
+++ b/cardano-lib/sanchonet-config-bp.nix
@@ -1,0 +1,39 @@
+##########################################################
+#######                 Sanchonet                 ########
+####### Cardano Node Block Producer Configuration ########
+##########################################################
+
+{
+  ##### Locations #####
+
+  ByronGenesisFile = ./sanchonet + "/byron-genesis.json";
+  ByronGenesisHash = "785eb88427e136378a15b0a152a8bfbeec7a611529ccda29c43a1e60ffb48eaa";
+  ShelleyGenesisFile = ./sanchonet + "/shelley-genesis.json";
+  ShelleyGenesisHash = "f94457ec45a0c6773057a529533cf7ccf746cb44dabd56ae970e1dbfb55bfdb2";
+  AlonzoGenesisFile = ./sanchonet + "/alonzo-genesis.json";
+  AlonzoGenesisHash = "8bedcaea62107d8a79ed5293b0027b3f8706a4bc2422f33380cb1fd01c6fa6ec";
+  ConwayGenesisFile = ./sanchonet + "/conway-genesis.json";
+  ConwayGenesisHash = "49ef010ff0d13b090893a919bbc22022038a8b782faa0b1561a256b781672174";
+
+  ### Core protocol parameters #####
+  Protocol = "Cardano";
+  RequiresNetworkMagic = "RequiresMagic";
+  EnableP2P = true;
+  PeerSharing = false;
+  TargetNumberOfActivePeers = 20;
+  TargetNumberOfEstablishedPeers = 50;
+  TargetNumberOfKnownPeers = 100;
+  TargetNumberOfRootPeers = 100;
+  ExperimentalHardForksEnabled = true;
+  ExperimentalProtocolsEnabled = true;
+  TestShelleyHardForkAtEpoch = 0;
+  TestAllegraHardForkAtEpoch = 0;
+  TestAlonzoHardForkAtEpoch = 0;
+  TestMaryHardForkAtEpoch = 0;
+
+  ##### Update system Parameters #####
+
+  LastKnownBlockVersion-Major = 3;
+  LastKnownBlockVersion-Minor = 1;
+  LastKnownBlockVersion-Alt = 0;
+}

--- a/cardano-lib/sanchonet-config.nix
+++ b/cardano-lib/sanchonet-config.nix
@@ -19,10 +19,11 @@
   Protocol = "Cardano";
   RequiresNetworkMagic = "RequiresMagic";
   EnableP2P = true;
+  PeerSharing = true;
   TargetNumberOfActivePeers = 20;
   TargetNumberOfEstablishedPeers = 50;
   TargetNumberOfKnownPeers = 100;
-  TargetNumberOfRootPeers = 100;
+  TargetNumberOfRootPeers = 60;
   ExperimentalHardForksEnabled = true;
   ExperimentalProtocolsEnabled = true;
   TestShelleyHardForkAtEpoch = 0;

--- a/cardano-lib/shelley_qa-config-bp.nix
+++ b/cardano-lib/shelley_qa-config-bp.nix
@@ -1,0 +1,42 @@
+##########################################################
+#######                 Shelley QA                ########
+####### Cardano Node Block Producer Configuration ########
+##########################################################
+
+{
+  ##### Locations #####
+
+  ByronGenesisFile = ./shelley_qa + "/byron-genesis.json";
+  ByronGenesisHash = "273cd12237b98d02f108c9c50063d29a8d1d7f32e9a75ade7cd48e08b3070258";
+  ShelleyGenesisFile = ./shelley_qa + "/shelley-genesis.json";
+  ShelleyGenesisHash = "73a9f6bdb0aa97f5e63190a6f14a702bd64a21f2bec831cbfc28f6037128b952";
+  AlonzoGenesisFile = ./shelley_qa + "/alonzo-genesis.json";
+  AlonzoGenesisHash = "8bedcaea62107d8a79ed5293b0027b3f8706a4bc2422f33380cb1fd01c6fa6ec";
+  ConwayGenesisFile = ./shelley_qa + "/conway-genesis.json";
+  ConwayGenesisHash = "49ef010ff0d13b090893a919bbc22022038a8b782faa0b1561a256b781672174";
+
+  ##### Core protocol parameters #####
+  Protocol = "Cardano";
+  RequiresNetworkMagic = "RequiresMagic";
+  EnableP2P = true;
+  PeerSharing = false;
+  TargetNumberOfActivePeers = 20;
+  TargetNumberOfEstablishedPeers = 50;
+  TargetNumberOfKnownPeers = 100;
+  TargetNumberOfRootPeers = 100;
+  ExperimentalHardForksEnabled = true;
+  ExperimentalProtocolsEnabled = true;
+  TestShelleyHardForkAtEpoch = 0;
+  TestAllegraHardForkAtEpoch = 0;
+  TestAlonzoHardForkAtEpoch = 0;
+  TestMaryHardForkAtEpoch = 0;
+
+  #### LOGGING Debug
+  minSeverity = "Debug";
+
+  ##### Update system parameters #####
+
+  LastKnownBlockVersion-Major = 3;
+  LastKnownBlockVersion-Minor = 1;
+  LastKnownBlockVersion-Alt = 0;
+}

--- a/cardano-lib/shelley_qa-config.nix
+++ b/cardano-lib/shelley_qa-config.nix
@@ -19,10 +19,11 @@
   Protocol = "Cardano";
   RequiresNetworkMagic = "RequiresMagic";
   EnableP2P = true;
+  PeerSharing = true;
   TargetNumberOfActivePeers = 20;
   TargetNumberOfEstablishedPeers = 50;
   TargetNumberOfKnownPeers = 100;
-  TargetNumberOfRootPeers = 100;
+  TargetNumberOfRootPeers = 60;
   ExperimentalHardForksEnabled = true;
   ExperimentalProtocolsEnabled = true;
   TestShelleyHardForkAtEpoch = 0;

--- a/cardano-lib/testnet-config-bp.nix
+++ b/cardano-lib/testnet-config-bp.nix
@@ -1,0 +1,38 @@
+##########################################################
+#######                  Testnet                  ########
+####### Cardano Node Block Producer Configuration ########
+##########################################################
+
+{
+  ##### Locations #####
+
+  ByronGenesisFile = ./testnet + "/byron-genesis.json";
+  ByronGenesisHash = "96fceff972c2c06bd3bb5243c39215333be6d56aaf4823073dca31afe5038471";
+  ShelleyGenesisFile = ./testnet + "/shelley-genesis.json";
+  ShelleyGenesisHash = "849a1764f152e1b09c89c0dfdbcbdd38d711d1fec2db5dfa0f87cf2737a0eaf4";
+  AlonzoGenesisFile = ./testnet + "/alonzo-genesis.json";
+  AlonzoGenesisHash = "7e94a15f55d1e82d10f09203fa1d40f8eede58fd8066542cf6566008068ed874";
+  ConwayGenesisFile = ./mainnet + "/conway-genesis.json";
+  ConwayGenesisHash = "49ef010ff0d13b090893a919bbc22022038a8b782faa0b1561a256b781672174";
+
+  ##### Core protocol parameters #####
+
+  # This is the instance of the Ouroboros family that we are running.
+  # The node also supports various test and mock instances.
+  # "RealPBFT" is the real (ie not mock) (permissive) OBFT protocol, which
+  # is what we use on mainnet in Byron era.
+  Protocol = "Cardano";
+
+  # The mainnet does not include the network magic into addresses. Testnets do.
+  RequiresNetworkMagic = "RequiresMagic";
+
+  MaxKnownMajorProtocolVersion = 2;
+
+  ##### Update system parameters #####
+
+  # This protocol version number gets used by block producing nodes as part
+  # part of the system for agreeing on and synchronising protocol updates.
+  LastKnownBlockVersion-Major = 3;
+  LastKnownBlockVersion-Minor = 0;
+  LastKnownBlockVersion-Alt = 0;
+}


### PR DESCRIPTION
* Sets `PeerSharing = true` as default for all networks with a corresponding reduction in `TargetNumberOfRootPeers` from 100 to 60 to allow for peer sharing connections
* Creates a seperate nodeConfigBp attribute for a block producer node configuration which will maintain `PeerSharing = false`
* Updates mkConfigHtml to publish `$ENV-config-bp.json` for block producers in addition to the usual `$ENV-config.json` for non-block-producers
* Adds a `MinNodeVersion` attribute (currently `8.10.0`) to node config