### PR TITLE
Update blst to v0.3.14

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3,16 +3,16 @@
     "blst": {
       "flake": false,
       "locked": {
-        "lastModified": 1691598027,
-        "narHash": "sha256-oqljy+ZXJAXEB/fJtmB8rlAr4UXM+Z2OkDa20gpILNA=",
+        "lastModified": 1739372843,
+        "narHash": "sha256-IlbNMLBjs/dvGogcdbWQIL+3qwy7EXJbIDpo4xBd4bY=",
         "owner": "supranational",
         "repo": "blst",
-        "rev": "3dd0f804b1819e5d03fb22ca2e6fac105932043a",
+        "rev": "8c7db7fe8d2ce6e76dc398ebd4d475c0ec564355",
         "type": "github"
       },
       "original": {
         "owner": "supranational",
-        "ref": "v0.3.11",
+        "ref": "v0.3.14",
         "repo": "blst",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -9,10 +9,10 @@
     # https://github.com/jedisct1/libsodium/discussions/1260
 
     # To update these, change the rev part in the url, and run
-    # nix flake lock --update-input <sodium|secp256k1|blst>
+    # nix flake update <sodium|secp256k1|blst>
     sodium = { url = "github:input-output-hk/libsodium?rev=dbb48cce5429cb6585c9034f002568964f1ce567"; flake = false; };
     secp256k1 = { url = "github:bitcoin-core/secp256k1?ref=v0.3.2"; flake = false; };
-    blst = { url = "github:supranational/blst?ref=v0.3.11"; flake = false; };
+    blst = { url = "github:supranational/blst?ref=v0.3.14"; flake = false; };
   };
 
   outputs = { self, nixpkgs, ... }@inputs: rec {


### PR DESCRIPTION
This fixes a problem building blst on x86_64-darwin using recent versions nixpkgs.