### PR TITLE
Add mithril network ancillary verification keys

### DIFF
--- a/cardano-lib/default.nix
+++ b/cardano-lib/default.nix
@@ -145,6 +145,7 @@ let
       smashUrl = "https://smash.cardano-mainnet.iohk.io";
       metadataUrl = "https://tokens.cardano.org";
       mithrilAggregatorEndpointUrl = "https://aggregator.release-mainnet.api.mithril.network/aggregator";
+      mithrilAncillaryVerificationKey = "5b32332c37312c39362c3133332c34372c3235332c3232362c3133362c3233352c35372c3136342c3130362c3138362c322c32312c32392c3132302c3136332c38392c3132312c3137372c3133382c3230382c3133382c3231342c39392c35382c32322c302c35382c332c36395d";
       mithrilEraReaderParams = {
         address = "addr1qy72kwgm6kypyc5maw0h8mfagwag8wjnx6emgfnsnhqaml6gx7gg4tzplw9l32nsgclqax7stc4u6c5dn0ctljwscm2sqv0teg";
         verification_key = "5b31312c3133342c3231352c37362c3134312c3232302c3131312c3135342c36332c3233302c3131342c31322c38372c37342c39342c3137322c3133322c32372c39362c3138362c3132362c3137382c31392c3131342c33302c3234332c36342c3134312c3131302c38332c38362c31395d";
@@ -183,6 +184,7 @@ let
       smashUrl = "https://preprod-smash.play.dev.cardano.org";
       metadataUrl = "https://metadata.play.dev.cardano.org";
       mithrilAggregatorEndpointUrl = "https://aggregator.release-preprod.api.mithril.network/aggregator";
+      mithrilAncillaryVerificationKey = "5b3138392c3139322c3231362c3135302c3131342c3231362c3233372c3231302c34352c31382c32312c3139362c3230382c3234362c3134362c322c3235322c3234332c3235312c3139372c32382c3135372c3230342c3134352c33302c31342c3232382c3136382c3132392c38332c3133362c33365d";
       mithrilEraReaderParams = {
         address = "addr_test1qpkyv2ws0deszm67t840sdnruqgr492n80g3y96xw3p2ksk6suj5musy6w8lsg3yjd09cnpgctc2qh386rtxphxt248qr0npnx";
         verification_key = "5b35352c3232382c3134342c38372c3133382c3133362c34382c382c31342c3138372c38352c3134382c39372c3233322c3235352c3232392c33382c3234342c3234372c3230342c3139382c31332c33312c3232322c32352c3136342c35322c3130322c39312c3132302c3230382c3134375d";
@@ -212,6 +214,7 @@ let
       smashUrl = "https://preview-smash.play.dev.cardano.org";
       metadataUrl = "https://metadata.play.dev.cardano.org";
       mithrilAggregatorEndpointUrl = "https://aggregator.pre-release-preview.api.mithril.network/aggregator";
+      mithrilAncillaryVerificationKey = "5b3138392c3139322c3231362c3135302c3131342c3231362c3233372c3231302c34352c31382c32312c3139362c3230382c3234362c3134362c322c3235322c3234332c3235312c3139372c32382c3135372c3230342c3134352c33302c31342c3232382c3136382c3132392c38332c3133362c33365d";
       mithrilEraReaderParams = {
         address = "addr_test1qrv5xfwh043mlc3vk5d97s4nmhxu7cmleyssvhx37gkfyejfe8d38v3vsfgetjafgrsdc49krug8wf04h5rmtengtejqlxrksk";
         verification_key = "5b35352c3232382c3134342c38372c3133382c3133362c34382c382c31342c3138372c38352c3134382c39372c3233322c3235352c3232392c33382c3234342c3234372c3230342c3139382c31332c33312c3232322c32352c3136342c35322c3130322c39312c3132302c3230382c3134375d";

--- a/cardano-lib/default.nix
+++ b/cardano-lib/default.nix
@@ -98,9 +98,9 @@ let
     store_retention_limit = 5;
   } // optionalAttrs (env ? mithrilAggregatorEndpointUrl) {
     aggregator_endpoint = env.mithrilAggregatorEndpointUrl;
-  } // optionalAttrs (env ? mithrilEraReaderParams) {
     era_reader_adapter_type = "cardano-chain";
     era_reader_adapter_params = toJSON env.mithrilEraReaderParams;
+    genesis_verification_key = env.mithrilGenesisVerificationKey;
   };
 
   mkSubmitApiConfig = name: nodeConfig: (filterAttrs (k: v: v != null) {


### PR DESCRIPTION
Adds mithril network ancillary verification keys:
* The ancillary verification keys are a breaking change required to pull ancillary mithril state (ie: ledger and volatile state) in addition to immutable state.  In earlier mithril releases, the ancillary state was bundled together with the immutable state.  The mithril [v2517.1 release](https://github.com/input-output-hk/mithril/releases/tag/2517.1) and recent [blog article](https://mithril.network/doc/dev-blog/2025/05/06/client-breaking-change/) discuss this change further.
* These keys are sourced from the [Mithril Network configurations page](https://mithril.network/doc/manual/getting-started/network-configurations) at the given Ancillary verification key  url