### PR TITLE
Use legacy tracing

### DIFF
--- a/cardano-lib/generic-log-config.nix
+++ b/cardano-lib/generic-log-config.nix
@@ -14,6 +14,9 @@
   # The verbosity can be: MinimalVerbosity, NormalVerbosity
   TracingVerbosity = "NormalVerbosity";
 
+  # Use legacy tracing
+  UseTraceDispatcher = false;
+
   # The system supports a number of backends for logging and monitoring.
   # This setting lists the the backends that will be available to use in the
   # configuration below. The logging backend is called Katip. Also enable the EKG


### PR DESCRIPTION
* Ensure the use of legacy tracing for iohk-nix generated configs when the node binary defaults to new tracing.