### PR TITLE
Drop legacy relay bootstrap filtering, simplify bp cfg generation

### DIFF
--- a/cardano-lib/default.nix
+++ b/cardano-lib/default.nix
@@ -62,18 +62,7 @@ let
     p2pTopology = mkEdgeTopologyP2P {
       inherit (env) edgeNodes;
 
-      # Until legacy mainnet relays are deprecated and replaced by IOG bootstrap peers for relaysNew,
-      # filter the legacy relaysNew definition from the mainnet bootstrapPeers list.
-      #
-      # All other envs can use the edgeNodes list as bootstrapPeers.
-      bootstrapPeers =
-        if env.name == "mainnet"
-        then
-          map (e: {address = e.addr; inherit (e) port;})
-            (builtins.filter (e: e.addr != env.relaysNew) env.edgeNodes)
-        else
-          map (e: {address = e.addr; inherit (e) port;}) env.edgeNodes;
-
+      bootstrapPeers = map (e: {address = e.addr; inherit (e) port;}) env.edgeNodes;
       useLedgerAfterSlot = env.usePeersFromLedgerAfterSlot;
     };
   in
@@ -142,8 +131,7 @@ let
       useByronWallet = true;
       private = false;
       domain = "cardano-mainnet.iohk.io";
-      relays = "relays.cardano-mainnet.iohk.io";
-      relaysNew = "backbone.cardano-mainnet.iohk.io";
+      relaysNew = "backbone.cardano.iog.io";
       explorerUrl = "https://explorer.cardano.org";
       smashUrl = "https://smash.cardano-mainnet.iohk.io";
       metadataUrl = "https://tokens.cardano.org";
@@ -159,15 +147,11 @@ let
           port = 3001;
         }
         {
-          addr = "backbone.cardano.iog.io";
+          addr = "backbone.mainnet.cardanofoundation.org";
           port = 3001;
         }
         {
           addr = "backbone.mainnet.emurgornd.com";
-          port = 3001;
-        }
-        {
-          addr = "backbone.mainnet.cardanofoundation.org";
           port = 3001;
         }
       ];

--- a/cardano-lib/mainnet-config-bp.nix
+++ b/cardano-lib/mainnet-config-bp.nix
@@ -3,43 +3,9 @@
 ####### Cardano Node Block Producer Configuration ########
 ##########################################################
 
-{
-  ##### Locations #####
-
-  ByronGenesisFile = ./mainnet + "/byron-genesis.json";
-  ByronGenesisHash = "5f20df933584822601f9e3f8c024eb5eb252fe8cefb24d1317dc3d432e940ebb";
-  ConwayGenesisFile = ./mainnet + "/conway-genesis.json";
-  ConwayGenesisHash = "15a199f895e461ec0ffc6dd4e4028af28a492ab4e806d39cb674c88f7643ef62";
-  ShelleyGenesisFile = ./mainnet + "/shelley-genesis.json";
-  ShelleyGenesisHash = "1a3be38bcbb7911969283716ad7aa550250226b76a61fc51cc9a9a35d9276d81";
-  AlonzoGenesisFile = ./mainnet + "/alonzo-genesis.json";
-  AlonzoGenesisHash = "7e94a15f55d1e82d10f09203fa1d40f8eede58fd8066542cf6566008068ed874";
-
+import ./mainnet-config.nix // {
   ##### Core protocol parameters #####
-
-  # This is the instance of the Ouroboros family that we are running.
-  # The node also supports various test and mock instances.
-  # "RealPBFT" is the real (ie not mock) (permissive) OBFT protocol, which
-  # is what we use on mainnet in Byron era.
-  Protocol = "Cardano";
-
-  # The mainnet does not include the network magic into addresses. Testnets do.
-  RequiresNetworkMagic = "RequiresNoMagic";
-  EnableP2P = true;
   PeerSharing = false;
-  TargetNumberOfActivePeers = 20;
-  TargetNumberOfEstablishedPeers = 50;
   TargetNumberOfKnownPeers = 100;
   TargetNumberOfRootPeers = 100;
-  TraceMempool = false;
-
-  MaxKnownMajorProtocolVersion = 2;
-
-  ##### Update system parameters #####
-
-  # This protocol version number gets used by block producing nodes as part
-  # part of the system for agreeing on and synchronising protocol updates.
-  LastKnownBlockVersion-Major = 3;
-  LastKnownBlockVersion-Minor = 0;
-  LastKnownBlockVersion-Alt = 0;
 }

--- a/cardano-lib/preprod-config-bp.nix
+++ b/cardano-lib/preprod-config-bp.nix
@@ -3,40 +3,9 @@
 ####### Cardano Node Block Producer Configuration ########
 ##########################################################
 
-{
-  ##### Locations #####
-
-  ByronGenesisFile = ./preprod + "/byron-genesis.json";
-  ByronGenesisHash = "d4b8de7a11d929a323373cbab6c1a9bdc931beffff11db111cf9d57356ee1937";
-  ConwayGenesisFile = ./preprod + "/conway-genesis.json";
-  ConwayGenesisHash = "0eb6adaec3fcb1fe286c1b4ae0da2a117eafc3add51e17577d36dd39eddfc3db";
-  ShelleyGenesisFile = ./preprod + "/shelley-genesis.json";
-  ShelleyGenesisHash = "162d29c4e1cf6b8a84f2d692e67a3ac6bc7851bc3e6e4afe64d15778bed8bd86";
-  AlonzoGenesisFile = ./preprod + "/alonzo-genesis.json";
-  AlonzoGenesisHash = "7e94a15f55d1e82d10f09203fa1d40f8eede58fd8066542cf6566008068ed874";
-
+import ./preprod-config.nix // {
   ##### Core protocol parameters #####
-
-  # This is the instance of the Ouroboros family that we are running.
-  # The node also supports various test and mock instances.
-  # "RealPBFT" is the real (ie not mock) (permissive) OBFT protocol, which
-  # is what we use on mainnet in Byron era.
-  Protocol = "Cardano";
-
-  # The mainnet does not include the network magic into addresses. Testnets do.
-  RequiresNetworkMagic = "RequiresMagic";
-  EnableP2P = true;
   PeerSharing = false;
-  TargetNumberOfActivePeers = 20;
-  TargetNumberOfEstablishedPeers = 50;
   TargetNumberOfKnownPeers = 100;
   TargetNumberOfRootPeers = 100;
-
-  ##### Update system parameters #####
-
-  # This protocol version number gets used by block producing nodes as part
-  # part of the system for agreeing on and synchronising protocol updates.
-  LastKnownBlockVersion-Major = 2;
-  LastKnownBlockVersion-Minor = 0;
-  LastKnownBlockVersion-Alt = 0;
 }

--- a/cardano-lib/preview-config-bp.nix
+++ b/cardano-lib/preview-config-bp.nix
@@ -3,37 +3,9 @@
 ####### Cardano Node Block Producer Configuration ########
 ##########################################################
 
-{
-  ##### Locations #####
-
-  ByronGenesisFile = ./preview + "/byron-genesis.json";
-  ByronGenesisHash = "83de1d7302569ad56cf9139a41e2e11346d4cb4a31c00142557b6ab3fa550761";
-  ConwayGenesisFile = ./preview + "/conway-genesis.json";
-  ConwayGenesisHash = "9cc5084f02e27210eacba47af0872e3dba8946ad9460b6072d793e1d2f3987ef";
-  ShelleyGenesisFile = ./preview + "/shelley-genesis.json";
-  ShelleyGenesisHash = "363498d1024f84bb39d3fa9593ce391483cb40d479b87233f868d6e57c3a400d";
-  AlonzoGenesisFile = ./preview + "/alonzo-genesis.json";
-  AlonzoGenesisHash = "7e94a15f55d1e82d10f09203fa1d40f8eede58fd8066542cf6566008068ed874";
-
-  ### Core protocol parameters #####
-  Protocol = "Cardano";
-  RequiresNetworkMagic = "RequiresMagic";
-  EnableP2P = true;
+import ./preview-config.nix // {
+  ##### Core protocol parameters #####
   PeerSharing = false;
-  TargetNumberOfActivePeers = 20;
-  TargetNumberOfEstablishedPeers = 50;
   TargetNumberOfKnownPeers = 100;
   TargetNumberOfRootPeers = 100;
-  ExperimentalHardForksEnabled = false;
-  ExperimentalProtocolsEnabled = false;
-  TestShelleyHardForkAtEpoch = 0;
-  TestAllegraHardForkAtEpoch = 0;
-  TestAlonzoHardForkAtEpoch = 0;
-  TestMaryHardForkAtEpoch = 0;
-
-  ##### Update system Parameters #####
-
-  LastKnownBlockVersion-Major = 3;
-  LastKnownBlockVersion-Minor = 1;
-  LastKnownBlockVersion-Alt = 0;
 }

--- a/cardano-lib/private-config-bp.nix
+++ b/cardano-lib/private-config-bp.nix
@@ -3,36 +3,9 @@
 ####### Cardano Node Block Producer Configuration ########
 ##########################################################
 
-{
-  ##### Locations #####
-
-  ByronGenesisFile = ./private + "/byron-genesis.json";
-  ByronGenesisHash = "200222f56d3582c58af09ba58d53e294fcca5de2fc6a27913803e427cdf147f3";
-  ShelleyGenesisFile = ./private + "/shelley-genesis.json";
-  ShelleyGenesisHash = "ae9da178ddecfbde046d2c59d4afd087bafd6e2ff04532e6077eab7f8098fa03";
-  AlonzoGenesisFile = ./private + "/alonzo-genesis.json";
-  AlonzoGenesisHash = "8bedcaea62107d8a79ed5293b0027b3f8706a4bc2422f33380cb1fd01c6fa6ec";
-  ConwayGenesisFile = ./private + "/conway-genesis.json";
-  ConwayGenesisHash = "75ff70079cca9f3fd2109d89d5770e96f6f79827dba7b410a69ee90066b78c5f";
-
-  ### Core protocol parameters #####
-  Protocol = "Cardano";
-  RequiresNetworkMagic = "RequiresMagic";
-  EnableP2P = true;
+import ./private-config.nix // {
+  ##### Core protocol parameters #####
   PeerSharing = false;
-  TargetNumberOfActivePeers = 20;
-  TargetNumberOfEstablishedPeers = 50;
   TargetNumberOfKnownPeers = 100;
   TargetNumberOfRootPeers = 100;
-  ExperimentalHardForksEnabled = true;
-  ExperimentalProtocolsEnabled = true;
-  TestShelleyHardForkAtEpoch = 0;
-  TestAllegraHardForkAtEpoch = 0;
-  TestAlonzoHardForkAtEpoch = 0;
-  TestMaryHardForkAtEpoch = 0;
-
-  ##### Update system Parameters #####
-  LastKnownBlockVersion-Major = 3;
-  LastKnownBlockVersion-Minor = 1;
-  LastKnownBlockVersion-Alt = 0;
 }

--- a/cardano-lib/sanchonet-config-bp.nix
+++ b/cardano-lib/sanchonet-config-bp.nix
@@ -3,37 +3,9 @@
 ####### Cardano Node Block Producer Configuration ########
 ##########################################################
 
-{
-  ##### Locations #####
-
-  ByronGenesisFile = ./sanchonet + "/byron-genesis.json";
-  ByronGenesisHash = "785eb88427e136378a15b0a152a8bfbeec7a611529ccda29c43a1e60ffb48eaa";
-  ShelleyGenesisFile = ./sanchonet + "/shelley-genesis.json";
-  ShelleyGenesisHash = "f94457ec45a0c6773057a529533cf7ccf746cb44dabd56ae970e1dbfb55bfdb2";
-  AlonzoGenesisFile = ./sanchonet + "/alonzo-genesis.json";
-  AlonzoGenesisHash = "8bedcaea62107d8a79ed5293b0027b3f8706a4bc2422f33380cb1fd01c6fa6ec";
-  ConwayGenesisFile = ./sanchonet + "/conway-genesis.json";
-  ConwayGenesisHash = "e85ee5b7af8ca5c273c20746c9f994aef1a72a79c38b4eea230817e7e66c0741";
-
-  ### Core protocol parameters #####
-  Protocol = "Cardano";
-  RequiresNetworkMagic = "RequiresMagic";
-  EnableP2P = true;
+import ./sanchonet-config.nix // {
+  ##### Core protocol parameters #####
   PeerSharing = false;
-  TargetNumberOfActivePeers = 20;
-  TargetNumberOfEstablishedPeers = 50;
   TargetNumberOfKnownPeers = 100;
   TargetNumberOfRootPeers = 100;
-  ExperimentalHardForksEnabled = true;
-  ExperimentalProtocolsEnabled = true;
-  TestShelleyHardForkAtEpoch = 0;
-  TestAllegraHardForkAtEpoch = 0;
-  TestAlonzoHardForkAtEpoch = 0;
-  TestMaryHardForkAtEpoch = 0;
-
-  ##### Update system Parameters #####
-
-  LastKnownBlockVersion-Major = 3;
-  LastKnownBlockVersion-Minor = 1;
-  LastKnownBlockVersion-Alt = 0;
 }

--- a/cardano-lib/shelley_qa-config-bp.nix
+++ b/cardano-lib/shelley_qa-config-bp.nix
@@ -3,40 +3,9 @@
 ####### Cardano Node Block Producer Configuration ########
 ##########################################################
 
-{
-  ##### Locations #####
-
-  ByronGenesisFile = ./shelley_qa + "/byron-genesis.json";
-  ByronGenesisHash = "273cd12237b98d02f108c9c50063d29a8d1d7f32e9a75ade7cd48e08b3070258";
-  ShelleyGenesisFile = ./shelley_qa + "/shelley-genesis.json";
-  ShelleyGenesisHash = "73a9f6bdb0aa97f5e63190a6f14a702bd64a21f2bec831cbfc28f6037128b952";
-  AlonzoGenesisFile = ./shelley_qa + "/alonzo-genesis.json";
-  AlonzoGenesisHash = "8bedcaea62107d8a79ed5293b0027b3f8706a4bc2422f33380cb1fd01c6fa6ec";
-  ConwayGenesisFile = ./shelley_qa + "/conway-genesis.json";
-  ConwayGenesisHash = "91bedad42212c07f6abdafedb7e7c8577fbd07152c695ffae1ab2a528741c6e4";
-
+import ./shelley_qa-config.nix // {
   ##### Core protocol parameters #####
-  Protocol = "Cardano";
-  RequiresNetworkMagic = "RequiresMagic";
-  EnableP2P = true;
   PeerSharing = false;
-  TargetNumberOfActivePeers = 20;
-  TargetNumberOfEstablishedPeers = 50;
   TargetNumberOfKnownPeers = 100;
   TargetNumberOfRootPeers = 100;
-  ExperimentalHardForksEnabled = true;
-  ExperimentalProtocolsEnabled = true;
-  TestShelleyHardForkAtEpoch = 0;
-  TestAllegraHardForkAtEpoch = 0;
-  TestAlonzoHardForkAtEpoch = 0;
-  TestMaryHardForkAtEpoch = 0;
-
-  #### LOGGING Debug
-  minSeverity = "Debug";
-
-  ##### Update system parameters #####
-
-  LastKnownBlockVersion-Major = 3;
-  LastKnownBlockVersion-Minor = 1;
-  LastKnownBlockVersion-Alt = 0;
 }

--- a/cardano-lib/testnet-config-bp.nix
+++ b/cardano-lib/testnet-config-bp.nix
@@ -3,34 +3,6 @@
 ####### Cardano Node Block Producer Configuration ########
 ##########################################################
 
-{
-  ##### Locations #####
-
-  ByronGenesisFile = ./testnet + "/byron-genesis.json";
-  ByronGenesisHash = "96fceff972c2c06bd3bb5243c39215333be6d56aaf4823073dca31afe5038471";
-  ShelleyGenesisFile = ./testnet + "/shelley-genesis.json";
-  ShelleyGenesisHash = "849a1764f152e1b09c89c0dfdbcbdd38d711d1fec2db5dfa0f87cf2737a0eaf4";
-  AlonzoGenesisFile = ./testnet + "/alonzo-genesis.json";
-  AlonzoGenesisHash = "7e94a15f55d1e82d10f09203fa1d40f8eede58fd8066542cf6566008068ed874";
-
+import ./testnet-config.nix // {
   ##### Core protocol parameters #####
-
-  # This is the instance of the Ouroboros family that we are running.
-  # The node also supports various test and mock instances.
-  # "RealPBFT" is the real (ie not mock) (permissive) OBFT protocol, which
-  # is what we use on mainnet in Byron era.
-  Protocol = "Cardano";
-
-  # The mainnet does not include the network magic into addresses. Testnets do.
-  RequiresNetworkMagic = "RequiresMagic";
-
-  MaxKnownMajorProtocolVersion = 2;
-
-  ##### Update system parameters #####
-
-  # This protocol version number gets used by block producing nodes as part
-  # part of the system for agreeing on and synchronising protocol updates.
-  LastKnownBlockVersion-Major = 3;
-  LastKnownBlockVersion-Minor = 0;
-  LastKnownBlockVersion-Alt = 0;
 }


### PR DESCRIPTION
* Removes deprecated legacy relays from mainnet env and corresponding filtering for bootstrap generation
* Simplifies bp config generation
* Arrange mainnet edgeNodes in alphabetical order