### PR TITLE
Add prebuilt packages for aarch64-darwin (m1)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
           script: |
             mkdir __pkgs
             echo ${{ github.sha }} > __pkgs/COMMIT_SHA
-            for sys in msys2 x86_64-macos arm64-macos debian; do
+            for sys in msys2 macos x86_64-macos arm64-macos debian; do
               for lib in libsodium libsodium-vrf libsecp256k1 libblst; do
                 out=$(nix build .#dist.$sys.$lib --no-link --print-out-paths -L)
                 for ext in pkg.tar.zstd pkg deb; do

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
           script: |
             mkdir __pkgs
             echo ${{ github.sha }} > __pkgs/COMMIT_SHA
-            for sys in msys2 macos debian; do
+            for sys in msys2 macos aarch64-macos debian; do
               for lib in libsodium libsodium-vrf libsecp256k1 libblst; do
                 out=$(nix build .#dist.$sys.$lib --no-link --print-out-paths -L)
                 for ext in pkg.tar.zstd pkg deb; do

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
           script: |
             mkdir __pkgs
             echo ${{ github.sha }} > __pkgs/COMMIT_SHA
-            for sys in msys2 macos aarch64-macos debian; do
+            for sys in msys2 x86_64-macos arm64-macos debian; do
               for lib in libsodium libsodium-vrf libsecp256k1 libblst; do
                 out=$(nix build .#dist.$sys.$lib --no-link --print-out-paths -L)
                 for ext in pkg.tar.zstd pkg deb; do

--- a/flake.nix
+++ b/flake.nix
@@ -45,6 +45,7 @@
 
     pkgs = import nixpkgs { system = "x86_64-linux"; overlays = builtins.attrValues overlays; };
     darwin-pkgs = import nixpkgs { system = "x86_64-darwin"; overlays = builtins.attrValues overlays; };
+    aarch64-darwin-pkgs = import nixpkgs { system = "aarch64-darwin"; overlays = builtins.attrValues overlays; };
 
 
     # we can use this, to get a coherent picture of the sources for
@@ -270,6 +271,12 @@
         libsodium    = mkDarwinPkg "/usr/local/opt/cardano" (mkSingleOutput darwin-pkgs.libsodium);
         libblst      = mkDarwinPkg "/usr/local/opt/cardano" (mkSingleOutput darwin-pkgs.libblst);
         libsecp256k1 = mkDarwinPkg "/usr/local/opt/cardano" (mkSingleOutput darwin-pkgs.secp256k1);
+      };
+      aarch64-macos = {
+        libsodium-vrf= mkDarwinPkg "/usr/local/opt/cardano" (mkSingleOutput aarch64-darwin-pkgs.libsodium-vrf);
+        libsodium    = mkDarwinPkg "/usr/local/opt/cardano" (mkSingleOutput aarch64-darwin-pkgs.libsodium);
+        libblst      = mkDarwinPkg "/usr/local/opt/cardano" (mkSingleOutput aarch64-darwin-pkgs.libblst);
+        libsecp256k1 = mkDarwinPkg "/usr/local/opt/cardano" (mkSingleOutput aarch64-darwin-pkgs.secp256k1);
       };
       debian = {
         libsodium-vrf= mkDebianPkg "/usr/local/opt/cardano" (mkSingleOutput pkgs.libsodium-vrf);

--- a/flake.nix
+++ b/flake.nix
@@ -259,25 +259,27 @@
           done
         '';
       };
-    in {
+    in rec {
       msys2 = {
         libsodium-vrf= mkPacmanPkg "/mingw64/opt/cardano" (mkSingleOutput pkgs.pkgsCross.mingwW64.libsodium-vrf);
         libsodium    = mkPacmanPkg "/mingw64/opt/cardano" (mkSingleOutput pkgs.pkgsCross.mingwW64.libsodium);
         libblst      = mkPacmanPkg "/mingw64/opt/cardano" (mkSingleOutput pkgs.pkgsCross.mingwW64.libblst);
         libsecp256k1 = mkPacmanPkg "/mingw64/opt/cardano" (mkSingleOutput pkgs.pkgsCross.mingwW64.secp256k1);
       };
-      macos = {
+      x86_64-macos = {
         libsodium-vrf= mkDarwinPkg "/usr/local/opt/cardano" (mkSingleOutput darwin-pkgs.libsodium-vrf);
         libsodium    = mkDarwinPkg "/usr/local/opt/cardano" (mkSingleOutput darwin-pkgs.libsodium);
         libblst      = mkDarwinPkg "/usr/local/opt/cardano" (mkSingleOutput darwin-pkgs.libblst);
         libsecp256k1 = mkDarwinPkg "/usr/local/opt/cardano" (mkSingleOutput darwin-pkgs.secp256k1);
       };
-      aarch64-macos = {
+      arm64-macos = {
         libsodium-vrf= mkDarwinPkg "/usr/local/opt/cardano" (mkSingleOutput aarch64-darwin-pkgs.libsodium-vrf);
         libsodium    = mkDarwinPkg "/usr/local/opt/cardano" (mkSingleOutput aarch64-darwin-pkgs.libsodium);
         libblst      = mkDarwinPkg "/usr/local/opt/cardano" (mkSingleOutput aarch64-darwin-pkgs.libblst);
         libsecp256k1 = mkDarwinPkg "/usr/local/opt/cardano" (mkSingleOutput aarch64-darwin-pkgs.secp256k1);
       };
+      # legacy mapping. macos used to be what is x86_64-macos now.
+      macos = x86_64-macos;
       debian = {
         libsodium-vrf= mkDebianPkg "/usr/local/opt/cardano" (mkSingleOutput pkgs.libsodium-vrf);
         libsodium    = mkDebianPkg "/usr/local/opt/cardano" (mkSingleOutput pkgs.libsodium);


### PR DESCRIPTION
Now that new GH runners are M1 macs, we need to have suitable libraries for them as well.