### PR TITLE
Node 10.5 updates

### DIFF
--- a/cardano-lib/default.nix
+++ b/cardano-lib/default.nix
@@ -175,7 +175,7 @@ let
       confKey = "mainnet_full";
       networkConfig = import ./mainnet-config.nix // minNodeVersion;
       networkConfigBp = import ./mainnet-config-bp.nix // minNodeVersion;
-      usePeersFromLedgerAfterSlot = 148350000;
+      usePeersFromLedgerAfterSlot = 156124816;
       extraDbSyncConfig = {
         enableFutureGenesis = true;
       };
@@ -205,7 +205,7 @@ let
       edgePort = 3001;
       networkConfig = import ./preprod-config.nix // minNodeVersion;
       networkConfigBp = import ./preprod-config-bp.nix // minNodeVersion;
-      usePeersFromLedgerAfterSlot = 83894000;
+      usePeersFromLedgerAfterSlot = 91670493;
       extraDbSyncConfig = {
         enableFutureGenesis = true;
       };
@@ -235,7 +235,7 @@ let
       edgePort = 3001;
       networkConfig = import ./preview-config.nix // minNodeVersion;
       networkConfigBp = import ./preview-config-bp.nix // minNodeVersion;
-      usePeersFromLedgerAfterSlot = 73267000;
+      usePeersFromLedgerAfterSlot = 81043228;
       extraDbSyncConfig = {
         enableFutureGenesis = true;
       };

--- a/cardano-lib/default.nix
+++ b/cardano-lib/default.nix
@@ -1,6 +1,6 @@
 {lib, writeText, runCommand, jq}:
 let
-  inherit (builtins) attrNames fromJSON readFile toFile toJSON;
+  inherit (builtins) attrNames elem fromJSON readFile toFile toJSON;
   inherit (lib) filterAttrs flip forEach listToAttrs mapAttrs mapAttrsToList optionalAttrs optionalString pipe;
 
   mkEdgeTopology = {
@@ -70,6 +70,12 @@ let
 
       bootstrapPeers = map (e: {address = e.addr; inherit (e) port;}) env.edgeNodes;
       useLedgerAfterSlot = env.usePeersFromLedgerAfterSlot;
+
+      # Genesis mode is now default for preview and preprod as of node 10.5
+      peerSnapshotFile =
+        if elem env.name ["preview" "preprod"]
+        then "peer-snapshot.json"
+        else null;
     };
   in
     if (env.nodeConfig.EnableP2P or false)

--- a/cardano-lib/mainnet-config.nix
+++ b/cardano-lib/mainnet-config.nix
@@ -30,7 +30,7 @@ with builtins; {
   EnableP2P = true;
   PeerSharing = true;
   TargetNumberOfActivePeers = 20;
-  TargetNumberOfEstablishedPeers = 40;
+  TargetNumberOfEstablishedPeers = 30;
   TargetNumberOfKnownPeers = 150;
   TargetNumberOfRootPeers = 60;
   TraceMempool = false;
@@ -46,7 +46,7 @@ with builtins; {
   # Default "GenesisMode" parameter values
   SyncTargetNumberOfActivePeers = 0;
   SyncTargetNumberOfActiveBigLedgerPeers = 30;
-  SyncTargetNumberOfEstablishedBigLedgerPeers = 50;
+  SyncTargetNumberOfEstablishedBigLedgerPeers = 40;
   SyncTargetNumberOfKnownBigLedgerPeers = 100;
   MinBigLedgerPeersForTrustedState = 5;
 

--- a/cardano-lib/mainnet/peer-snapshot.json
+++ b/cardano-lib/mainnet/peer-snapshot.json
@@ -1,50 +1,52 @@
 {
   "bigLedgerPools": [
     {
-      "accumulatedStake": 0.004156807533298409,
-      "relativeStake": 0.004156807533298409,
+      "accumulatedStake": 0.004481741500733465,
+      "relativeStake": 0.004481741500733465,
       "relays": [
         {
-          "domain": "77cb3f75.cardano-relay.herd.run",
-          "port": 1338
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.007964615279184796,
-      "relativeStake": 0.003807807745886388,
-      "relays": [
-        {
-          "domain": "relays-8a.cardano.2k2aa.com",
+          "domain": "relays-2a.cardano.figment.io",
           "port": 3001
         },
         {
-          "domain": "relays-8b.cardano.aeq5f.com",
+          "domain": "relays-2b.cardano.figment.io",
           "port": 3001
         }
       ]
     },
     {
-      "accumulatedStake": 0.011611680271961581,
-      "relativeStake": 0.0036470649927767846,
+      "accumulatedStake": 0.00797076098604038,
+      "relativeStake": 0.003489019485306915,
       "relays": [
         {
-          "domain": "relay-kiln-0-0.cardano.mainnet.kiln.fi",
-          "port": 3001
+          "domain": "Relay1.NordicPool.org",
+          "port": 3005
         },
         {
-          "domain": "relay-kiln-0-1.cardano.mainnet.kiln.fi",
-          "port": 3001
+          "domain": "Relay2.NordicPool.org",
+          "port": 3005
         },
         {
-          "domain": "relay-kiln-0-2.cardano.mainnet.kiln.fi",
-          "port": 3001
+          "domain": "Relay3.NordicPool.org",
+          "port": 3005
+        },
+        {
+          "domain": "Relay4.NordicPool.org",
+          "port": 3005
+        },
+        {
+          "domain": "Relay5.NordicPool.org",
+          "port": 3005
+        },
+        {
+          "domain": "Relay6.NordicPool.org",
+          "port": 3005
         }
       ]
     },
     {
-      "accumulatedStake": 0.015134695072175979,
-      "relativeStake": 0.003523014800214398,
+      "accumulatedStake": 0.01145329633075018,
+      "relativeStake": 0.0034825353447098,
       "relays": [
         {
           "domain": "cardanosuisse.com",
@@ -61,18 +63,50 @@
       ]
     },
     {
-      "accumulatedStake": 0.01864999463282789,
-      "relativeStake": 0.0035152995606519103,
+      "accumulatedStake": 0.014930398426008644,
+      "relativeStake": 0.003477102095258464,
       "relays": [
         {
-          "domain": "relays.bladepool.com",
-          "port": 3001
+          "domain": "r-eu-1.polypool.io",
+          "port": 4001
+        },
+        {
+          "domain": "r-sg-1.polypool.io",
+          "port": 4001
         }
       ]
     },
     {
-      "accumulatedStake": 0.02216514996218333,
-      "relativeStake": 0.0035151553293554403,
+      "accumulatedStake": 0.018406603088430774,
+      "relativeStake": 0.0034762046624221307,
+      "relays": [
+        {
+          "address": "162.120.71.180",
+          "port": 6000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.02188022435816957,
+      "relativeStake": 0.003473621269738796,
+      "relays": [
+        {
+          "address": "95.154.235.142",
+          "port": 6000
+        },
+        {
+          "address": "217.155.18.115",
+          "port": 6003
+        },
+        {
+          "address": "217.155.18.115",
+          "port": 6001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.025346207572578022,
+      "relativeStake": 0.003465983214408451,
       "relays": [
         {
           "address": "148.113.17.23",
@@ -93,64 +127,56 @@
       ]
     },
     {
-      "accumulatedStake": 0.025660698392526615,
-      "relativeStake": 0.0034955484303432825,
+      "accumulatedStake": 0.028801896408451152,
+      "relativeStake": 0.0034556888358731313,
       "relays": [
         {
-          "address": "95.154.235.142",
-          "port": 6000
-        },
-        {
-          "address": "217.155.18.115",
-          "port": 6003
-        },
-        {
-          "address": "217.155.18.115",
-          "port": 6001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.029150261666569754,
-      "relativeStake": 0.0034895632740431413,
-      "relays": [
-        {
-          "address": "162.120.71.180",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.032634875762265744,
-      "relativeStake": 0.0034846140956959933,
-      "relays": [
-        {
-          "address": "178.128.79.219",
-          "port": 3001
-        },
-        {
-          "address": "104.131.122.73",
+          "domain": "r1.spirestaking.com",
           "port": 3001
         }
       ]
     },
     {
-      "accumulatedStake": 0.03611350391920046,
-      "relativeStake": 0.0034786281569347097,
+      "accumulatedStake": 0.032252635407381956,
+      "relativeStake": 0.0034507389989308023,
       "relays": [
         {
-          "address": "57.128.184.33",
-          "port": 3001
-        },
-        {
-          "address": "57.128.184.31",
+          "domain": "relays.bladepool.com",
           "port": 3001
         }
       ]
     },
     {
-      "accumulatedStake": 0.039588004427469584,
-      "relativeStake": 0.003474500508269125,
+      "accumulatedStake": 0.03570330788924252,
+      "relativeStake": 0.003450672481860569,
+      "relays": [
+        {
+          "domain": "relay.cardano.securestaking.io",
+          "port": 3000
+        },
+        {
+          "domain": "secur2.cardano.securestaking.io",
+          "port": 3000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.039150110769774725,
+      "relativeStake": 0.003446802880532201,
+      "relays": [
+        {
+          "domain": "eu.relays.cardanians.io",
+          "port": 1000
+        },
+        {
+          "domain": "ca.relays.cardanians.io",
+          "port": 1000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.042581589619877847,
+      "relativeStake": 0.003431478850103119,
       "relays": [
         {
           "domain": "relay-kiln-2-0.cardano.mainnet.kiln.fi",
@@ -167,58 +193,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.043060232245436994,
-      "relativeStake": 0.0034722278179674087,
-      "relays": [
-        {
-          "domain": "relay-kiln-1-0.cardano.mainnet.kiln.fi",
-          "port": 3001
-        },
-        {
-          "domain": "relay-kiln-1-1.cardano.mainnet.kiln.fi",
-          "port": 3001
-        },
-        {
-          "domain": "relay-kiln-1-2.cardano.mainnet.kiln.fi",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.04652969288987569,
-      "relativeStake": 0.003469460644438702,
-      "relays": [
-        {
-          "domain": "r-eu-1.polypool.io",
-          "port": 4001
-        },
-        {
-          "domain": "r-sg-1.polypool.io",
-          "port": 4001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.04999704081906948,
-      "relativeStake": 0.003467347929193789,
-      "relays": [
-        {
-          "domain": "relay-kiln-4-0.cardano.mainnet.kiln.fi",
-          "port": 3001
-        },
-        {
-          "domain": "relay-kiln-4-1.cardano.mainnet.kiln.fi",
-          "port": 3001
-        },
-        {
-          "domain": "relay-kiln-4-2.cardano.mainnet.kiln.fi",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.05346100464780822,
-      "relativeStake": 0.0034639638287387443,
+      "accumulatedStake": 0.04601181536064653,
+      "relativeStake": 0.0034302257407686893,
       "relays": [
         {
           "domain": "relay-kiln-3-0.cardano.mainnet.kiln.fi",
@@ -235,28 +211,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.05692126981913203,
-      "relativeStake": 0.003460265171323805,
-      "relays": [
-        {
-          "address": "13.236.12.204",
-          "port": 8332
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.06037758055987973,
-      "relativeStake": 0.003456310740747701,
-      "relays": [
-        {
-          "address": "13.211.73.179",
-          "port": 8332
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.06383387916894528,
-      "relativeStake": 0.003456298609065552,
+      "accumulatedStake": 0.04943973447430133,
+      "relativeStake": 0.0034279191136547997,
       "relays": [
         {
           "domain": "relay-kiln-7-0.cardano.mainnet.kiln.fi",
@@ -273,32 +229,60 @@
       ]
     },
     {
-      "accumulatedStake": 0.0672901154203182,
-      "relativeStake": 0.003456236251372906,
+      "accumulatedStake": 0.052866240470862566,
+      "relativeStake": 0.003426505996561233,
       "relays": [
         {
-          "domain": "eu.relays.cardanians.io",
-          "port": 1000
+          "domain": "relays-8a.cardano.2k2aa.com",
+          "port": 3001
         },
         {
-          "domain": "ca.relays.cardanians.io",
-          "port": 1000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.07073976279468465,
-      "relativeStake": 0.003449647374366463,
-      "relays": [
-        {
-          "domain": "relays.wavepool.digital",
+          "domain": "relays-8b.cardano.aeq5f.com",
           "port": 3001
         }
       ]
     },
     {
-      "accumulatedStake": 0.07414099207993369,
-      "relativeStake": 0.00340122928524904,
+      "accumulatedStake": 0.05628923626959996,
+      "relativeStake": 0.0034229957987373934,
+      "relays": [
+        {
+          "address": "13.236.12.204",
+          "port": 8332
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.05971216450148793,
+      "relativeStake": 0.003422928231887972,
+      "relays": [
+        {
+          "domain": "relay-kiln-0-0.cardano.mainnet.kiln.fi",
+          "port": 3001
+        },
+        {
+          "domain": "relay-kiln-0-1.cardano.mainnet.kiln.fi",
+          "port": 3001
+        },
+        {
+          "domain": "relay-kiln-0-2.cardano.mainnet.kiln.fi",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.06313170901047198,
+      "relativeStake": 0.0034195445089840455,
+      "relays": [
+        {
+          "address": "13.211.73.179",
+          "port": 8332
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.06653931642583179,
+      "relativeStake": 0.003407607415359807,
       "relays": [
         {
           "domain": "Relay1.NordicPool.org",
@@ -327,8 +311,94 @@
       ]
     },
     {
-      "accumulatedStake": 0.07752932565888487,
-      "relativeStake": 0.003388333578951179,
+      "accumulatedStake": 0.06994501440542007,
+      "relativeStake": 0.0034056979795882925,
+      "relays": [
+        {
+          "domain": "45.cardano.staked.cloud",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.07335059066693239,
+      "relativeStake": 0.0034055762615123153,
+      "relays": [
+        {
+          "domain": "46.cardano.staked.cloud",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.07675594465704794,
+      "relativeStake": 0.00340535399011555,
+      "relays": [
+        {
+          "domain": "44.cardano.staked.cloud",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.08015995328018628,
+      "relativeStake": 0.0034040086231383435,
+      "relays": [
+        {
+          "domain": "relay.cardano.securestaking.io",
+          "port": 3000
+        },
+        {
+          "domain": "secur2.cardano.securestaking.io",
+          "port": 3000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.08356384215225822,
+      "relativeStake": 0.0034038888720719306,
+      "relays": [
+        {
+          "domain": "41.cardano.staked.cloud",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.08696733860963632,
+      "relativeStake": 0.003403496457378099,
+      "relays": [
+        {
+          "address": "178.128.79.219",
+          "port": 3001
+        },
+        {
+          "address": "104.131.122.73",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.09037008433098426,
+      "relativeStake": 0.0034027457213479414,
+      "relays": [
+        {
+          "domain": "relay-kiln-1-0.cardano.mainnet.kiln.fi",
+          "port": 3001
+        },
+        {
+          "domain": "relay-kiln-1-1.cardano.mainnet.kiln.fi",
+          "port": 3001
+        },
+        {
+          "domain": "relay-kiln-1-2.cardano.mainnet.kiln.fi",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.09377011532166593,
+      "relativeStake": 0.00340003099068167,
       "relays": [
         {
           "domain": "relays.wavepool.digital",
@@ -337,8 +407,40 @@
       ]
     },
     {
-      "accumulatedStake": 0.08089047466917983,
-      "relativeStake": 0.0033611490102949484,
+      "accumulatedStake": 0.09716657053355796,
+      "relativeStake": 0.003396455211892031,
+      "relays": [
+        {
+          "domain": "gateway.adavault.com",
+          "port": 4021
+        },
+        {
+          "domain": "gateway.adavault.com",
+          "port": 4022
+        },
+        {
+          "domain": "gateway.adavault.com",
+          "port": 4026
+        },
+        {
+          "domain": "gateway.adavault.com",
+          "port": 4027
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.10056068710961175,
+      "relativeStake": 0.0033941165760537867,
+      "relays": [
+        {
+          "domain": "relays.wavepool.digital",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.10395075162665517,
+      "relativeStake": 0.0033900645170434245,
       "relays": [
         {
           "domain": "Relay1.NordicPool.org",
@@ -367,126 +469,18 @@
       ]
     },
     {
-      "accumulatedStake": 0.0842515668345033,
-      "relativeStake": 0.003361092165323485,
+      "accumulatedStake": 0.10733644967205139,
+      "relativeStake": 0.0033856980453962145,
       "relays": [
         {
-          "domain": "gateway.adavault.com",
-          "port": 4021
-        },
-        {
-          "domain": "gateway.adavault.com",
-          "port": 4022
-        },
-        {
-          "domain": "gateway.adavault.com",
-          "port": 4026
-        },
-        {
-          "domain": "gateway.adavault.com",
-          "port": 4027
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.08761213153473864,
-      "relativeStake": 0.0033605647002353293,
-      "relays": [
-        {
-          "domain": "27.cardano.staked.cloud",
+          "domain": "relays.wavepool.digital",
           "port": 3001
         }
       ]
     },
     {
-      "accumulatedStake": 0.09097104407231206,
-      "relativeStake": 0.0033589125375734223,
-      "relays": [
-        {
-          "domain": "28.cardano.staked.cloud",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.09432836944488607,
-      "relativeStake": 0.003357325372574011,
-      "relays": [
-        {
-          "domain": "30.cardano.staked.cloud",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.09768567496610549,
-      "relativeStake": 0.0033573055212194262,
-      "relays": [
-        {
-          "domain": "r1.spirestaking.com",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.10104171922860782,
-      "relativeStake": 0.0033560442625023192,
-      "relays": [
-        {
-          "domain": "26.cardano.staked.cloud",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.10439700837415569,
-      "relativeStake": 0.0033552891455478737,
-      "relays": [
-        {
-          "domain": "29.cardano.staked.cloud",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.1077475481223825,
-      "relativeStake": 0.003350539748226814,
-      "relays": [
-        {
-          "domain": "gateway.adavault.com",
-          "port": 4021
-        },
-        {
-          "domain": "gateway.adavault.com",
-          "port": 4022
-        },
-        {
-          "domain": "gateway.adavault.com",
-          "port": 4026
-        },
-        {
-          "domain": "gateway.adavault.com",
-          "port": 4027
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.11107318488772716,
-      "relativeStake": 0.003325636765344663,
-      "relays": [
-        {
-          "address": "173.15.110.154",
-          "port": 6000
-        },
-        {
-          "address": "173.15.110.155",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.11439877355519878,
-      "relativeStake": 0.0033255886674716253,
+      "accumulatedStake": 0.11071098524964716,
+      "relativeStake": 0.003374535577595773,
       "relays": [
         {
           "domain": "relaynode1.bravostakepool.nl",
@@ -503,40 +497,48 @@
       ]
     },
     {
-      "accumulatedStake": 0.1177195351438548,
-      "relativeStake": 0.0033207615886560143,
+      "accumulatedStake": 0.11408140691471562,
+      "relativeStake": 0.0033704216650684562,
       "relays": [
         {
-          "domain": "relay1-dl.aichi-stakepool.com",
-          "port": 6000
-        },
-        {
-          "domain": "relay2-jp.aichi-stakepool.com",
-          "port": 6000
-        },
-        {
-          "domain": "relay3-li.aichi-stakepool.com",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.12103792795653032,
-      "relativeStake": 0.003318392812675517,
-      "relays": [
-        {
-          "address": "46.101.9.225",
-          "port": 3001
-        },
-        {
-          "address": "64.227.46.95",
+          "domain": "relays.wavepool.digital",
           "port": 3001
         }
       ]
     },
     {
-      "accumulatedStake": 0.12435388639016197,
-      "relativeStake": 0.0033159584336316513,
+      "accumulatedStake": 0.11744292321882488,
+      "relativeStake": 0.003361516304109262,
+      "relays": [
+        {
+          "domain": "relays.wavepool.digital",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.1208041949689565,
+      "relativeStake": 0.0033612717501316216,
+      "relays": [
+        {
+          "domain": "f9395b98.cardano-relay.herd.run",
+          "port": 1338
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.12411393849278371,
+      "relativeStake": 0.003309743523827214,
+      "relays": [
+        {
+          "domain": "27.cardano.staked.cloud",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.12742267285589207,
+      "relativeStake": 0.003308734363108344,
       "relays": [
         {
           "domain": "gateway.adavault.com",
@@ -557,300 +559,28 @@
       ]
     },
     {
-      "accumulatedStake": 0.12765609659268437,
-      "relativeStake": 0.0033022102025223933,
+      "accumulatedStake": 0.13072977269756417,
+      "relativeStake": 0.0033070998416721235,
       "relays": [
         {
-          "domain": "Relay1.NordicPool.org",
-          "port": 3005
-        },
-        {
-          "domain": "Relay2.NordicPool.org",
-          "port": 3005
-        },
-        {
-          "domain": "Relay3.NordicPool.org",
-          "port": 3005
-        },
-        {
-          "domain": "Relay4.NordicPool.org",
-          "port": 3005
-        },
-        {
-          "domain": "Relay5.NordicPool.org",
-          "port": 3005
-        },
-        {
-          "domain": "Relay6.NordicPool.org",
-          "port": 3005
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.13095221287765377,
-      "relativeStake": 0.0032961162849693922,
-      "relays": [
-        {
-          "address": "54.220.20.40",
-          "port": 3002
-        },
-        {
-          "domain": "octaluso.dyndns.org",
-          "port": 3002
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.13423637223181467,
-      "relativeStake": 0.0032841593541609246,
-      "relays": [
-        {
-          "domain": "8d6f8de4.cardano-relay.herd.run",
-          "port": 1338
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.13751764199942715,
-      "relativeStake": 0.0032812697676124687,
-      "relays": [
-        {
-          "domain": "31.cardano.staked.cloud",
+          "domain": "28.cardano.staked.cloud",
           "port": 3001
         }
       ]
     },
     {
-      "accumulatedStake": 0.14079815974971083,
-      "relativeStake": 0.0032805177502836756,
+      "accumulatedStake": 0.13403473002129088,
+      "relativeStake": 0.0033049573237266885,
       "relays": [
         {
-          "domain": "b3e201f4.cardano-relay.bison.run",
-          "port": 1338
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.14407756529511212,
-      "relativeStake": 0.0032794055454012983,
-      "relays": [
-        {
-          "domain": "b3bbbcac.cardano-relay.bison.run",
-          "port": 1338
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.14735602379307547,
-      "relativeStake": 0.0032784584979633565,
-      "relays": [
-        {
-          "domain": "ddbb5a06.cardano-relay.herd.run",
-          "port": 1338
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.15062923438174472,
-      "relativeStake": 0.0032732105886692257,
-      "relays": [
-        {
-          "domain": "7ddb9c28.cardano-relay.bison.run",
-          "port": 1338
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.15390215665116302,
-      "relativeStake": 0.003272922269418322,
-      "relays": [
-        {
-          "domain": "e4527900.cardano-relay.herd.run",
-          "port": 1338
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.15717398261575816,
-      "relativeStake": 0.003271825964595117,
-      "relays": [
-        {
-          "domain": "9a956262.cardano-relay.bison.run",
-          "port": 1338
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.16044579411171841,
-      "relativeStake": 0.003271811495960281,
-      "relays": [
-        {
-          "domain": "a94da6a8.cardano-relay.bison.run",
-          "port": 1338
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.1637175128634382,
-      "relativeStake": 0.003271718751719769,
-      "relays": [
-        {
-          "domain": "e646e266.cardano-relay.bison.run",
-          "port": 1338
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.1669890653495671,
-      "relativeStake": 0.0032715524861288824,
-      "relays": [
-        {
-          "domain": "f84db19f.cardano-relay.bison.run",
-          "port": 1338
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.17026041790157792,
-      "relativeStake": 0.003271352552010834,
-      "relays": [
-        {
-          "domain": "778cb679.cardano-relay.bison.run",
-          "port": 1338
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.17353135647029566,
-      "relativeStake": 0.0032709385687177427,
-      "relays": [
-        {
-          "domain": "94cc7304.cardano-relay.bison.run",
-          "port": 1338
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.17680227856113942,
-      "relativeStake": 0.003270922090843778,
-      "relays": [
-        {
-          "domain": "a5f2af9f.cardano-relay.bison.run",
-          "port": 1338
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.18007318082571502,
-      "relativeStake": 0.0032709022645756,
-      "relays": [
-        {
-          "domain": "bb78d57d.cardano-relay.bison.run",
-          "port": 1338
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.18334403225605922,
-      "relativeStake": 0.0032708514303441878,
-      "relays": [
-        {
-          "domain": "07f6ea55.cardano-relay.herd.run",
-          "port": 1338
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.186614815696106,
-      "relativeStake": 0.003270783440046769,
-      "relays": [
-        {
-          "domain": "9dc533bf.cardano-relay.herd.run",
-          "port": 1338
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.18988543402087488,
-      "relativeStake": 0.0032706183247688805,
-      "relays": [
-        {
-          "domain": "dbe22510.cardano-relay.bison.run",
-          "port": 1338
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.1931560208999753,
-      "relativeStake": 0.003270586879100415,
-      "relays": [
-        {
-          "domain": "72e508af.cardano-relay.herd.run",
-          "port": 1338
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.19642658697510204,
-      "relativeStake": 0.0032705660751267407,
-      "relays": [
-        {
-          "domain": "d489c136.cardano-relay.bison.run",
-          "port": 1338
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.1996970069653928,
-      "relativeStake": 0.0032704199902907636,
-      "relays": [
-        {
-          "domain": "d89eeea0.cardano-relay.herd.run",
-          "port": 1338
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.20295783276636578,
-      "relativeStake": 0.0032608258009729787,
-      "relays": [
-        {
-          "domain": "relay.cardano.securestaking.io",
-          "port": 3000
-        },
-        {
-          "domain": "secur2.cardano.securestaking.io",
-          "port": 3000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.2061942876180462,
-      "relativeStake": 0.003236454851680438,
-      "relays": [
-        {
-          "domain": "relays.wavepool.digital",
+          "domain": "26.cardano.staked.cloud",
           "port": 3001
         }
       ]
     },
     {
-      "accumulatedStake": 0.20942563168959502,
-      "relativeStake": 0.0032313440715488044,
-      "relays": [
-        {
-          "domain": "relays-2a.cardano.figment.io",
-          "port": 3001
-        },
-        {
-          "domain": "relays-2b.cardano.figment.io",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.21264896839579014,
-      "relativeStake": 0.0032233367061951395,
+      "accumulatedStake": 0.13733913560013478,
+      "relativeStake": 0.0033044055788439197,
       "relays": [
         {
           "domain": "cardano-main.everstake.one",
@@ -875,8 +605,356 @@
       ]
     },
     {
-      "accumulatedStake": 0.21583520985074825,
-      "relativeStake": 0.003186241454958112,
+      "accumulatedStake": 0.14061148587137393,
+      "relativeStake": 0.0032723502712391486,
+      "relays": [
+        {
+          "address": "57.128.184.33",
+          "port": 3001
+        },
+        {
+          "address": "57.128.184.31",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.1438806301079893,
+      "relativeStake": 0.003269144236615368,
+      "relays": [
+        {
+          "address": "46.101.9.225",
+          "port": 3001
+        },
+        {
+          "address": "64.227.46.95",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.147144937426532,
+      "relativeStake": 0.0032643073185426993,
+      "relays": [
+        {
+          "domain": "Relay1.NordicPool.org",
+          "port": 3005
+        },
+        {
+          "domain": "Relay2.NordicPool.org",
+          "port": 3005
+        },
+        {
+          "domain": "Relay3.NordicPool.org",
+          "port": 3005
+        },
+        {
+          "domain": "Relay4.NordicPool.org",
+          "port": 3005
+        },
+        {
+          "domain": "Relay5.NordicPool.org",
+          "port": 3005
+        },
+        {
+          "domain": "Relay6.NordicPool.org",
+          "port": 3005
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.15037918869163627,
+      "relativeStake": 0.0032342512651042754,
+      "relays": [
+        {
+          "domain": "8d6f8de4.cardano-relay.herd.run",
+          "port": 1338
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.15361058740058461,
+      "relativeStake": 0.0032313987089483344,
+      "relays": [
+        {
+          "domain": "b3e201f4.cardano-relay.bison.run",
+          "port": 1338
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.15684031601294832,
+      "relativeStake": 0.0032297286123636935,
+      "relays": [
+        {
+          "domain": "b3bbbcac.cardano-relay.bison.run",
+          "port": 1338
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.16006877604248956,
+      "relativeStake": 0.0032284600295412456,
+      "relays": [
+        {
+          "domain": "ddbb5a06.cardano-relay.herd.run",
+          "port": 1338
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.1632925725657836,
+      "relativeStake": 0.0032237965232940545,
+      "relays": [
+        {
+          "domain": "7ddb9c28.cardano-relay.bison.run",
+          "port": 1338
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.16651600584861834,
+      "relativeStake": 0.0032234332828347256,
+      "relays": [
+        {
+          "domain": "e4527900.cardano-relay.herd.run",
+          "port": 1338
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.16973875261372176,
+      "relativeStake": 0.003222746765103418,
+      "relays": [
+        {
+          "domain": "relay-kiln-4-0.cardano.mainnet.kiln.fi",
+          "port": 3001
+        },
+        {
+          "domain": "relay-kiln-4-1.cardano.mainnet.kiln.fi",
+          "port": 3001
+        },
+        {
+          "domain": "relay-kiln-4-2.cardano.mainnet.kiln.fi",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.17296102331076893,
+      "relativeStake": 0.003222270697047178,
+      "relays": [
+        {
+          "domain": "9a956262.cardano-relay.bison.run",
+          "port": 1338
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.17618268556324926,
+      "relativeStake": 0.003221662252480322,
+      "relays": [
+        {
+          "domain": "778cb679.cardano-relay.bison.run",
+          "port": 1338
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.1794043130278546,
+      "relativeStake": 0.003221627464605344,
+      "relays": [
+        {
+          "domain": "fdd5329e.cardano-relay.bison.run",
+          "port": 1338
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.18262589482413513,
+      "relativeStake": 0.0032215817962805288,
+      "relays": [
+        {
+          "domain": "f84db19f.cardano-relay.bison.run",
+          "port": 1338
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.18584737942669916,
+      "relativeStake": 0.003221484602564027,
+      "relays": [
+        {
+          "domain": "bb78d57d.cardano-relay.bison.run",
+          "port": 1338
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.18906867826033108,
+      "relativeStake": 0.003221298833631919,
+      "relays": [
+        {
+          "domain": "a5f2af9f.cardano-relay.bison.run",
+          "port": 1338
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.19228985113444427,
+      "relativeStake": 0.0032211728741132137,
+      "relays": [
+        {
+          "domain": "dbe22510.cardano-relay.bison.run",
+          "port": 1338
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.19551101805636528,
+      "relativeStake": 0.0032211669219209898,
+      "relays": [
+        {
+          "domain": "07f6ea55.cardano-relay.herd.run",
+          "port": 1338
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.19873218020823183,
+      "relativeStake": 0.003221162151866561,
+      "relays": [
+        {
+          "domain": "9dc533bf.cardano-relay.herd.run",
+          "port": 1338
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.20195332179770034,
+      "relativeStake": 0.0032211415894685077,
+      "relays": [
+        {
+          "domain": "72e508af.cardano-relay.herd.run",
+          "port": 1338
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.20517440948743126,
+      "relativeStake": 0.0032210876897309183,
+      "relays": [
+        {
+          "domain": "a94da6a8.cardano-relay.bison.run",
+          "port": 1338
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.20839543049343562,
+      "relativeStake": 0.0032210210060043556,
+      "relays": [
+        {
+          "domain": "e646e266.cardano-relay.bison.run",
+          "port": 1338
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.2116164505792949,
+      "relativeStake": 0.0032210200858592843,
+      "relays": [
+        {
+          "domain": "d489c136.cardano-relay.bison.run",
+          "port": 1338
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.21483741178214916,
+      "relativeStake": 0.0032209612028542473,
+      "relays": [
+        {
+          "domain": "d89eeea0.cardano-relay.herd.run",
+          "port": 1338
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.21805828362020738,
+      "relativeStake": 0.003220871838058236,
+      "relays": [
+        {
+          "domain": "94cc7304.cardano-relay.bison.run",
+          "port": 1338
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.22127563460089214,
+      "relativeStake": 0.003217350980684754,
+      "relays": [
+        {
+          "domain": "gateway.adavault.com",
+          "port": 4021
+        },
+        {
+          "domain": "gateway.adavault.com",
+          "port": 4022
+        },
+        {
+          "domain": "gateway.adavault.com",
+          "port": 4026
+        },
+        {
+          "domain": "gateway.adavault.com",
+          "port": 4027
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.22448755974491585,
+      "relativeStake": 0.0032119251440237144,
+      "relays": [
+        {
+          "domain": "relay1-dl.aichi-stakepool.com",
+          "port": 6000
+        },
+        {
+          "domain": "relay2-jp.aichi-stakepool.com",
+          "port": 6000
+        },
+        {
+          "domain": "relay3-li.aichi-stakepool.com",
+          "port": 6000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.2276934470798282,
+      "relativeStake": 0.003205887334912331,
+      "relays": [
+        {
+          "address": "148.113.17.23",
+          "port": 6000
+        },
+        {
+          "address": "158.69.25.103",
+          "port": 6000
+        },
+        {
+          "address": "95.216.70.238",
+          "port": 6000
+        },
+        {
+          "address": "149.102.140.234",
+          "port": 6000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.23088940142549624,
+      "relativeStake": 0.003195954345668059,
       "relays": [
         {
           "domain": "relay1.str8pool.com",
@@ -889,22 +967,110 @@
       ]
     },
     {
-      "accumulatedStake": 0.21902016856304804,
-      "relativeStake": 0.003184958712299777,
+      "accumulatedStake": 0.2340637759196461,
+      "relativeStake": 0.0031743744941498623,
       "relays": [
         {
-          "domain": "relay1.clovernodes.io",
+          "domain": "157.173.120.233",
+          "port": 3001
+        },
+        {
+          "domain": "157.173.120.233",
+          "port": 3002
+        },
+        {
+          "domain": "144.126.157.40",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.23723476451121192,
+      "relativeStake": 0.003170988591565813,
+      "relays": [
+        {
+          "address": "152.53.21.151",
           "port": 6000
         },
         {
-          "domain": "relay2.clovernodes.io",
+          "address": "149.102.152.63",
           "port": 6000
         }
       ]
     },
     {
-      "accumulatedStake": 0.22219782656810735,
-      "relativeStake": 0.0031776580050593053,
+      "accumulatedStake": 0.24036245641351361,
+      "relativeStake": 0.0031276919023017057,
+      "relays": [
+        {
+          "domain": "cardano.staking.copper.co",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.24348450710054423,
+      "relativeStake": 0.003122050687030611,
+      "relays": [
+        {
+          "domain": "bd-cardano-main-relay-12-a.bdnodes.net",
+          "port": 6000
+        },
+        {
+          "domain": "bd-cardano-main-relay-12-b.bdnodes.net",
+          "port": 6000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.24657833659866993,
+      "relativeStake": 0.0030938294981256937,
+      "relays": [
+        {
+          "domain": "92a8429c.cardano-relay.herd.run",
+          "port": 1338
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.24967070538671374,
+      "relativeStake": 0.0030923687880438262,
+      "relays": [
+        {
+          "domain": "r1.adastat.net",
+          "port": 3333
+        },
+        {
+          "domain": "r2.adastat.net",
+          "port": 3333
+        },
+        {
+          "domain": "r3.adastat.net",
+          "port": 3333
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.2527581940943777,
+      "relativeStake": 0.003087488707663957,
+      "relays": [
+        {
+          "domain": "relays.stakepool.at",
+          "port": 3001
+        },
+        {
+          "domain": "relay-1.stakepool.at",
+          "port": 3001
+        },
+        {
+          "domain": "relay-2.stakepool.at",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.2558130011934145,
+      "relativeStake": 0.0030548070990367724,
       "relays": [
         {
           "domain": "cof-1.cardanocafe.org",
@@ -933,82 +1099,34 @@
       ]
     },
     {
-      "accumulatedStake": 0.22537267092257302,
-      "relativeStake": 0.003174844354465657,
+      "accumulatedStake": 0.25885476598976115,
+      "relativeStake": 0.003041764796346656,
       "relays": [
         {
-          "address": "152.53.21.151",
-          "port": 6000
-        },
-        {
-          "address": "149.102.152.63",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.22853322950771895,
-      "relativeStake": 0.003160558585145943,
-      "relays": [
-        {
-          "domain": "bd-cardano-main-relay-12-a.bdnodes.net",
-          "port": 6000
-        },
-        {
-          "domain": "bd-cardano-main-relay-12-b.bdnodes.net",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.2316871392066803,
-      "relativeStake": 0.0031539096989613618,
-      "relays": [
-        {
-          "domain": "rockyrelay1.ddns.net",
+          "domain": "cardano-main.everstake.one",
           "port": 3001
         },
         {
-          "domain": "rockyrelay2.ddns.net",
-          "port": 3002
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.23484077615061344,
-      "relativeStake": 0.003153636943933128,
-      "relays": [
-        {
-          "domain": "relay.cardano.securestaking.io",
-          "port": 3000
-        },
-        {
-          "domain": "secur2.cardano.securestaking.io",
-          "port": 3000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.2379498689939587,
-      "relativeStake": 0.003109092843345254,
-      "relays": [
-        {
-          "domain": "relays.stakepool.at",
+          "domain": "cardano-main2.everstake.one",
           "port": 3001
         },
         {
-          "domain": "relay-1.stakepool.at",
+          "domain": "cardano-relay.everstake.one",
           "port": 3001
         },
         {
-          "domain": "relay-2.stakepool.at",
+          "domain": "cardano-relay1.everstake.one",
+          "port": 3001
+        },
+        {
+          "domain": "cardano-relay2.everstake.one",
           "port": 3001
         }
       ]
     },
     {
-      "accumulatedStake": 0.2410522295094514,
-      "relativeStake": 0.003102360515492703,
+      "accumulatedStake": 0.26189101916733093,
+      "relativeStake": 0.003036253177569816,
       "relays": [
         {
           "address": "148.113.17.23",
@@ -1029,48 +1147,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.24415344819435764,
-      "relativeStake": 0.003101218684906246,
-      "relays": [
-        {
-          "domain": "cardano-main.everstake.one",
-          "port": 3001
-        },
-        {
-          "domain": "cardano-main2.everstake.one",
-          "port": 3001
-        },
-        {
-          "domain": "cardano-relay.everstake.one",
-          "port": 3001
-        },
-        {
-          "domain": "cardano-relay1.everstake.one",
-          "port": 3001
-        },
-        {
-          "domain": "cardano-relay2.everstake.one",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.24723402976727732,
-      "relativeStake": 0.0030805815729196932,
-      "relays": [
-        {
-          "address": "57.129.28.179",
-          "port": 3001
-        },
-        {
-          "address": "57.129.28.180",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.25031445624640514,
-      "relativeStake": 0.003080426479127789,
+      "accumulatedStake": 0.26492313658360683,
+      "relativeStake": 0.0030321174162758952,
       "relays": [
         {
           "address": "109.123.231.213",
@@ -1083,48 +1161,60 @@
       ]
     },
     {
-      "accumulatedStake": 0.2533883199217026,
-      "relativeStake": 0.003073863675297482,
+      "accumulatedStake": 0.26795352524796046,
+      "relativeStake": 0.00303038866435362,
       "relays": [
         {
-          "domain": "relays.digi.pro",
+          "domain": "cardano-relays.autostake.com",
           "port": 3001
         }
       ]
     },
     {
-      "accumulatedStake": 0.25646195098732105,
-      "relativeStake": 0.003073631065618445,
+      "accumulatedStake": 0.27098109489813504,
+      "relativeStake": 0.0030275696501745495,
       "relays": [
         {
-          "domain": "Relay1.NordicPool.org",
-          "port": 3005
+          "domain": "relay1.clovernodes.io",
+          "port": 6000
         },
         {
-          "domain": "Relay2.NordicPool.org",
-          "port": 3005
-        },
-        {
-          "domain": "Relay3.NordicPool.org",
-          "port": 3005
-        },
-        {
-          "domain": "Relay4.NordicPool.org",
-          "port": 3005
-        },
-        {
-          "domain": "Relay5.NordicPool.org",
-          "port": 3005
-        },
-        {
-          "domain": "Relay6.NordicPool.org",
-          "port": 3005
+          "domain": "relay2.clovernodes.io",
+          "port": 6000
         }
       ]
     },
     {
-      "accumulatedStake": 0.2595347112439043,
-      "relativeStake": 0.0030727602565832892,
+      "accumulatedStake": 0.2740068018246911,
+      "relativeStake": 0.0030257069265560753,
+      "relays": [
+        {
+          "domain": "rockyrelay1.ddns.net",
+          "port": 3001
+        },
+        {
+          "domain": "rockyrelay2.ddns.net",
+          "port": 3002
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.2770282626834422,
+      "relativeStake": 0.0030214608587511376,
+      "relays": [
+        {
+          "domain": "relay1.snakerelays.link",
+          "port": 3001
+        },
+        {
+          "domain": "relay2.snakerelays.link",
+          "port": 3002
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.28004441364017374,
+      "relativeStake": 0.0030161509567314844,
       "relays": [
         {
           "domain": "relay.cardano.securestaking.io",
@@ -1137,64 +1227,40 @@
       ]
     },
     {
-      "accumulatedStake": 0.2625971106741357,
-      "relativeStake": 0.003062399430231392,
+      "accumulatedStake": 0.28305174510622766,
+      "relativeStake": 0.0030073314660539626,
       "relays": [
         {
-          "domain": "relay1.mainnet.pool.cardano.services",
-          "port": 3001
+          "domain": "r-eu-0.titanstaking.io",
+          "port": 4321
         },
         {
-          "domain": "relay2.mainnet.pool.cardano.services",
-          "port": 3001
+          "domain": "r-eu-1.titanstaking.io",
+          "port": 4321
+        },
+        {
+          "domain": "r-eu-2.titanstaking.io",
+          "port": 4321
         }
       ]
     },
     {
-      "accumulatedStake": 0.2656407361948341,
-      "relativeStake": 0.0030436255206983545,
+      "accumulatedStake": 0.2860570754452868,
+      "relativeStake": 0.003005330339059147,
       "relays": [
         {
-          "domain": "benitoite-rohan-d68b9.cardano.bdnodes.net",
-          "port": 6000
+          "address": "54.220.20.40",
+          "port": 3002
         },
         {
-          "domain": "brown-lagos-6a470.cardano.bdnodes.net",
-          "port": 6000
+          "domain": "octaluso.dyndns.org",
+          "port": 3002
         }
       ]
     },
     {
-      "accumulatedStake": 0.2686743653681939,
-      "relativeStake": 0.0030336291733597805,
-      "relays": [
-        {
-          "domain": "relays.wavepool.digital",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.2717069974815592,
-      "relativeStake": 0.003032632113365328,
-      "relays": [
-        {
-          "domain": "r1.adastat.net",
-          "port": 3333
-        },
-        {
-          "domain": "r2.adastat.net",
-          "port": 3333
-        },
-        {
-          "domain": "r3.adastat.net",
-          "port": 3333
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.2747353463178846,
-      "relativeStake": 0.003028348836325423,
+      "accumulatedStake": 0.28904774996464455,
+      "relativeStake": 0.0029906745193577517,
       "relays": [
         {
           "domain": "relays-2a.cardano.2k2aa.com",
@@ -1207,58 +1273,22 @@
       ]
     },
     {
-      "accumulatedStake": 0.2777609656536593,
-      "relativeStake": 0.0030256193357746913,
+      "accumulatedStake": 0.2920113847010661,
+      "relativeStake": 0.0029636347364215055,
       "relays": [
         {
-          "domain": "relays.wavepool.digital",
+          "address": "57.128.184.27",
+          "port": 3001
+        },
+        {
+          "address": "57.128.184.86",
           "port": 3001
         }
       ]
     },
     {
-      "accumulatedStake": 0.28078182499250437,
-      "relativeStake": 0.0030208593388450495,
-      "relays": [
-        {
-          "domain": "relay.anonaf.com",
-          "port": 3333
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.2837865615273827,
-      "relativeStake": 0.0030047365348783448,
-      "relays": [
-        {
-          "domain": "iogp4-relays.cardano.iog.io",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.2867912820944668,
-      "relativeStake": 0.0030047205670840987,
-      "relays": [
-        {
-          "domain": "iogp3-relays.cardano.iog.io",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.28979594582425766,
-      "relativeStake": 0.003004663729790872,
-      "relays": [
-        {
-          "domain": "iogp2-relays.cardano.iog.io",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.29279256941575305,
-      "relativeStake": 0.0029966235914953817,
+      "accumulatedStake": 0.29497280925215824,
+      "relativeStake": 0.002961424551092149,
       "relays": [
         {
           "domain": "relays-15a.cardano.2k2aa.com",
@@ -1271,8 +1301,48 @@
       ]
     },
     {
-      "accumulatedStake": 0.2957814315727438,
-      "relativeStake": 0.002988862156990706,
+      "accumulatedStake": 0.29793188552192534,
+      "relativeStake": 0.002959076269767089,
+      "relays": [
+        {
+          "domain": "iogp3-relays.cardano.iog.io",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.3008909273628129,
+      "relativeStake": 0.0029590418408876173,
+      "relays": [
+        {
+          "domain": "iogp4-relays.cardano.iog.io",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.3038499489007828,
+      "relativeStake": 0.0029590215379698957,
+      "relays": [
+        {
+          "domain": "iogp2-relays.cardano.iog.io",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.3068050511935983,
+      "relativeStake": 0.002955102292815448,
+      "relays": [
+        {
+          "domain": "relays.digi.pro",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.3097596436092651,
+      "relativeStake": 0.0029545924156668527,
       "relays": [
         {
           "domain": "relays-14a.cardano.2k2aa.com",
@@ -1285,8 +1355,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.2987692513195343,
-      "relativeStake": 0.0029878197467905353,
+      "accumulatedStake": 0.31271282930080685,
+      "relativeStake": 0.002953185691541745,
       "relays": [
         {
           "domain": "relays-16a.cardano.2k2aa.com",
@@ -1299,40 +1369,46 @@
       ]
     },
     {
-      "accumulatedStake": 0.30174339004785944,
-      "relativeStake": 0.002974138728325162,
+      "accumulatedStake": 0.31566024438276297,
+      "relativeStake": 0.0029474150819560757,
       "relays": [
         {
-          "domain": "92a8429c.cardano-relay.herd.run",
-          "port": 1338
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.30471749214822436,
-      "relativeStake": 0.0029741021003649097,
-      "relays": [
-        {
-          "address": "148.113.17.23",
+          "address": "54.37.87.63",
           "port": 6000
         },
         {
-          "address": "158.69.25.103",
-          "port": 6000
-        },
-        {
-          "address": "95.216.70.238",
-          "port": 6000
-        },
-        {
-          "address": "149.102.140.196",
+          "address": "54.36.178.85",
           "port": 6000
         }
       ]
     },
     {
-      "accumulatedStake": 0.30769071769936535,
-      "relativeStake": 0.002973225551140967,
+      "accumulatedStake": 0.3185991103508011,
+      "relativeStake": 0.002938865968038127,
+      "relays": [
+        {
+          "domain": "relays.wavepool.digital",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.32153792123584135,
+      "relativeStake": 0.0029388108850402868,
+      "relays": [
+        {
+          "address": "173.15.110.154",
+          "port": 6000
+        },
+        {
+          "address": "173.15.110.155",
+          "port": 6000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.32446432681872067,
+      "relativeStake": 0.0029264055828793277,
       "relays": [
         {
           "domain": "rel01.fairpool.eu",
@@ -1353,8 +1429,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.31066265708830215,
-      "relativeStake": 0.002971939388936794,
+      "accumulatedStake": 0.32737626219344057,
+      "relativeStake": 0.0029119353747198776,
       "relays": [
         {
           "domain": "relay1.adaocean.com",
@@ -1379,8 +1455,148 @@
       ]
     },
     {
-      "accumulatedStake": 0.31361257001157944,
-      "relativeStake": 0.002949912923277337,
+      "accumulatedStake": 0.3302745214176749,
+      "relativeStake": 0.0028982592242343284,
+      "relays": [
+        {
+          "domain": "relays.onyxstakepool.com",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.33316642694826426,
+      "relativeStake": 0.0028919055305893678,
+      "relays": [
+        {
+          "domain": "relay1.adaocean.com",
+          "port": 6000
+        },
+        {
+          "domain": "relay2.adaocean.com",
+          "port": 6000
+        },
+        {
+          "domain": "relay3.adaocean.com",
+          "port": 6000
+        },
+        {
+          "domain": "relay4.adaocean.com",
+          "port": 6000
+        },
+        {
+          "domain": "relay5.adaocean.com",
+          "port": 6000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.33604677092606605,
+      "relativeStake": 0.002880343977801785,
+      "relays": [
+        {
+          "domain": "relay.anonaf.com",
+          "port": 3333
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.3389246200844307,
+      "relativeStake": 0.0028778491583646305,
+      "relays": [
+        {
+          "domain": "cardano.staking.copper.co",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.34179831614711476,
+      "relativeStake": 0.0028736960626840717,
+      "relays": [
+        {
+          "domain": "11.relays.happystaking.io",
+          "port": 3001
+        },
+        {
+          "domain": "12.relays.happystaking.io",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.34466459125941307,
+      "relativeStake": 0.002866275112298304,
+      "relays": [
+        {
+          "domain": "relays-10a.cardano.2k2aa.com",
+          "port": 3001
+        },
+        {
+          "domain": "relays-10b.cardano.aeq5f.com",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.34753017715074874,
+      "relativeStake": 0.002865585891335698,
+      "relays": [
+        {
+          "domain": "r1.1percentpool.eu",
+          "port": 19001
+        },
+        {
+          "domain": "r2.1percentpool.eu",
+          "port": 19002
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.3503901709325453,
+      "relativeStake": 0.002859993781796576,
+      "relays": [
+        {
+          "domain": "eu.relays.cardanians.io",
+          "port": 1000
+        },
+        {
+          "domain": "ca.relays.cardanians.io",
+          "port": 1000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.35323870350373593,
+      "relativeStake": 0.0028485325711906048,
+      "relays": [
+        {
+          "domain": "relay1.mainnet.pool.cardano.services",
+          "port": 3001
+        },
+        {
+          "domain": "relay2.mainnet.pool.cardano.services",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.3560783237424523,
+      "relativeStake": 0.0028396202387163394,
+      "relays": [
+        {
+          "domain": "eu.relays.cardanians.io",
+          "port": 1000
+        },
+        {
+          "domain": "ca.relays.cardanians.io",
+          "port": 1000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.3588620669852814,
+      "relativeStake": 0.0027837432428291274,
       "relays": [
         {
           "domain": "relays.stakepool.at",
@@ -1397,172 +1613,46 @@
       ]
     },
     {
-      "accumulatedStake": 0.31655406585278895,
-      "relativeStake": 0.002941495841209475,
+      "accumulatedStake": 0.3616454585554114,
+      "relativeStake": 0.0027833915701300184,
       "relays": [
         {
-          "address": "57.128.184.27",
-          "port": 3001
-        },
-        {
-          "address": "57.128.184.86",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.3194863315954182,
-      "relativeStake": 0.002932265742629285,
-      "relays": [
-        {
-          "domain": "94c3c6d3.cardano-relay.herd.run",
-          "port": 1338
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.3224072018198557,
-      "relativeStake": 0.002920870224437485,
-      "relays": [
-        {
-          "address": "54.37.87.63",
+          "address": "49.12.198.221",
           "port": 6000
         },
         {
-          "address": "54.36.178.85",
+          "address": "89.58.18.51",
+          "port": 6000
+        },
+        {
+          "address": "131.153.199.82",
           "port": 6000
         }
       ]
     },
     {
-      "accumulatedStake": 0.3253263068019061,
-      "relativeStake": 0.00291910498205038,
+      "accumulatedStake": 0.36442483292728667,
+      "relativeStake": 0.0027793743718752513,
       "relays": [
         {
-          "domain": "relays.mainnet.pools.fivebinaries.com",
+          "address": "52.6.109.221",
           "port": 3001
         }
       ]
     },
     {
-      "accumulatedStake": 0.3282439501792248,
-      "relativeStake": 0.0029176433773187398,
+      "accumulatedStake": 0.36720181975513844,
+      "relativeStake": 0.002776986827851747,
       "relays": [
         {
-          "domain": "relay1.adaocean.com",
-          "port": 6000
-        },
-        {
-          "domain": "relay2.adaocean.com",
-          "port": 6000
-        },
-        {
-          "domain": "relay3.adaocean.com",
-          "port": 6000
-        },
-        {
-          "domain": "relay4.adaocean.com",
-          "port": 6000
-        },
-        {
-          "domain": "relay5.adaocean.com",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.331146919548804,
-      "relativeStake": 0.0029029693695791507,
-      "relays": [
-        {
-          "domain": "r1.1percentpool.eu",
-          "port": 19001
-        },
-        {
-          "domain": "r2.1percentpool.eu",
-          "port": 19002
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.33402834231131046,
-      "relativeStake": 0.0028814227625064766,
-      "relays": [
-        {
-          "domain": "eu.relays.cardanians.io",
-          "port": 1000
-        },
-        {
-          "domain": "ca.relays.cardanians.io",
-          "port": 1000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.3369090035812527,
-      "relativeStake": 0.002880661269942244,
-      "relays": [
-        {
-          "domain": "relays.wavepool.digital",
+          "domain": "relays.smaug.pool.pm",
           "port": 3001
         }
       ]
     },
     {
-      "accumulatedStake": 0.33978168691587657,
-      "relativeStake": 0.0028726833346238694,
-      "relays": [
-        {
-          "domain": "11.relays.happystaking.io",
-          "port": 3001
-        },
-        {
-          "domain": "12.relays.happystaking.io",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.34265239947264803,
-      "relativeStake": 0.00287071255677146,
-      "relays": [
-        {
-          "domain": "eu.relays.cardanians.io",
-          "port": 1000
-        },
-        {
-          "domain": "ca.relays.cardanians.io",
-          "port": 1000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.3454957519214724,
-      "relativeStake": 0.0028433524488244064,
-      "relays": [
-        {
-          "domain": "universe.pxlz.org",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.34829691503245674,
-      "relativeStake": 0.0028011631109842975,
-      "relays": [
-        {
-          "domain": "relay1.apexfusionhosting.com",
-          "port": 3001
-        },
-        {
-          "domain": "relay2.apexfusionhosting.com",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.3510891650551469,
-      "relativeStake": 0.0027922500226901714,
+      "accumulatedStake": 0.36997778414134996,
+      "relativeStake": 0.0027759643862115533,
       "relays": [
         {
           "domain": "r-eu-0.titanstaking.io",
@@ -1579,76 +1669,32 @@
       ]
     },
     {
-      "accumulatedStake": 0.35386544356395183,
-      "relativeStake": 0.00277627850880495,
+      "accumulatedStake": 0.3727195919418409,
+      "relativeStake": 0.0027418078004909107,
       "relays": [
         {
-          "domain": "relays.smaug.pool.pm",
+          "domain": "relays.mainnet.pools.fivebinaries.com",
           "port": 3001
         }
       ]
     },
     {
-      "accumulatedStake": 0.35662408425354425,
-      "relativeStake": 0.0027586406895924198,
+      "accumulatedStake": 0.3754279675390421,
+      "relativeStake": 0.002708375597201211,
       "relays": [
         {
-          "domain": "relays.cardanowithpaul.com",
-          "port": 1069
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.3593624352872084,
-      "relativeStake": 0.002738351033664157,
-      "relays": [
-        {
-          "domain": "cardano.staking.copper.co",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.36208480561810996,
-      "relativeStake": 0.002722370330901545,
-      "relays": [
-        {
-          "address": "91.242.214.33",
-          "port": 3001
+          "domain": "r1.1percentpool.eu",
+          "port": 19001
         },
         {
-          "address": "186.233.187.33",
-          "port": 3001
+          "domain": "r2.1percentpool.eu",
+          "port": 19002
         }
       ]
     },
     {
-      "accumulatedStake": 0.3648041189256034,
-      "relativeStake": 0.00271931330749342,
-      "relays": [
-        {
-          "address": "52.6.109.221",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.36751800481058056,
-      "relativeStake": 0.002713885884977182,
-      "relays": [
-        {
-          "domain": "relay-1.minswap.org",
-          "port": 3001
-        },
-        {
-          "domain": "relay-2.minswap.org",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.3702318126015134,
-      "relativeStake": 0.002713807790932794,
+      "accumulatedStake": 0.37812538884968583,
+      "relativeStake": 0.0026974213106437292,
       "relays": [
         {
           "domain": "relay1-us.xstakepool.com",
@@ -1669,8 +1715,160 @@
       ]
     },
     {
-      "accumulatedStake": 0.37293840442976256,
-      "relativeStake": 0.0027065918282491728,
+      "accumulatedStake": 0.3808196664706623,
+      "relativeStake": 0.0026942776209764353,
+      "relays": [
+        {
+          "domain": "benitoite-rohan-d68b9.cardano.bdnodes.net",
+          "port": 6000
+        },
+        {
+          "domain": "brown-lagos-6a470.cardano.bdnodes.net",
+          "port": 6000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.3835104130603558,
+      "relativeStake": 0.002690746589693582,
+      "relays": [
+        {
+          "address": "91.242.214.33",
+          "port": 3001
+        },
+        {
+          "address": "186.233.187.33",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.38616436390790254,
+      "relativeStake": 0.002653950847546704,
+      "relays": [
+        {
+          "address": "35.211.17.86",
+          "port": 3000
+        },
+        {
+          "address": "34.23.88.7",
+          "port": 3000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.388816785975754,
+      "relativeStake": 0.002652422067851421,
+      "relays": [
+        {
+          "domain": "relays.cardanowithpaul.com",
+          "port": 1069
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.3914672027261398,
+      "relativeStake": 0.002650416750385824,
+      "relays": [
+        {
+          "domain": "relay1.apexfusionhosting.com",
+          "port": 3001
+        },
+        {
+          "domain": "relay2.apexfusionhosting.com",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.39408991364016993,
+      "relativeStake": 0.0026227109140301392,
+      "relays": [
+        {
+          "domain": "olive-geonosis-edffc.cardano.bdnodes.net",
+          "port": 6000
+        },
+        {
+          "domain": "violet-kingston-8d67e.cardano.bdnodes.net",
+          "port": 6000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.39669477936249975,
+      "relativeStake": 0.002604865722329816,
+      "relays": [
+        {
+          "address": "20.61.229.103",
+          "port": 3001
+        },
+        {
+          "address": "20.61.228.218",
+          "port": 3001
+        },
+        {
+          "address": "108.142.42.221",
+          "port": 3001
+        },
+        {
+          "address": "108.142.42.161",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.3992877687415721,
+      "relativeStake": 0.0025929893790723906,
+      "relays": [
+        {
+          "domain": "104.131.47.170",
+          "port": 6000
+        },
+        {
+          "domain": "128.199.64.13",
+          "port": 6000
+        },
+        {
+          "domain": "165.232.180.100",
+          "port": 6000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.4018726821150925,
+      "relativeStake": 0.0025849133735203708,
+      "relays": [
+        {
+          "address": "148.113.17.23",
+          "port": 6000
+        },
+        {
+          "address": "158.69.25.103",
+          "port": 6000
+        },
+        {
+          "address": "95.216.70.238",
+          "port": 6000
+        },
+        {
+          "address": "149.102.140.196",
+          "port": 6000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.4044466997976169,
+      "relativeStake": 0.0025740176825243713,
+      "relays": [
+        {
+          "address": "52.6.109.221",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.40699641799636466,
+      "relativeStake": 0.0025497181987477564,
       "relays": [
         {
           "domain": "Relay1.NordicPool.org",
@@ -1699,114 +1897,26 @@
       ]
     },
     {
-      "accumulatedStake": 0.37564072859481473,
-      "relativeStake": 0.002702324165052196,
+      "accumulatedStake": 0.40954136597121965,
+      "relativeStake": 0.002544947974855039,
       "relays": [
         {
-          "address": "49.12.198.221",
-          "port": 6000
+          "domain": "relay1.blueocean.sg",
+          "port": 3001
         },
         {
-          "address": "89.58.18.51",
-          "port": 6000
+          "domain": "relay2.blueocean.sg",
+          "port": 3001
         },
         {
-          "address": "131.153.199.82",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.3783423478119916,
-      "relativeStake": 0.0027016192171768778,
-      "relays": [
-        {
-          "domain": "relays.onyxstakepool.com",
+          "domain": "hcm07xw90vx.sn.mynetname.net",
           "port": 3001
         }
       ]
     },
     {
-      "accumulatedStake": 0.381038236609023,
-      "relativeStake": 0.002695888797031351,
-      "relays": [
-        {
-          "domain": "r1.1percentpool.eu",
-          "port": 19001
-        },
-        {
-          "domain": "r2.1percentpool.eu",
-          "port": 19002
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.3837082894665087,
-      "relativeStake": 0.002670052857485738,
-      "relays": [
-        {
-          "domain": "cardano-relays.autostake.com",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.3863742994440414,
-      "relativeStake": 0.002666009977532707,
-      "relays": [
-        {
-          "address": "148.113.17.23",
-          "port": 6000
-        },
-        {
-          "address": "158.69.25.103",
-          "port": 6000
-        },
-        {
-          "address": "95.216.70.238",
-          "port": 6000
-        },
-        {
-          "address": "149.102.140.234",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.3890070966138202,
-      "relativeStake": 0.0026327971697788087,
-      "relays": [
-        {
-          "address": "57.128.184.28",
-          "port": 3001
-        },
-        {
-          "address": "57.128.184.30",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.3916275071424359,
-      "relativeStake": 0.002620410528615685,
-      "relays": [
-        {
-          "domain": "104.131.47.170",
-          "port": 6000
-        },
-        {
-          "domain": "128.199.64.13",
-          "port": 6000
-        },
-        {
-          "domain": "165.232.180.100",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.39422948883783027,
-      "relativeStake": 0.0026019816953943686,
+      "accumulatedStake": 0.41208248864939273,
+      "relativeStake": 0.0025411226781730765,
       "relays": [
         {
           "domain": "relay1.adaocean.com",
@@ -1831,8 +1941,86 @@
       ]
     },
     {
-      "accumulatedStake": 0.3967908553989765,
-      "relativeStake": 0.0025613665611462604,
+      "accumulatedStake": 0.41461392131461056,
+      "relativeStake": 0.002531432665217815,
+      "relays": [
+        {
+          "address": "198.71.57.191",
+          "port": 6000
+        },
+        {
+          "address": "154.12.240.223",
+          "port": 6000
+        },
+        {
+          "address": "94.16.113.130",
+          "port": 6000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.4171327288288559,
+      "relativeStake": 0.0025188075142453083,
+      "relays": [
+        {
+          "domain": "relay-kiln-6-0.cardano.mainnet.kiln.fi",
+          "port": 3001
+        },
+        {
+          "domain": "relay-kiln-6-1.cardano.mainnet.kiln.fi",
+          "port": 3001
+        },
+        {
+          "domain": "relay-kiln-6-2.cardano.mainnet.kiln.fi",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.41963866450173193,
+      "relativeStake": 0.0025059356728760742,
+      "relays": [
+        {
+          "domain": "relay1.able-pool.io",
+          "port": 4555
+        },
+        {
+          "domain": "relay2.able-pool.io",
+          "port": 4419
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.4221347149396085,
+      "relativeStake": 0.0024960504378765767,
+      "relays": [
+        {
+          "domain": "lucerne.datadyne.earth",
+          "port": 3001
+        },
+        {
+          "domain": "g5.datadyne.earth",
+          "port": 3002
+        },
+        {
+          "domain": "drcaroll.datadyne.earth",
+          "port": 3003
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.4246262178511867,
+      "relativeStake": 0.0024915029115781875,
+      "relays": [
+        {
+          "domain": "77cb3f75.cardano-relay.herd.run",
+          "port": 1338
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.4271012299095076,
+      "relativeStake": 0.0024750120583208854,
       "relays": [
         {
           "domain": "sydney.cardanode.com.au",
@@ -1853,26 +2041,22 @@
       ]
     },
     {
-      "accumulatedStake": 0.3993375235741846,
-      "relativeStake": 0.0025466681752080605,
+      "accumulatedStake": 0.4295684731532615,
+      "relativeStake": 0.00246724324375394,
       "relays": [
         {
-          "address": "198.71.57.191",
+          "address": "35.156.192.95",
           "port": 6000
         },
         {
-          "address": "154.12.240.223",
-          "port": 6000
-        },
-        {
-          "address": "94.16.113.130",
+          "address": "18.197.51.215",
           "port": 6000
         }
       ]
     },
     {
-      "accumulatedStake": 0.4018522119839063,
-      "relativeStake": 0.0025146884097217077,
+      "accumulatedStake": 0.43203155004087945,
+      "relativeStake": 0.002463076887617893,
       "relays": [
         {
           "domain": "relay.de.fikapool.com",
@@ -1889,66 +2073,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.40436173900562483,
-      "relativeStake": 0.0025095270217185394,
-      "relays": [
-        {
-          "address": "35.211.17.86",
-          "port": 3000
-        },
-        {
-          "address": "34.23.88.7",
-          "port": 3000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.4068694406773246,
-      "relativeStake": 0.0025077016716997637,
-      "relays": [
-        {
-          "domain": "relay-trustwallet-5-0.cardano.mainnet.kiln.fi",
-          "port": 3001
-        },
-        {
-          "domain": "relay-trustwallet-5-1.cardano.mainnet.kiln.fi",
-          "port": 3001
-        },
-        {
-          "domain": "relay-trustwallet-5-2.cardano.mainnet.kiln.fi",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.40937486728543376,
-      "relativeStake": 0.002505426608109142,
-      "relays": [
-        {
-          "domain": "relay1.adaocean.com",
-          "port": 6000
-        },
-        {
-          "domain": "relay2.adaocean.com",
-          "port": 6000
-        },
-        {
-          "domain": "relay3.adaocean.com",
-          "port": 6000
-        },
-        {
-          "domain": "relay4.adaocean.com",
-          "port": 6000
-        },
-        {
-          "domain": "relay5.adaocean.com",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.41186074376829646,
-      "relativeStake": 0.002485876482862688,
+      "accumulatedStake": 0.4344855771635199,
+      "relativeStake": 0.0024540271226404214,
       "relays": [
         {
           "domain": "st3ak.1337.cx",
@@ -1965,8 +2091,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.41433737685033706,
-      "relativeStake": 0.0024766330820405946,
+      "accumulatedStake": 0.4369271885089004,
+      "relativeStake": 0.00244161134538053,
       "relays": [
         {
           "domain": "fr.relays.cardanians.io",
@@ -1979,72 +2105,36 @@
       ]
     },
     {
-      "accumulatedStake": 0.41680568215648495,
-      "relativeStake": 0.0024683053061479126,
+      "accumulatedStake": 0.43935552130771455,
+      "relativeStake": 0.0024283327988141655,
       "relays": [
         {
-          "domain": "relay1.blueocean.sg",
-          "port": 3001
-        },
-        {
-          "domain": "relay2.blueocean.sg",
-          "port": 3001
-        },
-        {
-          "domain": "hcm07xw90vx.sn.mynetname.net",
+          "domain": "relays.wavepool.digital",
           "port": 3001
         }
       ]
     },
     {
-      "accumulatedStake": 0.4192705437794565,
-      "relativeStake": 0.002464861622971551,
+      "accumulatedStake": 0.4417799868177706,
+      "relativeStake": 0.00242446551005604,
       "relays": [
         {
-          "address": "35.156.192.95",
-          "port": 6000
+          "domain": "relay-trustwallet-5-0.cardano.mainnet.kiln.fi",
+          "port": 3001
         },
         {
-          "address": "18.197.51.215",
-          "port": 6000
+          "domain": "relay-trustwallet-5-1.cardano.mainnet.kiln.fi",
+          "port": 3001
+        },
+        {
+          "domain": "relay-trustwallet-5-2.cardano.mainnet.kiln.fi",
+          "port": 3001
         }
       ]
     },
     {
-      "accumulatedStake": 0.4217242305530622,
-      "relativeStake": 0.0024536867736056848,
-      "relays": [
-        {
-          "domain": "relay1-dl.aichi-stakepool.com",
-          "port": 6000
-        },
-        {
-          "domain": "relay2-jp.aichi-stakepool.com",
-          "port": 6000
-        },
-        {
-          "domain": "relay3-li.aichi-stakepool.com",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.4241349800564116,
-      "relativeStake": 0.0024107495033493893,
-      "relays": [
-        {
-          "address": "3.217.90.52",
-          "port": 6000
-        },
-        {
-          "address": "3.219.254.127",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.42650526781940656,
-      "relativeStake": 0.0023702877629949715,
+      "accumulatedStake": 0.4442042428506846,
+      "relativeStake": 0.0024242560329140093,
       "relays": [
         {
           "address": "15.204.97.132",
@@ -2057,40 +2147,36 @@
       ]
     },
     {
-      "accumulatedStake": 0.4288708667022363,
-      "relativeStake": 0.0023655988828297676,
+      "accumulatedStake": 0.4466037479853372,
+      "relativeStake": 0.0023995051346525713,
       "relays": [
         {
-          "domain": "eu-relay.hermes-stakepool.com",
-          "port": 1000
+          "address": "3.217.90.52",
+          "port": 6000
         },
         {
-          "domain": "us-relay.hermes-stakepool.com",
-          "port": 1000
+          "address": "3.219.254.127",
+          "port": 6000
         }
       ]
     },
     {
-      "accumulatedStake": 0.4312353419126804,
-      "relativeStake": 0.0023644752104441313,
+      "accumulatedStake": 0.4489982866722532,
+      "relativeStake": 0.002394538686916037,
       "relays": [
         {
-          "domain": "lucerne.datadyne.earth",
+          "domain": "relay1.0aaaa.org",
           "port": 3001
         },
         {
-          "domain": "g5.datadyne.earth",
-          "port": 3002
-        },
-        {
-          "domain": "drcaroll.datadyne.earth",
-          "port": 3003
+          "domain": "relay2.0aaaa.org",
+          "port": 3001
         }
       ]
     },
     {
-      "accumulatedStake": 0.4335980342485443,
-      "relativeStake": 0.0023626923358638706,
+      "accumulatedStake": 0.45137717083329326,
+      "relativeStake": 0.0023788841610400454,
       "relays": [
         {
           "domain": "cardano-main.everstake.one",
@@ -2115,8 +2201,210 @@
       ]
     },
     {
-      "accumulatedStake": 0.43595764221104255,
-      "relativeStake": 0.0023596079624982193,
+      "accumulatedStake": 0.45370579108781567,
+      "relativeStake": 0.0023286202545224196,
+      "relays": [
+        {
+          "address": "57.128.184.28",
+          "port": 3001
+        },
+        {
+          "address": "57.128.184.30",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.45600732015491885,
+      "relativeStake": 0.002301529067103195,
+      "relays": [
+        {
+          "address": "35.75.32.253",
+          "port": 6000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.45830773917238127,
+      "relativeStake": 0.0023004190174624075,
+      "relays": [
+        {
+          "address": "20.61.229.103",
+          "port": 3001
+        },
+        {
+          "address": "20.61.228.218",
+          "port": 3001
+        },
+        {
+          "address": "108.142.42.221",
+          "port": 3001
+        },
+        {
+          "address": "108.142.42.161",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.46060815133913635,
+      "relativeStake": 0.002300412166755078,
+      "relays": [
+        {
+          "address": "20.61.229.103",
+          "port": 3001
+        },
+        {
+          "address": "20.61.228.218",
+          "port": 3001
+        },
+        {
+          "address": "108.142.42.221",
+          "port": 3001
+        },
+        {
+          "address": "108.142.42.161",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.46290839804555606,
+      "relativeStake": 0.0023002467064197124,
+      "relays": [
+        {
+          "address": "20.61.229.103",
+          "port": 3001
+        },
+        {
+          "address": "20.61.228.218",
+          "port": 3001
+        },
+        {
+          "address": "108.142.42.221",
+          "port": 3001
+        },
+        {
+          "address": "108.142.42.161",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.4652083385631344,
+      "relativeStake": 0.0022999405175783793,
+      "relays": [
+        {
+          "address": "20.61.229.103",
+          "port": 3001
+        },
+        {
+          "address": "20.61.228.218",
+          "port": 3001
+        },
+        {
+          "address": "108.142.42.221",
+          "port": 3001
+        },
+        {
+          "address": "108.142.42.161",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.46750826846591836,
+      "relativeStake": 0.0022999299027839414,
+      "relays": [
+        {
+          "address": "20.61.229.103",
+          "port": 3001
+        },
+        {
+          "address": "20.61.228.218",
+          "port": 3001
+        },
+        {
+          "address": "108.142.42.221",
+          "port": 3001
+        },
+        {
+          "address": "108.142.42.161",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.46980819335365087,
+      "relativeStake": 0.002299924887732498,
+      "relays": [
+        {
+          "address": "20.61.229.103",
+          "port": 3001
+        },
+        {
+          "address": "20.61.228.218",
+          "port": 3001
+        },
+        {
+          "address": "108.142.42.221",
+          "port": 3001
+        },
+        {
+          "address": "108.142.42.161",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.4721081182413834,
+      "relativeStake": 0.002299924887732498,
+      "relays": [
+        {
+          "address": "20.61.229.103",
+          "port": 3001
+        },
+        {
+          "address": "20.61.228.218",
+          "port": 3001
+        },
+        {
+          "address": "108.142.42.221",
+          "port": 3001
+        },
+        {
+          "address": "108.142.42.161",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.4743720603401502,
+      "relativeStake": 0.0022639420987668178,
+      "relays": [
+        {
+          "domain": "eu-relay.hermes-stakepool.com",
+          "port": 1000
+        },
+        {
+          "domain": "us-relay.hermes-stakepool.com",
+          "port": 1000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.4766233759388227,
+      "relativeStake": 0.0022513155986724934,
+      "relays": [
+        {
+          "address": "18.157.253.103",
+          "port": 8381
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.47886326911674265,
+      "relativeStake": 0.002239893177919959,
       "relays": [
         {
           "address": "66.160.158.69",
@@ -2129,278 +2417,22 @@
       ]
     },
     {
-      "accumulatedStake": 0.43829875318681605,
-      "relativeStake": 0.002341110975773511,
+      "accumulatedStake": 0.4811000910445758,
+      "relativeStake": 0.0022368219278331193,
       "relays": [
         {
-          "domain": "r-eu-0.titanstaking.io",
-          "port": 4321
+          "address": "35.211.17.86",
+          "port": 3000
         },
         {
-          "domain": "r-eu-1.titanstaking.io",
-          "port": 4321
-        },
-        {
-          "domain": "r-eu-2.titanstaking.io",
-          "port": 4321
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.44063570032521304,
-      "relativeStake": 0.0023369471383970254,
-      "relays": [
-        {
-          "address": "35.75.32.253",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.44297159579347,
-      "relativeStake": 0.0023358954682569585,
-      "relays": [
-        {
-          "address": "20.61.229.103",
-          "port": 3001
-        },
-        {
-          "address": "20.61.228.218",
-          "port": 3001
-        },
-        {
-          "address": "108.142.42.221",
-          "port": 3001
-        },
-        {
-          "address": "108.142.42.161",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.44530732324920597,
-      "relativeStake": 0.0023357274557359235,
-      "relays": [
-        {
-          "address": "20.61.229.103",
-          "port": 3001
-        },
-        {
-          "address": "20.61.228.218",
-          "port": 3001
-        },
-        {
-          "address": "108.142.42.221",
-          "port": 3001
-        },
-        {
-          "address": "108.142.42.161",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.4476427397368445,
-      "relativeStake": 0.0023354164876385093,
-      "relays": [
-        {
-          "address": "20.61.229.103",
-          "port": 3001
-        },
-        {
-          "address": "20.61.228.218",
-          "port": 3001
-        },
-        {
-          "address": "108.142.42.221",
-          "port": 3001
-        },
-        {
-          "address": "108.142.42.161",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.4499781454459579,
-      "relativeStake": 0.0023354057091134334,
-      "relays": [
-        {
-          "address": "20.61.229.103",
-          "port": 3001
-        },
-        {
-          "address": "20.61.228.218",
-          "port": 3001
-        },
-        {
-          "address": "108.142.42.221",
-          "port": 3001
-        },
-        {
-          "address": "108.142.42.161",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.4523135461190312,
-      "relativeStake": 0.0023354006730732647,
-      "relays": [
-        {
-          "address": "20.61.229.103",
-          "port": 3001
-        },
-        {
-          "address": "20.61.228.218",
-          "port": 3001
-        },
-        {
-          "address": "108.142.42.221",
-          "port": 3001
-        },
-        {
-          "address": "108.142.42.161",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.45464894679210444,
-      "relativeStake": 0.0023354006730732647,
-      "relays": [
-        {
-          "address": "20.61.229.103",
-          "port": 3001
-        },
-        {
-          "address": "20.61.228.218",
-          "port": 3001
-        },
-        {
-          "address": "108.142.42.221",
-          "port": 3001
-        },
-        {
-          "address": "108.142.42.161",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.4569827690714771,
-      "relativeStake": 0.0023338222793726823,
-      "relays": [
-        {
-          "address": "18.157.253.103",
-          "port": 8381
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.45929916797567777,
-      "relativeStake": 0.0023163989042006778,
-      "relays": [
-        {
-          "domain": "relay1.0aaaa.org",
-          "port": 3001
-        },
-        {
-          "domain": "relay2.0aaaa.org",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.4616152316060127,
-      "relativeStake": 0.0023160636303349094,
-      "relays": [
-        {
-          "address": "150.136.111.193",
-          "port": 6001
-        },
-        {
-          "address": "150.136.84.82",
-          "port": 6001
-        },
-        {
-          "address": "158.101.99.150",
-          "port": 6001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.46392537290655733,
-      "relativeStake": 0.00231014130054462,
-      "relays": [
-        {
-          "domain": "40.cardano.staked.cloud",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.4662295025729764,
-      "relativeStake": 0.002304129666419119,
-      "relays": [
-        {
-          "domain": "cardano.staking.copper.co",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.4684958248132544,
-      "relativeStake": 0.002266322240278001,
-      "relays": [
-        {
-          "domain": "relay1.snakerelays.link",
-          "port": 3001
-        },
-        {
-          "domain": "relay2.snakerelays.link",
-          "port": 3002
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.4707401886354899,
-      "relativeStake": 0.002244363822235429,
-      "relays": [
-        {
-          "address": "52.177.36.96",
+          "address": "34.23.88.7",
           "port": 3000
         }
       ]
     },
     {
-      "accumulatedStake": 0.4729647447352879,
-      "relativeStake": 0.0022245560997980053,
-      "relays": [
-        {
-          "domain": "relays.wavepool.digital",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.4751835866423442,
-      "relativeStake": 0.002218841907056356,
-      "relays": [
-        {
-          "address": "54.168.30.53",
-          "port": 7328
-        },
-        {
-          "address": "192.145.47.68",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.47739366692061375,
-      "relativeStake": 0.0022100802782695117,
+      "accumulatedStake": 0.483308207832706,
+      "relativeStake": 0.002208116788130239,
       "relays": [
         {
           "domain": "ACLrelay1.cardanoland.com",
@@ -2429,200 +2461,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.4795953165633283,
-      "relativeStake": 0.002201649642714587,
-      "relays": [
-        {
-          "domain": "relay.azureada.com",
-          "port": 3001
-        },
-        {
-          "domain": "relay.azureada.com",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.481779330309878,
-      "relativeStake": 0.002184013746549674,
-      "relays": [
-        {
-          "domain": "relays-10a.cardano.2k2aa.com",
-          "port": 3001
-        },
-        {
-          "domain": "relays-10b.cardano.aeq5f.com",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.48395099260707264,
-      "relativeStake": 0.0021716622971946343,
-      "relays": [
-        {
-          "domain": "relays.digi.pro",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.4861194542055066,
-      "relativeStake": 0.002168461598433991,
-      "relays": [
-        {
-          "domain": "relay0.viperstaking.com",
-          "port": 4444
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.4882773679884976,
-      "relativeStake": 0.0021579137829909555,
-      "relays": [
-        {
-          "address": "20.61.229.103",
-          "port": 3001
-        },
-        {
-          "address": "20.61.228.218",
-          "port": 3001
-        },
-        {
-          "address": "108.142.42.221",
-          "port": 3001
-        },
-        {
-          "address": "108.142.42.161",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.49042914697925866,
-      "relativeStake": 0.0021517789907610635,
-      "relays": [
-        {
-          "domain": "adar1.stakit.io",
-          "port": 30500
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.4925724798228027,
-      "relativeStake": 0.002143332843544089,
-      "relays": [
-        {
-          "domain": "relay.sunnyada.com",
-          "port": 5001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.49471558614048067,
-      "relativeStake": 0.002143106317677922,
-      "relays": [
-        {
-          "domain": "cardano-main.everstake.one",
-          "port": 3001
-        },
-        {
-          "domain": "cardano-main2.everstake.one",
-          "port": 3001
-        },
-        {
-          "domain": "cardano-relay.everstake.one",
-          "port": 3001
-        },
-        {
-          "domain": "cardano-relay1.everstake.one",
-          "port": 3001
-        },
-        {
-          "domain": "cardano-relay2.everstake.one",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.4968192373929905,
-      "relativeStake": 0.0021036512525098483,
-      "relays": [
-        {
-          "domain": "cardano-main.everstake.one",
-          "port": 3001
-        },
-        {
-          "domain": "cardano-main2.everstake.one",
-          "port": 3001
-        },
-        {
-          "domain": "cardano-relay.everstake.one",
-          "port": 3001
-        },
-        {
-          "domain": "cardano-relay1.everstake.one",
-          "port": 3001
-        },
-        {
-          "domain": "cardano-relay2.everstake.one",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.4989221428071679,
-      "relativeStake": 0.0021029054141773833,
-      "relays": [
-        {
-          "address": "188.165.236.202",
-          "port": 3001
-        },
-        {
-          "address": "195.201.107.114",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.5010116609284322,
-      "relativeStake": 0.002089518121264279,
-      "relays": [
-        {
-          "domain": "relay.cardano.securestaking.io",
-          "port": 3000
-        },
-        {
-          "domain": "secur2.cardano.securestaking.io",
-          "port": 3000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.5030785675165255,
-      "relativeStake": 0.002066906588093352,
-      "relays": [
-        {
-          "domain": "relay1.nedscave.io",
-          "port": 3001
-        },
-        {
-          "domain": "relay2.nedscave.io",
-          "port": 3001
-        },
-        {
-          "domain": "relay3.nedscave.io",
-          "port": 3001
-        },
-        {
-          "domain": "relay4.nedscave.io",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.5051349026856721,
-      "relativeStake": 0.0020563351691465664,
+      "accumulatedStake": 0.48551376538819907,
+      "relativeStake": 0.00220555755549308,
       "relays": [
         {
           "address": "137.220.49.160",
@@ -2635,154 +2475,18 @@
       ]
     },
     {
-      "accumulatedStake": 0.5071866115326245,
-      "relativeStake": 0.002051708846952412,
+      "accumulatedStake": 0.4877189254644166,
+      "relativeStake": 0.0022051600762174966,
       "relays": [
         {
-          "domain": "cardano.staking.copper.co",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.5092352557601738,
-      "relativeStake": 0.002048644227549299,
-      "relays": [
-        {
-          "domain": "germany.cardanode.io",
-          "port": 6000
-        },
-        {
-          "domain": "missouri.cardanode.io",
-          "port": 6000
-        },
-        {
-          "domain": "la.cardanode.io",
-          "port": 6000
-        },
-        {
-          "domain": "perth.cardanode.io",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.5112807635857599,
-      "relativeStake": 0.0020455078255861535,
-      "relays": [
-        {
-          "domain": "cardano.staking.copper.co",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.5133255902207797,
-      "relativeStake": 0.002044826635019823,
-      "relays": [
-        {
-          "domain": "relay0.fimi.vn",
-          "port": 3000
-        },
-        {
-          "domain": "relay1.fimi.vn",
-          "port": 3000
-        },
-        {
-          "domain": "relay2.fimi.vn",
+          "address": "52.177.36.96",
           "port": 3000
         }
       ]
     },
     {
-      "accumulatedStake": 0.5153692190638597,
-      "relativeStake": 0.0020436288430799444,
-      "relays": [
-        {
-          "address": "102.130.127.242",
-          "port": 6000
-        },
-        {
-          "address": "94.16.106.16",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.5174118934799965,
-      "relativeStake": 0.002042674416136835,
-      "relays": [
-        {
-          "domain": "relay1-pub.ahlnet.nu",
-          "port": 2111
-        },
-        {
-          "domain": "relay2-pub.ahlnet.nu",
-          "port": 2111
-        },
-        {
-          "domain": "relay3-pub.ahlnet.nu",
-          "port": 2111
-        },
-        {
-          "domain": "relay-fallback.ahlnet.nu",
-          "port": 55218
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.5194449939798875,
-      "relativeStake": 0.002033100499890994,
-      "relays": [
-        {
-          "address": "20.61.229.103",
-          "port": 3001
-        },
-        {
-          "address": "20.61.228.218",
-          "port": 3001
-        },
-        {
-          "address": "108.142.42.221",
-          "port": 3001
-        },
-        {
-          "address": "108.142.42.161",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.5214767012898825,
-      "relativeStake": 0.0020317073099949683,
-      "relays": [
-        {
-          "address": "52.8.37.3",
-          "port": 3001
-        },
-        {
-          "address": "3.125.252.182",
-          "port": 3001
-        },
-        {
-          "address": "52.63.225.190",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.5235054945957619,
-      "relativeStake": 0.0020287933058793515,
-      "relays": [
-        {
-          "domain": "cardano.staking.copper.co",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.5255111666834125,
-      "relativeStake": 0.0020056720876505934,
+      "accumulatedStake": 0.4899223762996441,
+      "relativeStake": 0.002203450835227506,
       "relays": [
         {
           "domain": "relay1-us.xstakepool.com",
@@ -2803,18 +2507,82 @@
       ]
     },
     {
-      "accumulatedStake": 0.5275121778691045,
-      "relativeStake": 0.002001011185692134,
+      "accumulatedStake": 0.49208136151268944,
+      "relativeStake": 0.0021589852130453556,
       "relays": [
         {
-          "domain": "cardano.staking.copper.co",
+          "domain": "relay.azureada.com",
+          "port": 3001
+        },
+        {
+          "domain": "relay.azureada.com",
           "port": 3001
         }
       ]
     },
     {
-      "accumulatedStake": 0.5295082560264728,
-      "relativeStake": 0.0019960781573681646,
+      "accumulatedStake": 0.4942402587566072,
+      "relativeStake": 0.002158897243917778,
+      "relays": [
+        {
+          "domain": "relay1-dl.aichi-stakepool.com",
+          "port": 6000
+        },
+        {
+          "domain": "relay2-jp.aichi-stakepool.com",
+          "port": 6000
+        },
+        {
+          "domain": "relay3-li.aichi-stakepool.com",
+          "port": 6000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.4963912863559724,
+      "relativeStake": 0.00215102759936518,
+      "relays": [
+        {
+          "domain": "relay0.viperstaking.com",
+          "port": 4444
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.49853029146746397,
+      "relativeStake": 0.0021390051114915576,
+      "relays": [
+        {
+          "address": "150.136.111.193",
+          "port": 6001
+        },
+        {
+          "address": "150.136.84.82",
+          "port": 6001
+        },
+        {
+          "address": "158.101.99.150",
+          "port": 6001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.5006586742622726,
+      "relativeStake": 0.002128382794808691,
+      "relays": [
+        {
+          "domain": "relay-1.minswap.org",
+          "port": 3001
+        },
+        {
+          "domain": "relay-2.minswap.org",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.5027684981225806,
+      "relativeStake": 0.0021098238603079696,
       "relays": [
         {
           "domain": "eu1.stakecool.io",
@@ -2831,102 +2599,40 @@
       ]
     },
     {
-      "accumulatedStake": 0.5315034039212334,
-      "relativeStake": 0.001995147894760704,
+      "accumulatedStake": 0.504869761965867,
+      "relativeStake": 0.002101263843286382,
       "relays": [
         {
-          "domain": "cardano.staking.copper.co",
+          "domain": "relay1.nedscave.io",
+          "port": 3001
+        },
+        {
+          "domain": "relay2.nedscave.io",
+          "port": 3001
+        },
+        {
+          "domain": "relay3.nedscave.io",
+          "port": 3001
+        },
+        {
+          "domain": "relay4.nedscave.io",
           "port": 3001
         }
       ]
     },
     {
-      "accumulatedStake": 0.5334927202607562,
-      "relativeStake": 0.001989316339522742,
+      "accumulatedStake": 0.5069638979662785,
+      "relativeStake": 0.0020941360004114633,
       "relays": [
         {
-          "address": "35.211.17.86",
-          "port": 3000
-        },
-        {
-          "address": "34.23.88.7",
-          "port": 3000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.5354720441113626,
-      "relativeStake": 0.001979323850606441,
-      "relays": [
-        {
-          "domain": "ada-relay01.biglazycat.com",
-          "port": 6000
-        },
-        {
-          "domain": "ada-relay02.biglazycat.com",
-          "port": 6001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.5374493764919757,
-      "relativeStake": 0.001977332380612981,
-      "relays": [
-        {
-          "domain": "relay-kiln-6-0.cardano.mainnet.kiln.fi",
-          "port": 3001
-        },
-        {
-          "domain": "relay-kiln-6-1.cardano.mainnet.kiln.fi",
-          "port": 3001
-        },
-        {
-          "domain": "relay-kiln-6-2.cardano.mainnet.kiln.fi",
+          "domain": "relays.digi.pro",
           "port": 3001
         }
       ]
     },
     {
-      "accumulatedStake": 0.5394088357880367,
-      "relativeStake": 0.001959459296061034,
-      "relays": [
-        {
-          "address": "34.84.0.241",
-          "port": 3000
-        },
-        {
-          "address": "34.146.198.77",
-          "port": 3000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.5413526404921388,
-      "relativeStake": 0.0019438047041021326,
-      "relays": [
-        {
-          "domain": "relay1.able-pool.io",
-          "port": 4555
-        },
-        {
-          "domain": "relay2.able-pool.io",
-          "port": 4419
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.5432886314333197,
-      "relativeStake": 0.0019359909411808978,
-      "relays": [
-        {
-          "address": "52.177.36.96",
-          "port": 3000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.5452119214318893,
-      "relativeStake": 0.0019232899985696299,
+      "accumulatedStake": 0.5090498067665138,
+      "relativeStake": 0.0020859088002352904,
       "relays": [
         {
           "domain": "cardano-main.everstake.one",
@@ -2951,50 +2657,308 @@
       ]
     },
     {
-      "accumulatedStake": 0.5471182227826211,
-      "relativeStake": 0.0019063013507318446,
+      "accumulatedStake": 0.5111325241261238,
+      "relativeStake": 0.002082717359610045,
       "relays": [
         {
-          "domain": "r1.1percentpool.eu",
-          "port": 19001
-        },
-        {
-          "domain": "r2.1percentpool.eu",
-          "port": 19002
+          "domain": "relay.sunnyada.com",
+          "port": 5001
         }
       ]
     },
     {
-      "accumulatedStake": 0.5490134761709247,
-      "relativeStake": 0.001895253388303455,
+      "accumulatedStake": 0.5132100623791611,
+      "relativeStake": 0.0020775382530372846,
       "relays": [
         {
-          "domain": "cardano-relays-1.nu.fi",
-          "port": 3003
+          "domain": "adar1.stakit.io",
+          "port": 30500
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.5152829081637196,
+      "relativeStake": 0.0020728457845585265,
+      "relays": [
+        {
+          "address": "57.129.28.179",
+          "port": 3001
         },
         {
-          "domain": "cardano-relays-2.nu.fi",
+          "address": "57.129.28.180",
           "port": 3001
         }
       ]
     },
     {
-      "accumulatedStake": 0.550901480110902,
-      "relativeStake": 0.0018880039399774323,
+      "accumulatedStake": 0.5173542053483128,
+      "relativeStake": 0.0020712971845931773,
       "relays": [
         {
-          "domain": "cardano-relay1.nodes.lgns.xyz",
+          "address": "188.165.236.202",
+          "port": 3001
+        },
+        {
+          "address": "195.201.107.114",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.5194070854009886,
+      "relativeStake": 0.002052880052675766,
+      "relays": [
+        {
+          "address": "52.8.37.3",
+          "port": 3001
+        },
+        {
+          "address": "3.125.252.182",
+          "port": 3001
+        },
+        {
+          "address": "52.63.225.190",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.5214513795980544,
+      "relativeStake": 0.002044294197065828,
+      "relays": [
+        {
+          "address": "102.130.127.242",
           "port": 6000
         },
         {
-          "domain": "cardano-relay2.nodes.lgns.xyz",
+          "address": "94.16.106.16",
           "port": 6000
         }
       ]
     },
     {
-      "accumulatedStake": 0.552788743036951,
-      "relativeStake": 0.0018872629260489788,
+      "accumulatedStake": 0.5234918289220948,
+      "relativeStake": 0.002040449324040383,
+      "relays": [
+        {
+          "domain": "cardano-main.everstake.one",
+          "port": 3001
+        },
+        {
+          "domain": "cardano-main2.everstake.one",
+          "port": 3001
+        },
+        {
+          "domain": "cardano-relay.everstake.one",
+          "port": 3001
+        },
+        {
+          "domain": "cardano-relay1.everstake.one",
+          "port": 3001
+        },
+        {
+          "domain": "cardano-relay2.everstake.one",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.5255171486286471,
+      "relativeStake": 0.0020253197065523117,
+      "relays": [
+        {
+          "domain": "cardano.staking.copper.co",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.527537481447427,
+      "relativeStake": 0.0020203328187798917,
+      "relays": [
+        {
+          "domain": "cardano.staking.copper.co",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.5295575277800514,
+      "relativeStake": 0.002020046332624459,
+      "relays": [
+        {
+          "domain": "relay0.fimi.vn",
+          "port": 3000
+        },
+        {
+          "domain": "relay1.fimi.vn",
+          "port": 3000
+        },
+        {
+          "domain": "relay2.fimi.vn",
+          "port": 3000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.5315747688378558,
+      "relativeStake": 0.0020172410578043467,
+      "relays": [
+        {
+          "domain": "germany.cardanode.io",
+          "port": 6000
+        },
+        {
+          "domain": "missouri.cardanode.io",
+          "port": 6000
+        },
+        {
+          "domain": "la.cardanode.io",
+          "port": 6000
+        },
+        {
+          "domain": "perth.cardanode.io",
+          "port": 6000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.5335777377524635,
+      "relativeStake": 0.0020029689146077497,
+      "relays": [
+        {
+          "domain": "cardano.staking.copper.co",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.5355626494210658,
+      "relativeStake": 0.0019849116686022714,
+      "relays": [
+        {
+          "domain": "ada-relay01.biglazycat.com",
+          "port": 6000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.5375389709775739,
+      "relativeStake": 0.001976321556508096,
+      "relays": [
+        {
+          "domain": "relay01.ca.lovelace.community",
+          "port": 3001
+        },
+        {
+          "domain": "relay02.ca.lovelace.community",
+          "port": 3001
+        },
+        {
+          "domain": "relay01.fr.lovelace.community",
+          "port": 3001
+        },
+        {
+          "domain": "relay01.de.lovelace.community",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.5395098858474254,
+      "relativeStake": 0.0019709148698515773,
+      "relays": [
+        {
+          "domain": "cardano.staking.copper.co",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.5414327905252988,
+      "relativeStake": 0.0019229046778732944,
+      "relays": [
+        {
+          "domain": "relay1-pub.ahlnet.nu",
+          "port": 2111
+        },
+        {
+          "domain": "relay2-pub.ahlnet.nu",
+          "port": 2111
+        },
+        {
+          "domain": "relay3-pub.ahlnet.nu",
+          "port": 2111
+        },
+        {
+          "domain": "relay-fallback.ahlnet.nu",
+          "port": 55218
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.5433454383862053,
+      "relativeStake": 0.00191264786090659,
+      "relays": [
+        {
+          "domain": "relay.cardano.securestaking.io",
+          "port": 3000
+        },
+        {
+          "domain": "secur2.cardano.securestaking.io",
+          "port": 3000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.5452523765280606,
+      "relativeStake": 0.001906938141855231,
+      "relays": [
+        {
+          "address": "13.235.131.115",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.5471428162576972,
+      "relativeStake": 0.001890439729636642,
+      "relays": [
+        {
+          "domain": "relay1.adaocean.com",
+          "port": 6000
+        },
+        {
+          "domain": "relay2.adaocean.com",
+          "port": 6000
+        },
+        {
+          "domain": "relay3.adaocean.com",
+          "port": 6000
+        },
+        {
+          "domain": "relay4.adaocean.com",
+          "port": 6000
+        },
+        {
+          "domain": "relay5.adaocean.com",
+          "port": 6000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.5490267360373837,
+      "relativeStake": 0.001883919779686443,
+      "relays": [
+        {
+          "address": "20.69.213.207",
+          "port": 3000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.5509090133110413,
+      "relativeStake": 0.0018822772736575679,
       "relays": [
         {
           "address": "89.58.38.12",
@@ -3011,32 +2975,72 @@
       ]
     },
     {
-      "accumulatedStake": 0.554675104382535,
-      "relativeStake": 0.0018863613455839864,
+      "accumulatedStake": 0.5527857181461326,
+      "relativeStake": 0.001876704835091372,
       "relays": [
         {
-          "domain": "iog1-relays.cardano.iog.io",
+          "domain": "cardano-main.everstake.one",
+          "port": 3001
+        },
+        {
+          "domain": "cardano-main2.everstake.one",
+          "port": 3001
+        },
+        {
+          "domain": "cardano-relay.everstake.one",
+          "port": 3001
+        },
+        {
+          "domain": "cardano-relay1.everstake.one",
+          "port": 3001
+        },
+        {
+          "domain": "cardano-relay2.everstake.one",
           "port": 3001
         }
       ]
     },
     {
-      "accumulatedStake": 0.5565373088856642,
-      "relativeStake": 0.0018622045031291667,
+      "accumulatedStake": 0.5546605125698156,
+      "relativeStake": 0.0018747944236830268,
       "relays": [
         {
-          "address": "139.180.198.13",
+          "domain": "cardano-relays-1.nu.fi",
+          "port": 3003
+        },
+        {
+          "domain": "cardano-relays-2.nu.fi",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.5565264874361424,
+      "relativeStake": 0.0018659748663267266,
+      "relays": [
+        {
+          "domain": "cardano-relay1.nodes.lgns.xyz",
           "port": 6000
         },
         {
-          "address": "207.148.77.122",
+          "domain": "cardano-relay2.nodes.lgns.xyz",
           "port": 6000
         }
       ]
     },
     {
-      "accumulatedStake": 0.5583994819958712,
-      "relativeStake": 0.0018621731102070331,
+      "accumulatedStake": 0.5583818633948503,
+      "relativeStake": 0.0018553759587078892,
+      "relays": [
+        {
+          "domain": "relays.mainnet.pools.fivebinaries.com",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.5602357894444853,
+      "relativeStake": 0.001853926049635028,
       "relays": [
         {
           "address": "148.113.17.23",
@@ -3057,42 +3061,50 @@
       ]
     },
     {
-      "accumulatedStake": 0.5602524216993754,
-      "relativeStake": 0.001852939703504185,
+      "accumulatedStake": 0.5620881361128485,
+      "relativeStake": 0.0018523466683632124,
       "relays": [
         {
-          "domain": "olive-geonosis-edffc.cardano.bdnodes.net",
+          "address": "150.136.84.82",
+          "port": 6001
+        },
+        {
+          "address": "158.101.99.150",
+          "port": 6001
+        },
+        {
+          "address": "150.136.111.193",
+          "port": 6001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.5639211736814574,
+      "relativeStake": 0.0018330375686089247,
+      "relays": [
+        {
+          "address": "52.177.36.96",
+          "port": 3000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.565732701666517,
+      "relativeStake": 0.0018115279850596101,
+      "relays": [
+        {
+          "address": "35.154.118.137",
           "port": 6000
         },
         {
-          "domain": "violet-kingston-8d67e.cardano.bdnodes.net",
+          "address": "3.6.81.137",
           "port": 6000
         }
       ]
     },
     {
-      "accumulatedStake": 0.5621051306020248,
-      "relativeStake": 0.0018527089026494391,
-      "relays": [
-        {
-          "address": "52.6.109.221",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.5639506776828648,
-      "relativeStake": 0.001845547080839898,
-      "relays": [
-        {
-          "domain": "relays.digi.pro",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.565793622410885,
-      "relativeStake": 0.0018429447280203222,
+      "accumulatedStake": 0.5675433395869178,
+      "relativeStake": 0.0018106379204008267,
       "relays": [
         {
           "address": "195.201.143.213",
@@ -3109,92 +3121,234 @@
       ]
     },
     {
-      "accumulatedStake": 0.5676296116084734,
-      "relativeStake": 0.0018359891975882525,
+      "accumulatedStake": 0.569337317357835,
+      "relativeStake": 0.00179397777091712,
       "relays": [
         {
-          "domain": "cardano-main.everstake.one",
-          "port": 3001
-        },
-        {
-          "domain": "cardano-main2.everstake.one",
-          "port": 3001
-        },
-        {
-          "domain": "cardano-relay.everstake.one",
-          "port": 3001
-        },
-        {
-          "domain": "cardano-relay1.everstake.one",
-          "port": 3001
-        },
-        {
-          "domain": "cardano-relay2.everstake.one",
+          "domain": "relays.digi.pro",
           "port": 3001
         }
       ]
     },
     {
-      "accumulatedStake": 0.5694457478698494,
-      "relativeStake": 0.0018161362613760882,
+      "accumulatedStake": 0.5711232465627536,
+      "relativeStake": 0.0017859292049186536,
       "relays": [
         {
-          "domain": "cardano-main.everstake.one",
+          "address": "139.180.198.13",
+          "port": 6000
+        },
+        {
+          "address": "207.148.77.122",
+          "port": 6000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.5729012852640426,
+      "relativeStake": 0.0017780387012889616,
+      "relays": [
+        {
+          "address": "157.245.228.134",
           "port": 3001
         },
         {
-          "domain": "cardano-main2.everstake.one",
+          "address": "159.89.120.164",
           "port": 3001
         },
         {
-          "domain": "cardano-relay.everstake.one",
+          "address": "209.97.186.44",
           "port": 3001
         },
         {
-          "domain": "cardano-relay1.everstake.one",
-          "port": 3001
-        },
-        {
-          "domain": "cardano-relay2.everstake.one",
+          "domain": "na.bloompool.io",
           "port": 3001
         }
       ]
     },
     {
-      "accumulatedStake": 0.5712513277919461,
-      "relativeStake": 0.0018055799220967356,
+      "accumulatedStake": 0.5746743881033027,
+      "relativeStake": 0.0017731028392601257,
       "relays": [
         {
-          "address": "20.69.213.207",
+          "address": "52.177.36.96",
           "port": 3000
         }
       ]
     },
     {
-      "accumulatedStake": 0.5730522687378189,
-      "relativeStake": 0.0018009409458728074,
+      "accumulatedStake": 0.576435553620231,
+      "relativeStake": 0.0017611655169283203,
       "relays": [
         {
-          "domain": "r2.astch.com",
+          "domain": "cardano-main.everstake.one",
           "port": 3001
         },
         {
-          "domain": "r5.astch.com",
+          "domain": "cardano-main2.everstake.one",
+          "port": 3001
+        },
+        {
+          "domain": "cardano-relay.everstake.one",
+          "port": 3001
+        },
+        {
+          "domain": "cardano-relay1.everstake.one",
+          "port": 3001
+        },
+        {
+          "domain": "cardano-relay2.everstake.one",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.5781941578360684,
+      "relativeStake": 0.001758604215837338,
+      "relays": [
+        {
+          "address": "34.84.0.241",
+          "port": 3000
+        },
+        {
+          "address": "34.146.198.77",
+          "port": 3000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.5799427866538938,
+      "relativeStake": 0.0017486288178253436,
+      "relays": [
+        {
+          "domain": "europe-2.katanapool.net",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.5816910044676344,
+      "relativeStake": 0.001748217813740767,
+      "relays": [
+        {
+          "domain": "cardano-main.everstake.one",
+          "port": 3001
+        },
+        {
+          "domain": "cardano-main2.everstake.one",
+          "port": 3001
+        },
+        {
+          "domain": "cardano-relay.everstake.one",
+          "port": 3001
+        },
+        {
+          "domain": "cardano-relay1.everstake.one",
+          "port": 3001
+        },
+        {
+          "domain": "cardano-relay2.everstake.one",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.5834209928447708,
+      "relativeStake": 0.0017299883771362563,
+      "relays": [
+        {
+          "domain": "relays.mainnet.pools.fivebinaries.com",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.5851473687863966,
+      "relativeStake": 0.0017263759416259051,
+      "relays": [
+        {
+          "domain": "cardano-main.everstake.one",
+          "port": 3001
+        },
+        {
+          "domain": "cardano-main2.everstake.one",
+          "port": 3001
+        },
+        {
+          "domain": "cardano-relay.everstake.one",
+          "port": 3001
+        },
+        {
+          "domain": "cardano-relay1.everstake.one",
+          "port": 3001
+        },
+        {
+          "domain": "cardano-relay2.everstake.one",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.5868651777862275,
+      "relativeStake": 0.001717808999830805,
+      "relays": [
+        {
+          "address": "170.187.203.117",
           "port": 6000
         },
         {
-          "domain": "r6.astch.com",
-          "port": 6001
-        },
-        {
-          "domain": "r8.astch.com",
+          "address": "173.255.203.8",
           "port": 6000
         }
       ]
     },
     {
-      "accumulatedStake": 0.5748487258653008,
-      "relativeStake": 0.0017964571274818608,
+      "accumulatedStake": 0.5885758512607904,
+      "relativeStake": 0.0017106734745629662,
+      "relays": [
+        {
+          "domain": "25.cardano.staked.cloud",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.5902798723293516,
+      "relativeStake": 0.001704021068561181,
+      "relays": [
+        {
+          "domain": "r1.1percentpool.eu",
+          "port": 19001
+        },
+        {
+          "domain": "r2.1percentpool.eu",
+          "port": 19002
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.5919818678698819,
+      "relativeStake": 0.0017019955405303804,
+      "relays": [
+        {
+          "address": "202.61.246.91",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.5936805749844887,
+      "relativeStake": 0.0016987071146066762,
+      "relays": [
+        {
+          "address": "149.28.106.59",
+          "port": 6000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.5953730954129488,
+      "relativeStake": 0.0016925204284601865,
       "relays": [
         {
           "domain": "truth.kiwipool.org",
@@ -3223,8 +3377,36 @@
       ]
     },
     {
-      "accumulatedStake": 0.5766449100506773,
-      "relativeStake": 0.0017961841853764962,
+      "accumulatedStake": 0.5970624345580228,
+      "relativeStake": 0.001689339145073904,
+      "relays": [
+        {
+          "domain": "relays.wavepool.digital",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.5987442795292381,
+      "relativeStake": 0.0016818449712153586,
+      "relays": [
+        {
+          "address": "85.215.129.208",
+          "port": 3001
+        },
+        {
+          "address": "154.26.158.189",
+          "port": 3001
+        },
+        {
+          "address": "5.104.83.174",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.6004175803948582,
+      "relativeStake": 0.0016733008656200088,
       "relays": [
         {
           "domain": "norway.adanorthpool.com",
@@ -3249,28 +3431,26 @@
       ]
     },
     {
-      "accumulatedStake": 0.5784344466107867,
-      "relativeStake": 0.001789536560109396,
+      "accumulatedStake": 0.6020885105205181,
+      "relativeStake": 0.0016709301256600216,
       "relays": [
         {
-          "address": "13.235.131.115",
-          "port": 3001
+          "domain": "bra-relay.cardanistas.io",
+          "port": 8081
+        },
+        {
+          "domain": "usa-relay.cardanistas.io",
+          "port": 8082
+        },
+        {
+          "domain": "de-relay.cardanistas.io",
+          "port": 8083
         }
       ]
     },
     {
-      "accumulatedStake": 0.5802100063135663,
-      "relativeStake": 0.0017755597027796985,
-      "relays": [
-        {
-          "domain": "europe-2.katanapool.net",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.5819738270718107,
-      "relativeStake": 0.0017638207582442729,
+      "accumulatedStake": 0.6037499679196363,
+      "relativeStake": 0.0016614573991181499,
       "relays": [
         {
           "domain": "cardano-main.everstake.one",
@@ -3295,130 +3475,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.5837320432282462,
-      "relativeStake": 0.0017582161564356246,
-      "relays": [
-        {
-          "address": "202.61.246.91",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.5854833409623333,
-      "relativeStake": 0.001751297734087108,
-      "relays": [
-        {
-          "domain": "relays.mainnet.pools.fivebinaries.com",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.5872287101073213,
-      "relativeStake": 0.0017453691449878358,
-      "relays": [
-        {
-          "address": "170.187.203.117",
-          "port": 6000
-        },
-        {
-          "address": "173.255.203.8",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.5889711734256552,
-      "relativeStake": 0.001742463318333959,
-      "relays": [
-        {
-          "address": "52.177.36.96",
-          "port": 3000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.5907098519423557,
-      "relativeStake": 0.0017386785167004958,
-      "relays": [
-        {
-          "address": "157.245.228.134",
-          "port": 3001
-        },
-        {
-          "address": "159.89.120.164",
-          "port": 3001
-        },
-        {
-          "address": "209.97.186.44",
-          "port": 3001
-        },
-        {
-          "domain": "na.bloompool.io",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.5924289034498764,
-      "relativeStake": 0.0017190515075207735,
-      "relays": [
-        {
-          "address": "149.28.106.59",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.5941347512464782,
-      "relativeStake": 0.0017058477966016819,
-      "relays": [
-        {
-          "address": "150.136.84.82",
-          "port": 6001
-        },
-        {
-          "address": "158.101.99.150",
-          "port": 6001
-        },
-        {
-          "address": "150.136.111.193",
-          "port": 6001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.5958395590259463,
-      "relativeStake": 0.001704807779468131,
-      "relays": [
-        {
-          "domain": "bra-relay.cardanistas.io",
-          "port": 8081
-        },
-        {
-          "domain": "usa-relay.cardanistas.io",
-          "port": 8082
-        },
-        {
-          "domain": "de-relay.cardanistas.io",
-          "port": 8083
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.5975357915161921,
-      "relativeStake": 0.0016962324902457455,
-      "relays": [
-        {
-          "domain": "a1666f4c.cardano-relay.herd.run",
-          "port": 1338
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.5992169182643848,
-      "relativeStake": 0.0016811267481928079,
+      "accumulatedStake": 0.6054062098059855,
+      "relativeStake": 0.0016562418863491945,
       "relays": [
         {
           "domain": "cardano-relays-1.nu.fi",
@@ -3431,42 +3489,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.6008948106123213,
-      "relativeStake": 0.0016778923479365262,
-      "relays": [
-        {
-          "domain": "relays.mainnet.fortepool.io",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.6025704843045324,
-      "relativeStake": 0.0016756736922110733,
-      "relays": [
-        {
-          "address": "77.68.30.20",
-          "port": 6000
-        },
-        {
-          "address": "132.145.98.48",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.6042348989647072,
-      "relativeStake": 0.0016644146601747815,
-      "relays": [
-        {
-          "domain": "c2504518.cardano-relay.bison.run",
-          "port": 1338
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.6058923465438631,
-      "relativeStake": 0.001657447579155986,
+      "accumulatedStake": 0.6070541260707625,
+      "relativeStake": 0.001647916264776946,
       "relays": [
         {
           "domain": "btc-cardano-main-relay-00-a.bdnodes.net",
@@ -3479,8 +3503,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.607548768051189,
-      "relativeStake": 0.0016564215073257415,
+      "accumulatedStake": 0.6086907947457687,
+      "relativeStake": 0.0016366686750063045,
       "relays": [
         {
           "domain": "cardano-relays-1.nu.fi",
@@ -3493,8 +3517,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.6091985817366055,
-      "relativeStake": 0.0016498136854165278,
+      "accumulatedStake": 0.6103044300602263,
+      "relativeStake": 0.001613635314457494,
       "relays": [
         {
           "domain": "cork.queenada.com",
@@ -3503,8 +3527,78 @@
       ]
     },
     {
-      "accumulatedStake": 0.6108376978538204,
-      "relativeStake": 0.0016391161172149022,
+      "accumulatedStake": 0.6119171711733722,
+      "relativeStake": 0.001612741113145988,
+      "relays": [
+        {
+          "address": "129.80.153.243",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.6135281447814428,
+      "relativeStake": 0.0016109736080705916,
+      "relays": [
+        {
+          "domain": "c2504518.cardano-relay.bison.run",
+          "port": 1338
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.6151387547944475,
+      "relativeStake": 0.001610610013004658,
+      "relays": [
+        {
+          "domain": "d699483e.cardano-relay.bison.run",
+          "port": 1338
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.6167492734930679,
+      "relativeStake": 0.0016105186986203695,
+      "relays": [
+        {
+          "domain": "3ef2283d.cardano-relay.bison.run",
+          "port": 1338
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.6183596156460814,
+      "relativeStake": 0.0016103421530136073,
+      "relays": [
+        {
+          "domain": "84cbba68.cardano-relay.herd.run",
+          "port": 1338
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.6199590289792146,
+      "relativeStake": 0.00159941333313319,
+      "relays": [
+        {
+          "domain": "north-america-relay.jpn-sp.net",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.6215522328496231,
+      "relativeStake": 0.0015932038704085467,
+      "relays": [
+        {
+          "address": "199.247.23.219",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.6231400313456225,
+      "relativeStake": 0.0015877984959992877,
       "relays": [
         {
           "address": "185.161.193.91",
@@ -3529,8 +3623,124 @@
       ]
     },
     {
-      "accumulatedStake": 0.6124753898693216,
-      "relativeStake": 0.0016376920155012852,
+      "accumulatedStake": 0.6247081750194926,
+      "relativeStake": 0.0015681436738701159,
+      "relays": [
+        {
+          "domain": "r1.21ada.ca",
+          "port": 6000
+        },
+        {
+          "domain": "r2.21ada.ca",
+          "port": 6000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.6262659691194733,
+      "relativeStake": 0.0015577940999807042,
+      "relays": [
+        {
+          "domain": "relays.staking4ada.org",
+          "port": 1818
+        },
+        {
+          "domain": "globecast.staking4ada.org",
+          "port": 6061
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.6278189928074962,
+      "relativeStake": 0.0015530236880229448,
+      "relays": [
+        {
+          "domain": "relays.mainnet.fortepool.io",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.6293654942298597,
+      "relativeStake": 0.0015465014223634275,
+      "relays": [
+        {
+          "domain": "relay1.hyperlinkpool.kr",
+          "port": 3002
+        },
+        {
+          "domain": "relay2.hyperlinkpool.kr",
+          "port": 3003
+        },
+        {
+          "domain": "relay3.hyperlinkpool.kr",
+          "port": 3004
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.6309119938068237,
+      "relativeStake": 0.0015464995769640937,
+      "relays": [
+        {
+          "domain": "relays.wavepool.digital",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.632452830890396,
+      "relativeStake": 0.001540837083572212,
+      "relays": [
+        {
+          "address": "52.8.37.3",
+          "port": 3001
+        },
+        {
+          "address": "3.125.252.182",
+          "port": 3001
+        },
+        {
+          "address": "52.63.225.190",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.6339932796996615,
+      "relativeStake": 0.0015404488092654453,
+      "relays": [
+        {
+          "address": "157.245.228.134",
+          "port": 3001
+        },
+        {
+          "address": "159.89.120.164",
+          "port": 3001
+        },
+        {
+          "address": "209.97.186.44",
+          "port": 3001
+        },
+        {
+          "domain": "eu.bloompool.io",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.6355320547355906,
+      "relativeStake": 0.001538775035929158,
+      "relays": [
+        {
+          "domain": "relays.cardanowithpaul.com",
+          "port": 1069
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.6370647902735698,
+      "relativeStake": 0.0015327355379792036,
       "relays": [
         {
           "domain": "53e378bf.cardano-relay.bison.run",
@@ -3539,84 +3749,298 @@
       ]
     },
     {
-      "accumulatedStake": 0.6141126706212501,
-      "relativeStake": 0.0016372807519284736,
+      "accumulatedStake": 0.6385932959869186,
+      "relativeStake": 0.001528505713348891,
       "relays": [
         {
-          "domain": "cardano-main.everstake.one",
+          "domain": "r2.cosd.com",
+          "port": 5250
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.640119675887709,
+      "relativeStake": 0.001526379900790306,
+      "relays": [
+        {
+          "address": "157.245.228.134",
           "port": 3001
         },
         {
-          "domain": "cardano-main2.everstake.one",
+          "address": "159.89.120.164",
           "port": 3001
         },
         {
-          "domain": "cardano-relay.everstake.one",
+          "address": "209.97.186.44",
           "port": 3001
         },
         {
-          "domain": "cardano-relay1.everstake.one",
+          "domain": "eu.bloompool.io",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.6416392036523483,
+      "relativeStake": 0.0015195277646393407,
+      "relays": [
+        {
+          "address": "3.231.140.4",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.643148630367913,
+      "relativeStake": 0.0015094267155647688,
+      "relays": [
+        {
+          "address": "3.234.66.234",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.644656964450644,
+      "relativeStake": 0.0015083340827309114,
+      "relays": [
+        {
+          "address": "3.234.66.234",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.6461641641747606,
+      "relativeStake": 0.0015071997241166823,
+      "relays": [
+        {
+          "address": "3.234.185.23",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.6476710151973276,
+      "relativeStake": 0.0015068510225668917,
+      "relays": [
+        {
+          "address": "23.23.190.5",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.6491778136330429,
+      "relativeStake": 0.0015067984357153433,
+      "relays": [
+        {
+          "address": "23.23.190.5",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.6506840784815231,
+      "relativeStake": 0.0015062648484801776,
+      "relays": [
+        {
+          "address": "52.177.36.96",
+          "port": 3000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.652188445279123,
+      "relativeStake": 0.001504366797599969,
+      "relays": [
+        {
+          "address": "3.231.62.160",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.653692345836599,
+      "relativeStake": 0.0015039005574759507,
+      "relays": [
+        {
+          "address": "3.231.140.4",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.6551959688814686,
+      "relativeStake": 0.0015036230448696047,
+      "relays": [
+        {
+          "domain": "relays.digi.pro",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.6566995278220432,
+      "relativeStake": 0.0015035589405746276,
+      "relays": [
+        {
+          "address": "3.221.94.137",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.6582028049756311,
+      "relativeStake": 0.0015032771535878227,
+      "relays": [
+        {
+          "address": "3.231.62.160",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.6597056815528007,
+      "relativeStake": 0.0015028765771696775,
+      "relays": [
+        {
+          "address": "3.221.94.137",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.6612085192369377,
+      "relativeStake": 0.0015028376841369645,
+      "relays": [
+        {
+          "address": "3.222.153.137",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.6627113109819632,
+      "relativeStake": 0.0015027917450255242,
+      "relays": [
+        {
+          "address": "3.224.130.99",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.6642140540256057,
+      "relativeStake": 0.001502743043642564,
+      "relays": [
+        {
+          "address": "3.221.184.134",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.6657167218929813,
+      "relativeStake": 0.0015026678673755057,
+      "relays": [
+        {
+          "address": "3.228.183.84",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.6672193824749724,
+      "relativeStake": 0.00150266058199102,
+      "relays": [
+        {
+          "address": "3.222.153.137",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.66872200810307,
+      "relativeStake": 0.0015026256280977583,
+      "relays": [
+        {
+          "address": "3.228.183.84",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.6702245233707992,
+      "relativeStake": 0.0015025152677291245,
+      "relays": [
+        {
+          "address": "34.192.61.190",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.6717264570305799,
+      "relativeStake": 0.0015019336597807149,
+      "relays": [
+        {
+          "address": "3.225.242.57",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.6732274627686156,
+      "relativeStake": 0.0015010057380356,
+      "relays": [
+        {
+          "domain": "cardano1.staked.cloud",
           "port": 3001
         },
         {
-          "domain": "cardano-relay2.everstake.one",
+          "address": "44.242.70.220",
           "port": 3001
         }
       ]
     },
     {
-      "accumulatedStake": 0.6157483795151029,
-      "relativeStake": 0.001635708893852747,
+      "accumulatedStake": 0.6747284384365565,
+      "relativeStake": 0.0015009756679409784,
       "relays": [
         {
-          "domain": "fdd5329e.cardano-relay.bison.run",
-          "port": 1338
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.6173838343425686,
-      "relativeStake": 0.0016354548274657764,
-      "relays": [
-        {
-          "domain": "3ef2283d.cardano-relay.bison.run",
-          "port": 1338
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.6190192081362987,
-      "relativeStake": 0.001635373793730046,
-      "relays": [
-        {
-          "domain": "84cbba68.cardano-relay.herd.run",
-          "port": 1338
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.6206545653218335,
-      "relativeStake": 0.001635357185534792,
-      "relays": [
-        {
-          "domain": "d699483e.cardano-relay.bison.run",
-          "port": 1338
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.6222853475003666,
-      "relativeStake": 0.0016307821785330589,
-      "relays": [
-        {
-          "address": "199.247.23.219",
+          "address": "3.221.184.134",
           "port": 3001
         }
       ]
     },
     {
-      "accumulatedStake": 0.6239030429056687,
-      "relativeStake": 0.0016176954053021585,
+      "accumulatedStake": 0.6762293605780758,
+      "relativeStake": 0.001500922141519331,
+      "relays": [
+        {
+          "address": "3.234.185.23",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.6777216414881629,
+      "relativeStake": 0.0014922809100870946,
+      "relays": [
+        {
+          "domain": "cardano2.staked.cloud",
+          "port": 3001
+        },
+        {
+          "address": "52.39.19.247",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.6792117923382511,
+      "relativeStake": 0.001490150850088267,
       "relays": [
         {
           "domain": "node.pipool.online",
@@ -3637,354 +4061,76 @@
       ]
     },
     {
-      "accumulatedStake": 0.6255150836379131,
-      "relativeStake": 0.0016120407322443638,
+      "accumulatedStake": 0.6806930234896411,
+      "relativeStake": 0.0014812311513899164,
       "relays": [
         {
-          "domain": "north-america-relay.jpn-sp.net",
+          "domain": "csn.relay1.cardanoscan.io",
+          "port": 3101
+        },
+        {
+          "domain": "csn.relay2.cardanoscan.io",
+          "port": 3101
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.6821712885967582,
+      "relativeStake": 0.0014782651071171733,
+      "relays": [
+        {
+          "address": "23.21.195.62",
           "port": 3001
         }
       ]
     },
     {
-      "accumulatedStake": 0.6271181402759942,
-      "relativeStake": 0.0016030566380811797,
+      "accumulatedStake": 0.6836459602755751,
+      "relativeStake": 0.0014746716788168258,
       "relays": [
         {
-          "address": "35.154.118.137",
+          "address": "18.207.62.97",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.6851189229711172,
+      "relativeStake": 0.0014729626955421588,
+      "relays": [
+        {
+          "address": "18.207.62.97",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.6865909634988573,
+      "relativeStake": 0.0014720405277400205,
+      "relays": [
+        {
+          "address": "18.222.201.35",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.6880466215049149,
+      "relativeStake": 0.0014556580060576636,
+      "relays": [
+        {
+          "address": "77.68.30.20",
           "port": 6000
         },
         {
-          "address": "3.6.81.137",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.6287162995985598,
-      "relativeStake": 0.0015981593225655802,
-      "relays": [
-        {
-          "domain": "relays.cardanowithpaul.com",
-          "port": 1069
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.6303101712275624,
-      "relativeStake": 0.0015938716290026145,
-      "relays": [
-        {
-          "domain": "relay01.ca.lovelace.community",
-          "port": 3001
-        },
-        {
-          "domain": "relay02.ca.lovelace.community",
-          "port": 3001
-        },
-        {
-          "domain": "relay01.fr.lovelace.community",
-          "port": 3001
-        },
-        {
-          "domain": "relay01.de.lovelace.community",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.6318986205688362,
-      "relativeStake": 0.0015884493412736847,
-      "relays": [
-        {
-          "domain": "relay1.hyperlinkpool.kr",
-          "port": 3002
-        },
-        {
-          "domain": "relay2.hyperlinkpool.kr",
-          "port": 3003
-        },
-        {
-          "domain": "relay3.hyperlinkpool.kr",
-          "port": 3004
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.6334799053989404,
-      "relativeStake": 0.0015812848301042124,
-      "relays": [
-        {
-          "address": "52.8.37.3",
-          "port": 3001
-        },
-        {
-          "address": "3.125.252.182",
-          "port": 3001
-        },
-        {
-          "address": "52.63.225.190",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.635056609563746,
-      "relativeStake": 0.0015767041648056374,
-      "relays": [
-        {
-          "domain": "relay1.cardanotech.io",
+          "address": "132.145.98.48",
           "port": 6000
         }
       ]
     },
     {
-      "accumulatedStake": 0.6366313173981553,
-      "relativeStake": 0.0015747078344093188,
-      "relays": [
-        {
-          "domain": "relays.staking4ada.org",
-          "port": 1818
-        },
-        {
-          "domain": "globecast.staking4ada.org",
-          "port": 6061
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.638198669729601,
-      "relativeStake": 0.0015673523314457553,
-      "relays": [
-        {
-          "domain": "25.cardano.staked.cloud",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.6397632010842943,
-      "relativeStake": 0.0015645313546932829,
-      "relays": [
-        {
-          "address": "52.177.36.96",
-          "port": 3000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.6413227984446199,
-      "relativeStake": 0.0015595973603256404,
-      "relays": [
-        {
-          "domain": "relays.wavepool.digital",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.6428751136281016,
-      "relativeStake": 0.0015523151834816436,
-      "relays": [
-        {
-          "domain": "eu.relays.cardanians.io",
-          "port": 1000
-        },
-        {
-          "domain": "ca.relays.cardanians.io",
-          "port": 1000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.6444244666311935,
-      "relativeStake": 0.0015493530030918606,
-      "relays": [
-        {
-          "domain": "r2.cosd.com",
-          "port": 5250
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.6459707563565347,
-      "relativeStake": 0.00154628972534117,
-      "relays": [
-        {
-          "domain": "relay1.angelstakepool.net",
-          "port": 5001
-        },
-        {
-          "domain": "relay2.angelstakepool.net",
-          "port": 5002
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.6475129867838453,
-      "relativeStake": 0.001542230427310614,
-      "relays": [
-        {
-          "address": "157.245.228.134",
-          "port": 3001
-        },
-        {
-          "address": "159.89.120.164",
-          "port": 3001
-        },
-        {
-          "address": "209.97.186.44",
-          "port": 3001
-        },
-        {
-          "domain": "eu.bloompool.io",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.6490537995886774,
-      "relativeStake": 0.0015408128048321557,
-      "relays": [
-        {
-          "address": "52.177.36.96",
-          "port": 3000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.6505905584417048,
-      "relativeStake": 0.0015367588530273042,
-      "relays": [
-        {
-          "address": "3.231.140.4",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.6521176003250365,
-      "relativeStake": 0.0015270418833318517,
-      "relays": [
-        {
-          "address": "3.234.66.234",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.6536436762869469,
-      "relativeStake": 0.0015260759619102513,
-      "relays": [
-        {
-          "address": "3.234.66.234",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.6551685777252161,
-      "relativeStake": 0.0015249014382692065,
-      "relays": [
-        {
-          "address": "3.234.185.23",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.656693052802288,
-      "relativeStake": 0.0015244750770719727,
-      "relays": [
-        {
-          "address": "23.23.190.5",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.658217489482262,
-      "relativeStake": 0.0015244366799739668,
-      "relays": [
-        {
-          "address": "23.23.190.5",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.6597393068192318,
-      "relativeStake": 0.0015218173369698396,
-      "relays": [
-        {
-          "address": "3.231.62.160",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.6612606469612167,
-      "relativeStake": 0.0015213401419848262,
-      "relays": [
-        {
-          "address": "3.231.140.4",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.6627818632029849,
-      "relativeStake": 0.0015212162417682432,
-      "relays": [
-        {
-          "address": "3.221.94.137",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.6643029044032962,
-      "relativeStake": 0.0015210412003113711,
-      "relays": [
-        {
-          "address": "3.221.94.137",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.665823795264094,
-      "relativeStake": 0.0015208908607977014,
-      "relays": [
-        {
-          "address": "3.221.184.134",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.6673445998182062,
-      "relativeStake": 0.0015208045541122185,
-      "relays": [
-        {
-          "address": "34.192.61.190",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.6688653871968488,
-      "relativeStake": 0.0015207873786426762,
-      "relays": [
-        {
-          "address": "3.231.62.160",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.6703860592393801,
-      "relativeStake": 0.0015206720425313036,
+      "accumulatedStake": 0.6894927714301918,
+      "relativeStake": 0.001446149925276859,
       "relays": [
         {
           "address": "3.224.130.99",
@@ -3993,114 +4139,28 @@
       ]
     },
     {
-      "accumulatedStake": 0.671906444739297,
-      "relativeStake": 0.0015203854999168442,
+      "accumulatedStake": 0.6909346445533009,
+      "relativeStake": 0.0014418731231090837,
       "relays": [
         {
-          "address": "3.228.183.84",
+          "address": "52.177.36.96",
+          "port": 3000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.692371885370925,
+      "relativeStake": 0.0014372408176240598,
+      "relays": [
+        {
+          "domain": "asia-pacific-zzzrelay.zzzpool.net",
           "port": 3001
         }
       ]
     },
     {
-      "accumulatedStake": 0.673426751116265,
-      "relativeStake": 0.0015203063769680177,
-      "relays": [
-        {
-          "address": "3.228.183.84",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.6749470518404761,
-      "relativeStake": 0.0015203007242111197,
-      "relays": [
-        {
-          "address": "3.222.153.137",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.6764670357924952,
-      "relativeStake": 0.0015199839520191074,
-      "relays": [
-        {
-          "address": "3.222.153.137",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.6779870000151557,
-      "relativeStake": 0.0015199642226604354,
-      "relays": [
-        {
-          "domain": "cardano1.staked.cloud",
-          "port": 3001
-        },
-        {
-          "address": "44.242.70.220",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.6795062810572741,
-      "relativeStake": 0.0015192810421184352,
-      "relays": [
-        {
-          "address": "3.221.184.134",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.6810254534690998,
-      "relativeStake": 0.0015191724118256904,
-      "relays": [
-        {
-          "address": "3.225.242.57",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.6825441435141056,
-      "relativeStake": 0.0015186900450058333,
-      "relays": [
-        {
-          "address": "3.234.185.23",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.6840583726744444,
-      "relativeStake": 0.0015142291603387553,
-      "relays": [
-        {
-          "address": "157.245.228.134",
-          "port": 3001
-        },
-        {
-          "address": "159.89.120.164",
-          "port": 3001
-        },
-        {
-          "address": "209.97.186.44",
-          "port": 3001
-        },
-        {
-          "domain": "eu.bloompool.io",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.6855698520969297,
-      "relativeStake": 0.001511479422485263,
+      "accumulatedStake": 0.6938050227501456,
+      "relativeStake": 0.0014331373792206452,
       "relays": [
         {
           "domain": "eu-de-blue-cdn-relays.cardano.fans",
@@ -4121,160 +4181,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.6870805548075262,
-      "relativeStake": 0.0015107027105965435,
-      "relays": [
-        {
-          "domain": "cardano2.staked.cloud",
-          "port": 3001
-        },
-        {
-          "address": "52.39.19.247",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.6885847853122063,
-      "relativeStake": 0.0015042305046802072,
-      "relays": [
-        {
-          "domain": "csn.relay1.cardanoscan.io",
-          "port": 3101
-        },
-        {
-          "domain": "csn.relay2.cardanoscan.io",
-          "port": 3101
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.6900751402668898,
-      "relativeStake": 0.0014903549546833688,
-      "relays": [
-        {
-          "address": "18.222.201.35",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.691555056987085,
-      "relativeStake": 0.001479916720195242,
-      "relays": [
-        {
-          "address": "89.58.57.185",
-          "port": 4000
-        },
-        {
-          "address": "5.250.178.133",
-          "port": 4000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.6930295273920195,
-      "relativeStake": 0.0014744704049345111,
-      "relays": [
-        {
-          "address": "94.130.191.208",
-          "port": 9630
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.6944927857315022,
-      "relativeStake": 0.0014632583394826191,
-      "relays": [
-        {
-          "address": "3.224.130.99",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.6959455126842145,
-      "relativeStake": 0.001452726952712261,
-      "relays": [
-        {
-          "domain": "relays.digi.pro",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.6973854577563671,
-      "relativeStake": 0.001439945072152702,
-      "relays": [
-        {
-          "address": "3.225.242.57",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.69881935456922,
-      "relativeStake": 0.0014338968128528482,
-      "relays": [
-        {
-          "domain": "cardano-relays-1.nu.fi",
-          "port": 3003
-        },
-        {
-          "domain": "cardano-relays-2.nu.fi",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.7002449810605577,
-      "relativeStake": 0.0014256264913376673,
-      "relays": [
-        {
-          "domain": "relay1.cerostakepool.com",
-          "port": 3001
-        },
-        {
-          "domain": "relay2.cerostakepool.com",
-          "port": 3001
-        },
-        {
-          "domain": "relay3.cerostakepool.com",
-          "port": 3001
-        },
-        {
-          "domain": "relay4.cerostakepool.com",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.7016612104268932,
-      "relativeStake": 0.0014162293663356018,
-      "relays": [
-        {
-          "domain": "asia.jazzstakepool.net",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.7030696677158264,
-      "relativeStake": 0.0014084572889331703,
-      "relays": [
-        {
-          "address": "133.167.33.31",
-          "port": 6000
-        },
-        {
-          "address": "162.43.71.205",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.7044747445978664,
-      "relativeStake": 0.0014050768820400282,
+      "accumulatedStake": 0.6952365503564101,
+      "relativeStake": 0.0014315276062645428,
       "relays": [
         {
           "domain": "relay1.zetetic.tech",
@@ -4295,22 +4203,42 @@
       ]
     },
     {
-      "accumulatedStake": 0.7058760947501411,
-      "relativeStake": 0.0014013501522746534,
+      "accumulatedStake": 0.6966615840108837,
+      "relativeStake": 0.0014250336544735988,
       "relays": [
         {
-          "address": "35.211.17.86",
-          "port": 3000
+          "address": "89.58.57.185",
+          "port": 4000
         },
         {
-          "address": "34.23.88.7",
-          "port": 3000
+          "address": "5.250.178.133",
+          "port": 4000
         }
       ]
     },
     {
-      "accumulatedStake": 0.7072738781722625,
-      "relativeStake": 0.0013977834221214655,
+      "accumulatedStake": 0.6980848240926105,
+      "relativeStake": 0.0014232400817268454,
+      "relays": [
+        {
+          "address": "3.225.242.57",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.6995027772098297,
+      "relativeStake": 0.0014179531172190478,
+      "relays": [
+        {
+          "domain": "iog1-relays.cardano.iog.io",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.7009091831579998,
+      "relativeStake": 0.0014064059481701766,
       "relays": [
         {
           "domain": "cardano-relays-1.nu.fi",
@@ -4323,46 +4251,98 @@
       ]
     },
     {
-      "accumulatedStake": 0.7086685290346494,
-      "relativeStake": 0.0013946508623868315,
+      "accumulatedStake": 0.7023074451042086,
+      "relativeStake": 0.0013982619462088665,
       "relays": [
         {
-          "domain": "r1.21ada.ca",
-          "port": 6000
+          "domain": "relay1.p2p.mainnet.cardano.p2p.org",
+          "port": 6001
         },
         {
-          "domain": "r2.21ada.ca",
+          "domain": "relay2.p2p.mainnet.cardano.p2p.org",
+          "port": 6001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.703701884078708,
+      "relativeStake": 0.0013944389744993996,
+      "relays": [
+        {
+          "address": "35.211.17.86",
+          "port": 3000
+        },
+        {
+          "address": "34.23.88.7",
+          "port": 3000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.7050889658322311,
+      "relativeStake": 0.0013870817535230145,
+      "relays": [
+        {
+          "address": "94.130.191.208",
+          "port": 9630
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.7064667355086202,
+      "relativeStake": 0.001377769676389102,
+      "relays": [
+        {
+          "domain": "a1666f4c.cardano-relay.herd.run",
+          "port": 1338
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.7078404258363837,
+      "relativeStake": 0.0013736903277635918,
+      "relays": [
+        {
+          "domain": "asia.jazzstakepool.net",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.7092136319454907,
+      "relativeStake": 0.0013732061091069466,
+      "relays": [
+        {
+          "domain": "relay1.cerostakepool.com",
+          "port": 3001
+        },
+        {
+          "domain": "relay2.cerostakepool.com",
+          "port": 3001
+        },
+        {
+          "domain": "relay3.cerostakepool.com",
+          "port": 3001
+        },
+        {
+          "domain": "relay4.cerostakepool.com",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.7105854536983927,
+      "relativeStake": 0.0013718217529019325,
+      "relays": [
+        {
+          "domain": "relay1.cardanotech.io",
           "port": 6000
         }
       ]
     },
     {
-      "accumulatedStake": 0.7100608435793766,
-      "relativeStake": 0.0013923145447272316,
-      "relays": [
-        {
-          "domain": "relays.planetstake.com",
-          "port": 3001
-        },
-        {
-          "address": "161.97.90.20",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.7114418366468767,
-      "relativeStake": 0.0013809930675000787,
-      "relays": [
-        {
-          "domain": "relays.mainnet.pools.fivebinaries.com",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.7128221852992572,
-      "relativeStake": 0.001380348652380532,
+      "accumulatedStake": 0.7119498431607038,
+      "relativeStake": 0.0013643894623110659,
       "relays": [
         {
           "domain": "cardano-relay-1.upbit.com",
@@ -4379,8 +4359,22 @@
       ]
     },
     {
-      "accumulatedStake": 0.714193720474111,
-      "relativeStake": 0.0013715351748538073,
+      "accumulatedStake": 0.7133131863350388,
+      "relativeStake": 0.0013633431743350494,
+      "relays": [
+        {
+          "domain": "cardano-relays-1.nu.fi",
+          "port": 3003
+        },
+        {
+          "domain": "cardano-relays-2.nu.fi",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.7146534659128992,
+      "relativeStake": 0.001340279577860501,
       "relays": [
         {
           "domain": "relays.eu-de.cardano24.net",
@@ -4421,28 +4415,18 @@
       ]
     },
     {
-      "accumulatedStake": 0.7155555827930138,
-      "relativeStake": 0.0013618623189027214,
+      "accumulatedStake": 0.7159899296467733,
+      "relativeStake": 0.001336463733874105,
       "relays": [
         {
-          "domain": "asia-pacific-zzzrelay.zzzpool.net",
-          "port": 3001
+          "domain": "644dd09c.cardano-relay.herd.run",
+          "port": 1338
         }
       ]
     },
     {
-      "accumulatedStake": 0.716912631377486,
-      "relativeStake": 0.0013570485844721595,
-      "relays": [
-        {
-          "address": "129.80.153.243",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.7182627614848512,
-      "relativeStake": 0.001350130107365363,
+      "accumulatedStake": 0.7173245430171216,
+      "relativeStake": 0.0013346133703481613,
       "relays": [
         {
           "domain": "cardano-relay-2.upbit.com",
@@ -4459,22 +4443,36 @@
       ]
     },
     {
-      "accumulatedStake": 0.7196071762788917,
-      "relativeStake": 0.0013444147940404126,
+      "accumulatedStake": 0.7186576268999298,
+      "relativeStake": 0.0013330838828083075,
       "relays": [
         {
-          "address": "20.42.119.172",
+          "address": "34.146.212.90",
           "port": 6000
         },
         {
-          "address": "160.251.196.40",
+          "address": "34.175.85.49",
           "port": 6000
         }
       ]
     },
     {
-      "accumulatedStake": 0.720947272396147,
-      "relativeStake": 0.0013400961172552604,
+      "accumulatedStake": 0.7199829180140355,
+      "relativeStake": 0.001325291114105622,
+      "relays": [
+        {
+          "domain": "relay1.cardanesia.com",
+          "port": 3001
+        },
+        {
+          "domain": "relay2.cardanesia.com",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.7213024028548257,
+      "relativeStake": 0.0013194848407902479,
       "relays": [
         {
           "domain": "ipclub29-1.relay.my-ip.at",
@@ -4491,56 +4489,36 @@
       ]
     },
     {
-      "accumulatedStake": 0.7222797110030514,
-      "relativeStake": 0.0013324386069044755,
+      "accumulatedStake": 0.7226208722997032,
+      "relativeStake": 0.0013184694448774444,
       "relays": [
         {
-          "domain": "europe-de.popsp.net",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.7236078763366286,
-      "relativeStake": 0.0013281653335771282,
-      "relays": [
-        {
-          "domain": "relay1.ada-stake.com",
-          "port": 3001
+          "address": "20.42.119.172",
+          "port": 6000
         },
         {
-          "domain": "relay2.ada-stake.com",
-          "port": 3001
+          "address": "160.251.196.40",
+          "port": 6000
         }
       ]
     },
     {
-      "accumulatedStake": 0.7249353130764036,
-      "relativeStake": 0.001327436739774993,
+      "accumulatedStake": 0.7239341938723314,
+      "relativeStake": 0.00131332157262823,
       "relays": [
         {
-          "domain": "relay1.cardanesia.com",
-          "port": 3001
+          "domain": "relay1.angelstakepool.net",
+          "port": 5001
         },
         {
-          "domain": "relay2.cardanesia.com",
-          "port": 3001
+          "domain": "relay2.angelstakepool.net",
+          "port": 5002
         }
       ]
     },
     {
-      "accumulatedStake": 0.7262479986225253,
-      "relativeStake": 0.0013126855461217499,
-      "relays": [
-        {
-          "domain": "europe1-zzz3relay.zzzpool.net",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.7275465758072207,
-      "relativeStake": 0.001298577184695421,
+      "accumulatedStake": 0.7252245727608777,
+      "relativeStake": 0.0012903788885463296,
       "relays": [
         {
           "domain": "cardano-relays-1.nu.fi",
@@ -4553,8 +4531,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.7288448710676788,
-      "relativeStake": 0.0012982952604580743,
+      "accumulatedStake": 0.7265142926082753,
+      "relativeStake": 0.0012897198473975037,
       "relays": [
         {
           "address": "20.69.213.207",
@@ -4563,28 +4541,276 @@
       ]
     },
     {
-      "accumulatedStake": 0.7301335226206745,
-      "relativeStake": 0.001288651552995808,
+      "accumulatedStake": 0.7278009814467056,
+      "relativeStake": 0.0012866888384303668,
       "relays": [
         {
-          "address": "161.35.209.217",
-          "port": 6000
+          "domain": "cardano-relay-1.upbit.com",
+          "port": 30800
+        },
+        {
+          "domain": "cardano-relay-2.upbit.com",
+          "port": 30800
+        },
+        {
+          "domain": "cardano-relay-3.upbit.com",
+          "port": 30800
         }
       ]
     },
     {
-      "accumulatedStake": 0.731404474871964,
-      "relativeStake": 0.001270952251289414,
+      "accumulatedStake": 0.7290852221361389,
+      "relativeStake": 0.0012842406894333425,
       "relays": [
         {
-          "domain": "asia.jazzstakepool.net",
+          "domain": "cardano-relay-1.upbit.com",
+          "port": 30800
+        },
+        {
+          "domain": "cardano-relay-2.upbit.com",
+          "port": 30800
+        },
+        {
+          "domain": "cardano-relay-3.upbit.com",
+          "port": 30800
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.7303667949634705,
+      "relativeStake": 0.0012815728273315628,
+      "relays": [
+        {
+          "domain": "cardano-relay-1.upbit.com",
+          "port": 30800
+        },
+        {
+          "domain": "cardano-relay-2.upbit.com",
+          "port": 30800
+        },
+        {
+          "domain": "cardano-relay-3.upbit.com",
+          "port": 30800
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.7316475657554212,
+      "relativeStake": 0.0012807707919507067,
+      "relays": [
+        {
+          "domain": "cardano-relay-2.upbit.com",
+          "port": 30800
+        },
+        {
+          "domain": "cardano-relay-3.upbit.com",
+          "port": 30800
+        },
+        {
+          "domain": "cardano-relay-1.upbit.com",
+          "port": 30800
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.7329266436485145,
+      "relativeStake": 0.0012790778930932896,
+      "relays": [
+        {
+          "domain": "cardano-relay-1.upbit.com",
+          "port": 30800
+        },
+        {
+          "domain": "cardano-relay-2.upbit.com",
+          "port": 30800
+        },
+        {
+          "domain": "cardano-relay-3.upbit.com",
+          "port": 30800
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.7342048591718467,
+      "relativeStake": 0.0012782155233322524,
+      "relays": [
+        {
+          "domain": "cardano-relay-2.upbit.com",
+          "port": 30800
+        },
+        {
+          "domain": "cardano-relay-3.upbit.com",
+          "port": 30800
+        },
+        {
+          "domain": "cardano-relay-1.upbit.com",
+          "port": 30800
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.7354814180682979,
+      "relativeStake": 0.0012765588964511862,
+      "relays": [
+        {
+          "domain": "cardano-relay-1.upbit.com",
+          "port": 30800
+        },
+        {
+          "domain": "cardano-relay-2.upbit.com",
+          "port": 30800
+        },
+        {
+          "domain": "cardano-relay-3.upbit.com",
+          "port": 30800
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.7367557831760173,
+      "relativeStake": 0.0012743651077193842,
+      "relays": [
+        {
+          "domain": "eu.relays.cardanians.io",
+          "port": 1000
+        },
+        {
+          "domain": "ca.relays.cardanians.io",
+          "port": 1000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.7380280480728153,
+      "relativeStake": 0.0012722648967980084,
+      "relays": [
+        {
+          "domain": "europe1-zzz3relay.zzzpool.net",
           "port": 3001
         }
       ]
     },
     {
-      "accumulatedStake": 0.7326751271373713,
-      "relativeStake": 0.0012706522654072196,
+      "accumulatedStake": 0.7392994612481228,
+      "relativeStake": 0.0012714131753075058,
+      "relays": [
+        {
+          "domain": "94c3c6d3.cardano-relay.herd.run",
+          "port": 1338
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.7405601253309338,
+      "relativeStake": 0.0012606640828110261,
+      "relays": [
+        {
+          "domain": "cardano-relay-1.upbit.com",
+          "port": 30800
+        },
+        {
+          "domain": "cardano-relay-2.upbit.com",
+          "port": 30800
+        },
+        {
+          "domain": "cardano-relay-3.upbit.com",
+          "port": 30800
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.7418203512650619,
+      "relativeStake": 0.0012602259341279595,
+      "relays": [
+        {
+          "domain": "cardano-relay-1.upbit.com",
+          "port": 30800
+        },
+        {
+          "domain": "cardano-relay-2.upbit.com",
+          "port": 30800
+        },
+        {
+          "domain": "cardano-relay-3.upbit.com",
+          "port": 30800
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.743078378948809,
+      "relativeStake": 0.0012580276837471666,
+      "relays": [
+        {
+          "domain": "cardano-relay-1.upbit.com",
+          "port": 30800
+        },
+        {
+          "domain": "cardano-relay-2.upbit.com",
+          "port": 30800
+        },
+        {
+          "domain": "cardano-relay-3.upbit.com",
+          "port": 30800
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.7443353082322002,
+      "relativeStake": 0.001256929283391208,
+      "relays": [
+        {
+          "domain": "cardano-relay-1.upbit.com",
+          "port": 30800
+        },
+        {
+          "domain": "cardano-relay-2.upbit.com",
+          "port": 30800
+        },
+        {
+          "domain": "cardano-relay-3.upbit.com",
+          "port": 30800
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.7455879477432124,
+      "relativeStake": 0.0012526395110121174,
+      "relays": [
+        {
+          "domain": "cardano-relay-2.upbit.com",
+          "port": 30800
+        },
+        {
+          "domain": "cardano-relay-3.upbit.com",
+          "port": 30800
+        },
+        {
+          "domain": "cardano-relay-1.upbit.com",
+          "port": 30800
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.7468375677107808,
+      "relativeStake": 0.0012496199675684789,
+      "relays": [
+        {
+          "domain": "cardano-relay-1.upbit.com",
+          "port": 30800
+        },
+        {
+          "domain": "cardano-relay-2.upbit.com",
+          "port": 30800
+        },
+        {
+          "domain": "cardano-relay-3.upbit.com",
+          "port": 30800
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.7480847277910758,
+      "relativeStake": 0.0012471600802949879,
       "relays": [
         {
           "address": "65.109.12.161",
@@ -4597,8 +4823,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.733941885270841,
-      "relativeStake": 0.0012667581334697886,
+      "accumulatedStake": 0.7493244590623087,
+      "relativeStake": 0.0012397312712329914,
       "relays": [
         {
           "address": "206.81.3.194",
@@ -4607,8 +4833,22 @@
       ]
     },
     {
-      "accumulatedStake": 0.7351990375565962,
-      "relativeStake": 0.0012571522857552425,
+      "accumulatedStake": 0.7505617769397124,
+      "relativeStake": 0.0012373178774035749,
+      "relays": [
+        {
+          "domain": "relays.planetstake.com",
+          "port": 3001
+        },
+        {
+          "address": "161.97.90.20",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.7517965372240778,
+      "relativeStake": 0.0012347602843654347,
       "relays": [
         {
           "domain": "32.cardano.staked.cloud",
@@ -4617,8 +4857,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.7364471655521367,
-      "relativeStake": 0.001248127995540519,
+      "accumulatedStake": 0.7530302299106479,
+      "relativeStake": 0.0012336926865701924,
       "relays": [
         {
           "address": "3.139.50.19",
@@ -4631,8 +4871,18 @@
       ]
     },
     {
-      "accumulatedStake": 0.737693508186111,
-      "relativeStake": 0.0012463426339741923,
+      "accumulatedStake": 0.7542599247706075,
+      "relativeStake": 0.0012296948599596132,
+      "relays": [
+        {
+          "address": "161.35.209.217",
+          "port": 6000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.7554866627825436,
+      "relativeStake": 0.0012267380119360277,
       "relays": [
         {
           "domain": "tadpole.adafrog.io",
@@ -4641,158 +4891,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.7389285927707905,
-      "relativeStake": 0.0012350845846795014,
-      "relays": [
-        {
-          "domain": "relay1.growpools.io",
-          "port": 4181
-        },
-        {
-          "domain": "relay5.growpools.io",
-          "port": 4181
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.7401598788567142,
-      "relativeStake": 0.001231286085923753,
-      "relays": [
-        {
-          "domain": "cardano-relay-1.upbit.com",
-          "port": 30800
-        },
-        {
-          "domain": "cardano-relay-2.upbit.com",
-          "port": 30800
-        },
-        {
-          "domain": "cardano-relay-3.upbit.com",
-          "port": 30800
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.7413879706097205,
-      "relativeStake": 0.0012280917530062517,
-      "relays": [
-        {
-          "domain": "cardano-relay-2.upbit.com",
-          "port": 30800
-        },
-        {
-          "domain": "cardano-relay-3.upbit.com",
-          "port": 30800
-        },
-        {
-          "domain": "cardano-relay-1.upbit.com",
-          "port": 30800
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.7426144318794891,
-      "relativeStake": 0.0012264612697686042,
-      "relays": [
-        {
-          "domain": "cardano-relay-1.upbit.com",
-          "port": 30800
-        },
-        {
-          "domain": "cardano-relay-2.upbit.com",
-          "port": 30800
-        },
-        {
-          "domain": "cardano-relay-3.upbit.com",
-          "port": 30800
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.7438401545775946,
-      "relativeStake": 0.0012257226981055357,
-      "relays": [
-        {
-          "domain": "cardano-relay-1.upbit.com",
-          "port": 30800
-        },
-        {
-          "domain": "cardano-relay-2.upbit.com",
-          "port": 30800
-        },
-        {
-          "domain": "cardano-relay-3.upbit.com",
-          "port": 30800
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.7450656816780961,
-      "relativeStake": 0.0012255271005014031,
-      "relays": [
-        {
-          "domain": "cardano-relay-1.upbit.com",
-          "port": 30800
-        },
-        {
-          "domain": "cardano-relay-2.upbit.com",
-          "port": 30800
-        },
-        {
-          "domain": "cardano-relay-3.upbit.com",
-          "port": 30800
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.7462902652229843,
-      "relativeStake": 0.0012245835448882686,
-      "relays": [
-        {
-          "domain": "cardano-relay-1.upbit.com",
-          "port": 30800
-        },
-        {
-          "domain": "cardano-relay-2.upbit.com",
-          "port": 30800
-        },
-        {
-          "domain": "cardano-relay-3.upbit.com",
-          "port": 30800
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.7474935648870804,
-      "relativeStake": 0.0012032996640961495,
-      "relays": [
-        {
-          "domain": "relays.wavepool.digital",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.7486947956362442,
-      "relativeStake": 0.0012012307491638145,
-      "relays": [
-        {
-          "domain": "cardano-relay-1.upbit.com",
-          "port": 30800
-        },
-        {
-          "domain": "cardano-relay-2.upbit.com",
-          "port": 30800
-        },
-        {
-          "domain": "cardano-relay-3.upbit.com",
-          "port": 30800
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.7498958743965924,
-      "relativeStake": 0.0012010787603481989,
+      "accumulatedStake": 0.7567040808704247,
+      "relativeStake": 0.0012174180878811245,
       "relays": [
         {
           "domain": "relay1.nedscave.io",
@@ -4813,8 +4913,56 @@
       ]
     },
     {
-      "accumulatedStake": 0.7510902485952393,
-      "relativeStake": 0.001194374198646844,
+      "accumulatedStake": 0.7579119529033508,
+      "relativeStake": 0.0012078720329260083,
+      "relays": [
+        {
+          "domain": "relay1.growpools.io",
+          "port": 4181
+        },
+        {
+          "domain": "relay5.growpools.io",
+          "port": 4181
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.7591071824579461,
+      "relativeStake": 0.0011952295545953424,
+      "relays": [
+        {
+          "domain": "relays.liqwid.finance",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.7603023206187524,
+      "relativeStake": 0.0011951381608062853,
+      "relays": [
+        {
+          "domain": "relays.liqwid.finance",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.7614957796598981,
+      "relativeStake": 0.0011934590411457912,
+      "relays": [
+        {
+          "domain": "relay1.ada-stake.com",
+          "port": 3001
+        },
+        {
+          "domain": "relay2.ada-stake.com",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.7626846717844856,
+      "relativeStake": 0.0011888921245874382,
       "relays": [
         {
           "address": "158.101.99.150",
@@ -4831,54 +4979,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.752284363012417,
-      "relativeStake": 0.0011941144171776239,
-      "relays": [
-        {
-          "domain": "relay-dfm.cryptoblocks.pro",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.7534772256876333,
-      "relativeStake": 0.0011928626752163913,
-      "relays": [
-        {
-          "domain": "cardano-relay-2.upbit.com",
-          "port": 30800
-        },
-        {
-          "domain": "cardano-relay-3.upbit.com",
-          "port": 30800
-        },
-        {
-          "domain": "cardano-relay-1.upbit.com",
-          "port": 30800
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.7546686378589953,
-      "relativeStake": 0.001191412171362006,
-      "relays": [
-        {
-          "domain": "cardano-relay-1.upbit.com",
-          "port": 30800
-        },
-        {
-          "domain": "cardano-relay-2.upbit.com",
-          "port": 30800
-        },
-        {
-          "domain": "cardano-relay-3.upbit.com",
-          "port": 30800
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.7558482448014832,
-      "relativeStake": 0.0011796069424878347,
+      "accumulatedStake": 0.7638506477189608,
+      "relativeStake": 0.0011659759344752403,
       "relays": [
         {
           "domain": "r1.isp-r1.wjg.jp",
@@ -4891,228 +4993,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.7570222401767925,
-      "relativeStake": 0.0011739953753093593,
-      "relays": [
-        {
-          "address": "168.119.124.16",
-          "port": 3001
-        },
-        {
-          "address": "202.61.246.91",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.7581891007190538,
-      "relativeStake": 0.0011668605422612876,
-      "relays": [
-        {
-          "address": "52.167.20.127",
-          "port": 4000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.7593536433877367,
-      "relativeStake": 0.0011645426686828749,
-      "relays": [
-        {
-          "domain": "relays.liqwid.finance",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.7605178011726031,
-      "relativeStake": 0.0011641577848664835,
-      "relays": [
-        {
-          "domain": "relays.liqwid.finance",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.7616797647798773,
-      "relativeStake": 0.0011619636072741455,
-      "relays": [
-        {
-          "domain": "cardano-relay-1.upbit.com",
-          "port": 30800
-        },
-        {
-          "domain": "cardano-relay-2.upbit.com",
-          "port": 30800
-        },
-        {
-          "domain": "cardano-relay-3.upbit.com",
-          "port": 30800
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.7628388512531771,
-      "relativeStake": 0.0011590864732997845,
-      "relays": [
-        {
-          "domain": "relay1.nedscave.io",
-          "port": 3001
-        },
-        {
-          "domain": "relay2.nedscave.io",
-          "port": 3001
-        },
-        {
-          "domain": "relay3.nedscave.io",
-          "port": 3001
-        },
-        {
-          "domain": "relay4.nedscave.io",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.7639960512148554,
-      "relativeStake": 0.0011571999616782971,
-      "relays": [
-        {
-          "address": "217.160.14.223",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.7651524381131848,
-      "relativeStake": 0.0011563868983293678,
-      "relays": [
-        {
-          "domain": "cardano-relay-2.upbit.com",
-          "port": 30800
-        },
-        {
-          "domain": "cardano-relay-3.upbit.com",
-          "port": 30800
-        },
-        {
-          "domain": "cardano-relay-1.upbit.com",
-          "port": 30800
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.7663070599085317,
-      "relativeStake": 0.0011546217953469066,
-      "relays": [
-        {
-          "domain": "cardano-relay-1.upbit.com",
-          "port": 30800
-        },
-        {
-          "domain": "cardano-relay-2.upbit.com",
-          "port": 30800
-        },
-        {
-          "domain": "cardano-relay-3.upbit.com",
-          "port": 30800
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.7674513845471151,
-      "relativeStake": 0.001144324638583523,
-      "relays": [
-        {
-          "domain": "relay1.bluecheesestakehouse.com",
-          "port": 5001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.7685950075052133,
-      "relativeStake": 0.001143622958098065,
-      "relays": [
-        {
-          "domain": "relaynode1.kaldano.work",
-          "port": 3001
-        },
-        {
-          "domain": "relaynode2.kaldano.work",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.7697376811016147,
-      "relativeStake": 0.0011426735964014118,
-      "relays": [
-        {
-          "address": "3.111.14.60",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.7708724465070401,
-      "relativeStake": 0.0011347654054254953,
-      "relays": [
-        {
-          "domain": "relay1.p2p.mainnet.cardano.p2p.org",
-          "port": 6001
-        },
-        {
-          "domain": "relay2.p2p.mainnet.cardano.p2p.org",
-          "port": 6001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.7720068240045991,
-      "relativeStake": 0.0011343774975588854,
-      "relays": [
-        {
-          "address": "20.69.213.207",
-          "port": 3000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.7731407407575382,
-      "relativeStake": 0.0011339167529392455,
-      "relays": [
-        {
-          "domain": "cardano-relay-1.upbit.com",
-          "port": 30800
-        },
-        {
-          "domain": "cardano-relay-2.upbit.com",
-          "port": 30800
-        },
-        {
-          "domain": "cardano-relay-3.upbit.com",
-          "port": 30800
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.774274340275823,
-      "relativeStake": 0.001133599518284653,
-      "relays": [
-        {
-          "address": "212.103.79.154",
-          "port": 6002
-        },
-        {
-          "address": "212.103.79.154",
-          "port": 6003
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.7754065515820195,
-      "relativeStake": 0.0011322113061966077,
+      "accumulatedStake": 0.7650066607575303,
+      "relativeStake": 0.0011560130385695152,
       "relays": [
         {
           "domain": "relay01.nekota.work",
@@ -5129,36 +5011,104 @@
       ]
     },
     {
-      "accumulatedStake": 0.7765264137257766,
-      "relativeStake": 0.001119862143757081,
+      "accumulatedStake": 0.7661522808323488,
+      "relativeStake": 0.0011456200748183806,
       "relays": [
         {
-          "domain": "relay1.kaizn.kaizencrypto.com",
-          "port": 6000
+          "address": "168.119.124.16",
+          "port": 3001
         },
         {
-          "domain": "relay2.kaizn.kaizencrypto.com",
-          "port": 6000
+          "address": "202.61.246.91",
+          "port": 3001
         }
       ]
     },
     {
-      "accumulatedStake": 0.7776455983811611,
-      "relativeStake": 0.001119184655384481,
+      "accumulatedStake": 0.7672823980120763,
+      "relativeStake": 0.0011301171797275635,
       "relays": [
         {
-          "domain": "white-denver-a41cf.cardano.bdnodes.net",
-          "port": 6000
+          "domain": "relaynode1.kaldano.work",
+          "port": 3001
         },
         {
-          "domain": "cinnabar-prague-71400.cardano.bdnodes.net",
-          "port": 6000
+          "domain": "relaynode2.kaldano.work",
+          "port": 3001
         }
       ]
     },
     {
-      "accumulatedStake": 0.7787625770686217,
-      "relativeStake": 0.0011169786874606106,
+      "accumulatedStake": 0.7684109361815015,
+      "relativeStake": 0.0011285381694251687,
+      "relays": [
+        {
+          "domain": "asia.jazzstakepool.net",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.7695392906472425,
+      "relativeStake": 0.001128354465740973,
+      "relays": [
+        {
+          "domain": "relay.hazelpool.com",
+          "port": 39213
+        },
+        {
+          "domain": "relay2.hazelpool.com",
+          "port": 39213
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.7706637566339416,
+      "relativeStake": 0.001124465986699182,
+      "relays": [
+        {
+          "address": "3.111.14.60",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.7717878388377091,
+      "relativeStake": 0.0011240822037674296,
+      "relays": [
+        {
+          "domain": "relay1.bluecheesestakehouse.com",
+          "port": 5001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.7729094176202967,
+      "relativeStake": 0.0011215787825876898,
+      "relays": [
+        {
+          "address": "212.103.79.154",
+          "port": 6002
+        },
+        {
+          "address": "212.103.79.154",
+          "port": 6003
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.7740294462367389,
+      "relativeStake": 0.0011200286164421216,
+      "relays": [
+        {
+          "domain": "europe-de.popsp.net",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.775144694381552,
+      "relativeStake": 0.001115248144813135,
       "relays": [
         {
           "domain": "relay1.nedscave.io",
@@ -5179,8 +5129,22 @@
       ]
     },
     {
-      "accumulatedStake": 0.7798784728391298,
-      "relativeStake": 0.0011158957705080822,
+      "accumulatedStake": 0.7762569305397311,
+      "relativeStake": 0.0011122361581791117,
+      "relays": [
+        {
+          "address": "89.58.11.57",
+          "port": 6000
+        },
+        {
+          "address": "185.207.104.130",
+          "port": 6000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.7773678577780851,
+      "relativeStake": 0.001110927238354013,
       "relays": [
         {
           "address": "54.150.77.128",
@@ -5193,22 +5157,28 @@
       ]
     },
     {
-      "accumulatedStake": 0.7809908353013432,
-      "relativeStake": 0.0011123624622133466,
+      "accumulatedStake": 0.7784781923507653,
+      "relativeStake": 0.0011103345726802228,
       "relays": [
         {
-          "domain": "relay.hazelpool.com",
-          "port": 39213
-        },
-        {
-          "domain": "relay2.hazelpool.com",
-          "port": 39213
+          "address": "67.205.138.106",
+          "port": 3001
         }
       ]
     },
     {
-      "accumulatedStake": 0.7821028415768098,
-      "relativeStake": 0.0011120062754666038,
+      "accumulatedStake": 0.7795855095978899,
+      "relativeStake": 0.0011073172471244852,
+      "relays": [
+        {
+          "address": "20.69.213.207",
+          "port": 3000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.7806863783743555,
+      "relativeStake": 0.0011008687764656765,
       "relays": [
         {
           "domain": "relay1.lidonation.com",
@@ -5221,8 +5191,74 @@
       ]
     },
     {
-      "accumulatedStake": 0.7832130579044291,
-      "relativeStake": 0.0011102163276193698,
+      "accumulatedStake": 0.7817868220508851,
+      "relativeStake": 0.0011004436765296441,
+      "relays": [
+        {
+          "address": "20.91.236.57",
+          "port": 6000
+        },
+        {
+          "address": "160.251.204.162",
+          "port": 6000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.782882098061651,
+      "relativeStake": 0.0010952760107658499,
+      "relays": [
+        {
+          "address": "217.160.14.223",
+          "port": 6000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.7839703580964239,
+      "relativeStake": 0.0010882600347728781,
+      "relays": [
+        {
+          "domain": "relay1.kaizn.kaizencrypto.com",
+          "port": 6000
+        },
+        {
+          "domain": "relay2.kaizn.kaizencrypto.com",
+          "port": 6000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.785056138929506,
+      "relativeStake": 0.0010857808330820683,
+      "relays": [
+        {
+          "domain": "relay1.apexpool.info",
+          "port": 5001
+        },
+        {
+          "domain": "relay2.apexpool.info",
+          "port": 5001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.7861417238792566,
+      "relativeStake": 0.0010855849497506866,
+      "relays": [
+        {
+          "address": "57.129.24.185",
+          "port": 3001
+        },
+        {
+          "address": "57.129.28.178",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.7872262653035829,
+      "relativeStake": 0.0010845414243261832,
       "relays": [
         {
           "domain": "asia.jazzstakepool.net",
@@ -5231,8 +5267,46 @@
       ]
     },
     {
-      "accumulatedStake": 0.7843182727433469,
-      "relativeStake": 0.0011052148389176985,
+      "accumulatedStake": 0.7883073851764161,
+      "relativeStake": 0.0010811198728332362,
+      "relays": [
+        {
+          "domain": "europe3-zzz5relay.zzzpool.net",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.7893814577415799,
+      "relativeStake": 0.0010740725651638423,
+      "relays": [
+        {
+          "domain": "relay.azureada.com",
+          "port": 3001
+        },
+        {
+          "domain": "relay.azureada.com",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.7904519906005836,
+      "relativeStake": 0.0010705328590036446,
+      "relays": [
+        {
+          "address": "133.167.33.31",
+          "port": 6000
+        },
+        {
+          "address": "162.43.71.205",
+          "port": 6000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.7915220579430544,
+      "relativeStake": 0.0010700673424708627,
       "relays": [
         {
           "address": "135.181.194.233",
@@ -5249,590 +5323,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.7854234203524388,
-      "relativeStake": 0.0011051476090920371,
-      "relays": [
-        {
-          "domain": "relay.azureada.com",
-          "port": 3001
-        },
-        {
-          "domain": "relay.azureada.com",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.786525106653654,
-      "relativeStake": 0.0011016863012151855,
-      "relays": [
-        {
-          "domain": "europe3-zzz5relay.zzzpool.net",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.7876227719104993,
-      "relativeStake": 0.001097665256845316,
-      "relays": [
-        {
-          "address": "57.129.24.185",
-          "port": 3001
-        },
-        {
-          "address": "57.129.28.178",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.7887037280292739,
-      "relativeStake": 0.0010809561187745905,
-      "relays": [
-        {
-          "domain": "asia.jazzstakepool.net",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.789781968397751,
-      "relativeStake": 0.0010782403684771163,
-      "relays": [
-        {
-          "domain": "relay1.apexpool.info",
-          "port": 5001
-        },
-        {
-          "domain": "relay2.apexpool.info",
-          "port": 5001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.7908581324666515,
-      "relativeStake": 0.0010761640689004245,
-      "relays": [
-        {
-          "address": "152.53.121.193",
-          "port": 6000
-        },
-        {
-          "address": "84.247.163.186",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.7919314050198298,
-      "relativeStake": 0.001073272553178362,
-      "relays": [
-        {
-          "domain": "relays.koralabs.io",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.7929956646033246,
-      "relativeStake": 0.0010642595834947147,
-      "relays": [
-        {
-          "address": "52.167.20.127",
-          "port": 4000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.7940575435799568,
-      "relativeStake": 0.001061878976632329,
-      "relays": [
-        {
-          "domain": "r1.1percentpool.eu",
-          "port": 19001
-        },
-        {
-          "domain": "r2.1percentpool.eu",
-          "port": 19002
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.7951145071800149,
-      "relativeStake": 0.0010569636000580206,
-      "relays": [
-        {
-          "domain": "relay.azureada.com",
-          "port": 3001
-        },
-        {
-          "domain": "relay.azureada.com",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.7961608697713013,
-      "relativeStake": 0.001046362591286383,
-      "relays": [
-        {
-          "address": "35.154.123.251",
-          "port": 3001
-        },
-        {
-          "address": "15.206.230.107",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.7971976931951346,
-      "relativeStake": 0.0010368234238333008,
-      "relays": [
-        {
-          "domain": "relay-0-eu.junostakepool.com",
-          "port": 4321
-        },
-        {
-          "domain": "relay-1-eu.junostakepool.com",
-          "port": 4321
-        },
-        {
-          "domain": "relay-1-nuc.junostakepool.com",
-          "port": 17421
-        },
-        {
-          "domain": "relay-2-nuc.junostakepool.com",
-          "port": 17431
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.7982315130848405,
-      "relativeStake": 0.001033819889705887,
-      "relays": [
-        {
-          "domain": "relay0.bluecheesestakehouse.com",
-          "port": 5000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.7992540413007043,
-      "relativeStake": 0.0010225282158637865,
-      "relays": [
-        {
-          "domain": "relays.zw3rkpool.com",
-          "port": 3000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8002749534455506,
-      "relativeStake": 0.001020912144846242,
-      "relays": [
-        {
-          "address": "67.205.138.106",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8012896260651983,
-      "relativeStake": 0.0010146726196478145,
-      "relays": [
-        {
-          "domain": "relay01.lacepool.com",
-          "port": 3000
-        },
-        {
-          "domain": "relay02.lacepool.com",
-          "port": 3000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8023038464138857,
-      "relativeStake": 0.0010142203486874274,
-      "relays": [
-        {
-          "domain": "relay1.squidpool.com",
-          "port": 3001
-        },
-        {
-          "domain": "relay2.squidpool.com",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8033096659177916,
-      "relativeStake": 0.0010058195039059242,
-      "relays": [
-        {
-          "domain": "guru-relays.cloudpro.cl",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8043150927673102,
-      "relativeStake": 0.0010054268495185334,
-      "relays": [
-        {
-          "domain": "relay.gmbl.mainnet.cardano.gimbalabs.io",
-          "port": 30042
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8053201292523537,
-      "relativeStake": 0.0010050364850435352,
-      "relays": [
-        {
-          "domain": "relays.banderini.net",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8063250354897395,
-      "relativeStake": 0.0010049062373858335,
-      "relays": [
-        {
-          "address": "45.77.67.30",
-          "port": 3000
-        },
-        {
-          "address": "45.32.153.230",
-          "port": 3000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8073298514489997,
-      "relativeStake": 0.0010048159592600987,
-      "relays": [
-        {
-          "domain": "relays.xray.app",
-          "port": 3000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8083303992024693,
-      "relativeStake": 0.0010005477534696752,
-      "relays": [
-        {
-          "address": "89.58.11.57",
-          "port": 6000
-        },
-        {
-          "address": "185.207.104.130",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8093269446579183,
-      "relativeStake": 0.0009965454554489593,
-      "relays": [
-        {
-          "domain": "relay1.adaverse.com",
-          "port": 5000
-        },
-        {
-          "domain": "relay2.adaverse.com",
-          "port": 4000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8103172891775072,
-      "relativeStake": 0.0009903445195889125,
-      "relays": [
-        {
-          "domain": "eu.relays.cardanians.io",
-          "port": 1000
-        },
-        {
-          "domain": "ca.relays.cardanians.io",
-          "port": 1000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8113058469656181,
-      "relativeStake": 0.0009885577881108814,
-      "relays": [
-        {
-          "domain": "relay1.toiro.love",
-          "port": 6000
-        },
-        {
-          "domain": "relay2.toiro.love",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8122926303411246,
-      "relativeStake": 0.0009867833755065642,
-      "relays": [
-        {
-          "domain": "ipclub29-1.relay.my-ip.at",
-          "port": 3001
-        },
-        {
-          "domain": "ipclub29-1.relay.my-ip.at",
-          "port": 3002
-        },
-        {
-          "domain": "ipclub29-2.relay.my-ip.at",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8132789161465196,
-      "relativeStake": 0.000986285805394933,
-      "relays": [
-        {
-          "domain": "relay1.314pool.com",
-          "port": 31415
-        },
-        {
-          "domain": "relay2.314pool.com",
-          "port": 31415
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8142636486445552,
-      "relativeStake": 0.0009847324980356762,
-      "relays": [
-        {
-          "domain": "north-america.katanapool.net",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8152459460268373,
-      "relativeStake": 0.0009822973822820082,
-      "relays": [
-        {
-          "domain": "relay.plushpool.com",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8162206803403789,
-      "relativeStake": 0.0009747343135415515,
-      "relays": [
-        {
-          "address": "168.119.124.16",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8171949968567722,
-      "relativeStake": 0.0009743165163933386,
-      "relays": [
-        {
-          "address": "143.198.100.84",
-          "port": 6000
-        },
-        {
-          "address": "159.65.156.43",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8181688287665867,
-      "relativeStake": 0.0009738319098145657,
-      "relays": [
-        {
-          "address": "3.6.124.226",
-          "port": 3001
-        },
-        {
-          "address": "18.193.92.87",
-          "port": 3001
-        },
-        {
-          "address": "54.219.241.10",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8191360863015278,
-      "relativeStake": 0.0009672575349410113,
-      "relays": [
-        {
-          "address": "20.61.229.103",
-          "port": 3001
-        },
-        {
-          "address": "20.61.228.218",
-          "port": 3001
-        },
-        {
-          "address": "108.142.42.221",
-          "port": 3001
-        },
-        {
-          "address": "108.142.42.161",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8201013304605065,
-      "relativeStake": 0.0009652441589786834,
-      "relays": [
-        {
-          "domain": "cardano-relay.atomicwallet.io",
-          "port": 6001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8210631671522731,
-      "relativeStake": 0.000961836691766648,
-      "relays": [
-        {
-          "domain": "relay1.viperstaking.com",
-          "port": 4444
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8220168244226727,
-      "relativeStake": 0.0009536572703995876,
-      "relays": [
-        {
-          "domain": "cpr1.sargatxet.cloud",
-          "port": 6001
-        },
-        {
-          "domain": "cpr2.sargatxet.cloud",
-          "port": 6001
-        },
-        {
-          "domain": "cpr3.sargatxet.cloud",
-          "port": 6001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8229684262733515,
-      "relativeStake": 0.0009516018506789229,
-      "relays": [
-        {
-          "domain": "cardano-relays-1.nu.fi",
-          "port": 3003
-        },
-        {
-          "domain": "cardano-relays-2.nu.fi",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8239193914551913,
-      "relativeStake": 0.0009509651818397331,
-      "relays": [
-        {
-          "domain": "relay1-uk.wada.org",
-          "port": 3001
-        },
-        {
-          "address": "107.155.122.169",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8248654303612222,
-      "relativeStake": 0.0009460389060308679,
-      "relays": [
-        {
-          "address": "54.228.75.154",
-          "port": 3003
-        },
-        {
-          "address": "54.228.75.154",
-          "port": 3001
-        },
-        {
-          "address": "34.249.11.89",
-          "port": 3003
-        },
-        {
-          "address": "34.249.11.89",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8258088381291836,
-      "relativeStake": 0.0009434077679613981,
-      "relays": [
-        {
-          "domain": "relay-ca.ada.psiloblox.io",
-          "port": 3002
-        },
-        {
-          "address": "2600:ac02:7c06:0:20c:29ff:fe01:4ff9",
-          "port": 3002
-        },
-        {
-          "address": "208.118.69.126",
-          "port": 3003
-        },
-        {
-          "domain": "relay-jp.ada.psiloblox.io",
-          "port": 3001
-        },
-        {
-          "domain": "relay-de.ada.psiloblox.io",
-          "port": 3002
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8267455139390458,
-      "relativeStake": 0.0009366758098621865,
-      "relays": [
-        {
-          "domain": "relay1.ppcx1.mainnet.cardano.p2p.org",
-          "port": 6001
-        },
-        {
-          "domain": "relay2.ppcx1.mainnet.cardano.p2p.org",
-          "port": 6001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8276800151304211,
-      "relativeStake": 0.000934501191375336,
-      "relays": [
-        {
-          "domain": "relays.xray.app",
-          "port": 3000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8286144596966225,
-      "relativeStake": 0.0009344445662013679,
+      "accumulatedStake": 0.7925897051755494,
+      "relativeStake": 0.001067647232494948,
       "relays": [
         {
           "address": "180.150.102.25",
@@ -5861,8 +5353,344 @@
       ]
     },
     {
-      "accumulatedStake": 0.8295462525631675,
-      "relativeStake": 0.0009317928665449754,
+      "accumulatedStake": 0.7936526943180372,
+      "relativeStake": 0.0010629891424878397,
+      "relays": [
+        {
+          "address": "152.53.121.193",
+          "port": 6000
+        },
+        {
+          "address": "84.247.163.186",
+          "port": 6000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.7947150504248142,
+      "relativeStake": 0.0010623561067769334,
+      "relays": [
+        {
+          "domain": "relays.koralabs.io",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.7957761531529303,
+      "relativeStake": 0.0010611027281161474,
+      "relays": [
+        {
+          "domain": "relay.gmbl.mainnet.cardano.gimbalabs.io",
+          "port": 30042
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.7968371835887039,
+      "relativeStake": 0.0010610304357737102,
+      "relays": [
+        {
+          "address": "52.167.20.127",
+          "port": 4000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.7978906498966206,
+      "relativeStake": 0.001053466307916665,
+      "relays": [
+        {
+          "domain": "relay1.nedscave.io",
+          "port": 3001
+        },
+        {
+          "domain": "relay2.nedscave.io",
+          "port": 3001
+        },
+        {
+          "domain": "relay3.nedscave.io",
+          "port": 3001
+        },
+        {
+          "domain": "relay4.nedscave.io",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.7989406773966171,
+      "relativeStake": 0.0010500274999964382,
+      "relays": [
+        {
+          "domain": "relay.azureada.com",
+          "port": 3001
+        },
+        {
+          "domain": "relay.azureada.com",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.799987987673558,
+      "relativeStake": 0.001047310276940941,
+      "relays": [
+        {
+          "address": "52.167.20.127",
+          "port": 4000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8010352369861522,
+      "relativeStake": 0.0010472493125942217,
+      "relays": [
+        {
+          "domain": "asia.jazzstakepool.net",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8020697412790635,
+      "relativeStake": 0.001034504292911246,
+      "relays": [
+        {
+          "domain": "relay0.bluecheesestakehouse.com",
+          "port": 5000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8031038688919142,
+      "relativeStake": 0.0010341276128506796,
+      "relays": [
+        {
+          "domain": "white-denver-a41cf.cardano.bdnodes.net",
+          "port": 6000
+        },
+        {
+          "domain": "cinnabar-prague-71400.cardano.bdnodes.net",
+          "port": 6000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8041361262100838,
+      "relativeStake": 0.0010322573181695872,
+      "relays": [
+        {
+          "address": "35.154.123.251",
+          "port": 3001
+        },
+        {
+          "address": "15.206.230.107",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8051556170817471,
+      "relativeStake": 0.0010194908716633531,
+      "relays": [
+        {
+          "domain": "relay-0-eu.junostakepool.com",
+          "port": 4321
+        },
+        {
+          "domain": "relay-1-eu.junostakepool.com",
+          "port": 4321
+        },
+        {
+          "domain": "relay-1-nuc.junostakepool.com",
+          "port": 17421
+        },
+        {
+          "domain": "relay-2-nuc.junostakepool.com",
+          "port": 17431
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8061651624284498,
+      "relativeStake": 0.0010095453467027676,
+      "relays": [
+        {
+          "domain": "relays.zw3rkpool.com",
+          "port": 3000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8071713562598465,
+      "relativeStake": 0.0010061938313966428,
+      "relays": [
+        {
+          "domain": "relay01.lacepool.com",
+          "port": 3000
+        },
+        {
+          "domain": "relay02.lacepool.com",
+          "port": 3000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.808161401121213,
+      "relativeStake": 0.000990044861366492,
+      "relays": [
+        {
+          "domain": "guru-relays.cloudpro.cl",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8091481870950791,
+      "relativeStake": 0.0009867859738660733,
+      "relays": [
+        {
+          "domain": "relay1.squidpool.com",
+          "port": 3001
+        },
+        {
+          "domain": "relay2.squidpool.com",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8101302624093297,
+      "relativeStake": 0.0009820753142505976,
+      "relays": [
+        {
+          "domain": "relays.banderini.net",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8111089761090137,
+      "relativeStake": 0.000978713699683994,
+      "relays": [
+        {
+          "domain": "relay1.toiro.love",
+          "port": 6000
+        },
+        {
+          "domain": "relay2.toiro.love",
+          "port": 6000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8120876522989577,
+      "relativeStake": 0.000978676189944095,
+      "relays": [
+        {
+          "domain": "ipclub29-1.relay.my-ip.at",
+          "port": 3001
+        },
+        {
+          "domain": "ipclub29-1.relay.my-ip.at",
+          "port": 3002
+        },
+        {
+          "domain": "ipclub29-2.relay.my-ip.at",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8130646523805181,
+      "relativeStake": 0.0009770000815602607,
+      "relays": [
+        {
+          "domain": "eu.relays.cardanians.io",
+          "port": 1000
+        },
+        {
+          "domain": "ca.relays.cardanians.io",
+          "port": 1000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8140387458136465,
+      "relativeStake": 0.0009740934331285182,
+      "relays": [
+        {
+          "address": "45.77.67.30",
+          "port": 3000
+        },
+        {
+          "address": "45.32.153.230",
+          "port": 3000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8150124774609678,
+      "relativeStake": 0.0009737316473213128,
+      "relays": [
+        {
+          "domain": "north-america.katanapool.net",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8159846525009733,
+      "relativeStake": 0.0009721750400054142,
+      "relays": [
+        {
+          "domain": "relays.xray.app",
+          "port": 3000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8169559164206752,
+      "relativeStake": 0.0009712639197019022,
+      "relays": [
+        {
+          "domain": "relay1.viperstaking.com",
+          "port": 4444
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.817926953573666,
+      "relativeStake": 0.0009710371529908116,
+      "relays": [
+        {
+          "domain": "relay1.314pool.com",
+          "port": 31415
+        },
+        {
+          "domain": "relay2.314pool.com",
+          "port": 31415
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8188877227954683,
+      "relativeStake": 0.0009607692218023138,
+      "relays": [
+        {
+          "address": "143.198.100.84",
+          "port": 6000
+        },
+        {
+          "address": "159.65.156.43",
+          "port": 6000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8198413873680039,
+      "relativeStake": 0.0009536645725356107,
       "relays": [
         {
           "address": "168.119.124.16",
@@ -5871,8 +5699,118 @@
       ]
     },
     {
-      "accumulatedStake": 0.8304779810626741,
-      "relativeStake": 0.0009317284995066595,
+      "accumulatedStake": 0.8207927368497987,
+      "relativeStake": 0.0009513494817947773,
+      "relays": [
+        {
+          "address": "3.6.124.226",
+          "port": 3001
+        },
+        {
+          "address": "18.193.92.87",
+          "port": 3001
+        },
+        {
+          "address": "54.219.241.10",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8217425374171841,
+      "relativeStake": 0.0009498005673853995,
+      "relays": [
+        {
+          "domain": "adaboy-mainnet-2a.gleeze.com",
+          "port": 6000
+        },
+        {
+          "domain": "adaboy-mainnet-3a.gleeze.com",
+          "port": 6000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8226896527489356,
+      "relativeStake": 0.0009471153317514325,
+      "relays": [
+        {
+          "domain": "relay-ca.ada.psiloblox.io",
+          "port": 3002
+        },
+        {
+          "address": "2600:ac02:7c06:0:20c:29ff:fe01:4ff9",
+          "port": 3002
+        },
+        {
+          "address": "208.118.69.126",
+          "port": 3003
+        },
+        {
+          "domain": "relay-jp.ada.psiloblox.io",
+          "port": 3001
+        },
+        {
+          "domain": "relay-de.ada.psiloblox.io",
+          "port": 3002
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.823626804257851,
+      "relativeStake": 0.0009371515089153976,
+      "relays": [
+        {
+          "domain": "cardano-relay.atomicwallet.io",
+          "port": 6001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8245636628966888,
+      "relativeStake": 0.0009368586388378467,
+      "relays": [
+        {
+          "domain": "relay1-uk.wada.org",
+          "port": 3001
+        },
+        {
+          "address": "107.155.122.169",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8254991834135593,
+      "relativeStake": 0.0009355205168705882,
+      "relays": [
+        {
+          "domain": "cpr1.sargatxet.cloud",
+          "port": 6001
+        },
+        {
+          "domain": "cpr2.sargatxet.cloud",
+          "port": 6001
+        },
+        {
+          "domain": "cpr3.sargatxet.cloud",
+          "port": 6001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8264346526709417,
+      "relativeStake": 0.000935469257382418,
+      "relays": [
+        {
+          "domain": "relay.plushpool.com",
+          "port": 6000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.827363556562126,
+      "relativeStake": 0.0009289038911841848,
       "relays": [
         {
           "domain": "relays.wavepool.digital",
@@ -5881,8 +5819,118 @@
       ]
     },
     {
-      "accumulatedStake": 0.831398442554607,
-      "relativeStake": 0.0009204614919328815,
+      "accumulatedStake": 0.8282901076889464,
+      "relativeStake": 0.0009265511268204644,
+      "relays": [
+        {
+          "domain": "relays.xray.app",
+          "port": 3000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.829216523384419,
+      "relativeStake": 0.000926415695472565,
+      "relays": [
+        {
+          "domain": "cardano-relays-1.nu.fi",
+          "port": 3003
+        },
+        {
+          "domain": "cardano-relays-2.nu.fi",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8301369565219622,
+      "relativeStake": 0.0009204331375431908,
+      "relays": [
+        {
+          "domain": "cardano-relays.atomicwallet.io",
+          "port": 6001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8310478556739631,
+      "relativeStake": 0.0009108991520009186,
+      "relays": [
+        {
+          "domain": "relay-dfm.cryptoblocks.pro",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8319585126516879,
+      "relativeStake": 0.0009106569777247872,
+      "relays": [
+        {
+          "address": "168.119.124.16",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8328685396878455,
+      "relativeStake": 0.0009100270361576166,
+      "relays": [
+        {
+          "domain": "43.cardano.staked.cloud",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8337726428429953,
+      "relativeStake": 0.0009041031551497978,
+      "relays": [
+        {
+          "domain": "relays.wavepool.digital",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8346707503906857,
+      "relativeStake": 0.0008981075476904026,
+      "relays": [
+        {
+          "address": "154.38.174.71",
+          "port": 6000
+        },
+        {
+          "address": "89.117.19.225",
+          "port": 6000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8355606493137094,
+      "relativeStake": 0.000889898923023686,
+      "relays": [
+        {
+          "address": "157.245.228.134",
+          "port": 3001
+        },
+        {
+          "address": "159.89.120.164",
+          "port": 3001
+        },
+        {
+          "address": "209.97.186.44",
+          "port": 3001
+        },
+        {
+          "domain": "na.bloompool.io",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8364410528165156,
+      "relativeStake": 0.0008804035028062014,
       "relays": [
         {
           "address": "64.176.49.224",
@@ -5895,8 +5943,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.8323176972235427,
-      "relativeStake": 0.0009192546689356375,
+      "accumulatedStake": 0.8373195853664579,
+      "relativeStake": 0.0008785325499423102,
       "relays": [
         {
           "domain": "germany.cardanode.io",
@@ -5917,18 +5965,68 @@
       ]
     },
     {
-      "accumulatedStake": 0.8332339617566349,
-      "relativeStake": 0.000916264533092265,
+      "accumulatedStake": 0.838197754124031,
+      "relativeStake": 0.0008781687575730423,
       "relays": [
         {
-          "domain": "cardano-relays.atomicwallet.io",
+          "domain": "relay1.ppcx1.mainnet.cardano.p2p.org",
+          "port": 6001
+        },
+        {
+          "domain": "relay2.ppcx1.mainnet.cardano.p2p.org",
           "port": 6001
         }
       ]
     },
     {
-      "accumulatedStake": 0.8341450296488887,
-      "relativeStake": 0.0009110678922537702,
+      "accumulatedStake": 0.8390756263099275,
+      "relativeStake": 0.0008778721858965144,
+      "relays": [
+        {
+          "address": "54.168.30.53",
+          "port": 7328
+        },
+        {
+          "address": "192.145.47.68",
+          "port": 6000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8399534838216215,
+      "relativeStake": 0.0008778575116940789,
+      "relays": [
+        {
+          "address": "75.119.157.236",
+          "port": 6000
+        },
+        {
+          "address": "149.102.144.126",
+          "port": 6000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8408301218222668,
+      "relativeStake": 0.0008766380006452589,
+      "relays": [
+        {
+          "address": "135.181.194.233",
+          "port": 6000
+        },
+        {
+          "address": "168.119.101.200",
+          "port": 6000
+        },
+        {
+          "address": "5.161.59.12",
+          "port": 6000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8417053174430364,
+      "relativeStake": 0.0008751956207696211,
       "relays": [
         {
           "domain": "ACLrelay1.cardanoland.com",
@@ -5957,44 +6055,44 @@
       ]
     },
     {
-      "accumulatedStake": 0.8350560666724529,
-      "relativeStake": 0.0009110370235642103,
+      "accumulatedStake": 0.8425790447211964,
+      "relativeStake": 0.0008737272781599191,
       "relays": [
         {
-          "address": "154.38.174.71",
-          "port": 6000
+          "address": "194.233.70.42",
+          "port": 57997
         },
         {
-          "address": "89.117.19.225",
-          "port": 6000
+          "address": "194.233.71.183",
+          "port": 51180
         }
       ]
     },
     {
-      "accumulatedStake": 0.8359655591216094,
-      "relativeStake": 0.0009094924491565498,
+      "accumulatedStake": 0.8434514721862835,
+      "relativeStake": 0.0008724274650871846,
       "relays": [
         {
-          "address": "157.245.228.134",
+          "address": "54.228.75.154",
+          "port": 3003
+        },
+        {
+          "address": "54.228.75.154",
           "port": 3001
         },
         {
-          "address": "159.89.120.164",
-          "port": 3001
+          "address": "34.249.11.89",
+          "port": 3003
         },
         {
-          "address": "209.97.186.44",
-          "port": 3001
-        },
-        {
-          "domain": "na.bloompool.io",
+          "address": "34.249.11.89",
           "port": 3001
         }
       ]
     },
     {
-      "accumulatedStake": 0.8368600867433001,
-      "relativeStake": 0.0008945276216907165,
+      "accumulatedStake": 0.8443197112924986,
+      "relativeStake": 0.0008682391062151415,
       "relays": [
         {
           "address": "178.128.79.219",
@@ -6007,66 +6105,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.8377514007331331,
-      "relativeStake": 0.0008913139898329976,
-      "relays": [
-        {
-          "address": "75.119.157.236",
-          "port": 6000
-        },
-        {
-          "address": "149.102.144.126",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8386329428563503,
-      "relativeStake": 0.0008815421232171521,
-      "relays": [
-        {
-          "domain": "relays.wavepool.digital",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8395048114767758,
-      "relativeStake": 0.0008718686204255176,
-      "relays": [
-        {
-          "domain": "relays.cardaspians.io",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.840374617340904,
-      "relativeStake": 0.00086980586412818,
-      "relays": [
-        {
-          "domain": "cardano-relays-1.nu.fi",
-          "port": 3003
-        },
-        {
-          "domain": "cardano-relays-2.nu.fi",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8412390676336499,
-      "relativeStake": 0.0008644502927458771,
-      "relays": [
-        {
-          "address": "13.208.79.46",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8421030802773436,
-      "relativeStake": 0.000864012643693746,
+      "accumulatedStake": 0.8451754396586194,
+      "relativeStake": 0.0008557283661207646,
       "relays": [
         {
           "domain": "cardano-relays.autostake.com",
@@ -6075,8 +6115,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.8429661375481444,
-      "relativeStake": 0.0008630572708007978,
+      "accumulatedStake": 0.8460288703827212,
+      "relativeStake": 0.0008534307241017689,
       "relays": [
         {
           "address": "126.77.67.70",
@@ -6089,60 +6129,28 @@
       ]
     },
     {
-      "accumulatedStake": 0.8438219782392649,
-      "relativeStake": 0.0008558406911203863,
+      "accumulatedStake": 0.8468768833644039,
+      "relativeStake": 0.0008480129816827635,
       "relays": [
         {
-          "domain": "adar2.stakit.io",
-          "port": 30501
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8446726881908576,
-      "relativeStake": 0.000850709951592787,
-      "relays": [
-        {
-          "address": "3.125.129.213",
+          "address": "13.208.79.46",
           "port": 6000
         }
       ]
     },
     {
-      "accumulatedStake": 0.8455217221803178,
-      "relativeStake": 0.000849033989460203,
+      "accumulatedStake": 0.8477195510375668,
+      "relativeStake": 0.0008426676731628462,
       "relays": [
         {
-          "address": "85.215.147.174",
-          "port": 6000
-        },
-        {
-          "address": "85.215.187.104",
-          "port": 6000
+          "domain": "relays.cardaspians.io",
+          "port": 3001
         }
       ]
     },
     {
-      "accumulatedStake": 0.8463693203762443,
-      "relativeStake": 0.0008475981959265514,
-      "relays": [
-        {
-          "address": "135.181.194.233",
-          "port": 6000
-        },
-        {
-          "address": "168.119.101.200",
-          "port": 6000
-        },
-        {
-          "address": "5.161.59.12",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8472137911600944,
-      "relativeStake": 0.0008444707838500861,
+      "accumulatedStake": 0.8485504258228344,
+      "relativeStake": 0.000830874785267526,
       "relays": [
         {
           "address": "157.245.228.134",
@@ -6163,8 +6171,46 @@
       ]
     },
     {
-      "accumulatedStake": 0.8480576226698447,
-      "relativeStake": 0.0008438315097503316,
+      "accumulatedStake": 0.8493803417426304,
+      "relativeStake": 0.0008299159197961231,
+      "relays": [
+        {
+          "address": "143.110.217.207",
+          "port": 6000
+        },
+        {
+          "address": "167.99.88.198",
+          "port": 6000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8502068402090402,
+      "relativeStake": 0.0008264984664098019,
+      "relays": [
+        {
+          "domain": "adar2.stakit.io",
+          "port": 30501
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8510313190163612,
+      "relativeStake": 0.0008244788073209821,
+      "relays": [
+        {
+          "address": "85.215.147.174",
+          "port": 6000
+        },
+        {
+          "address": "85.215.187.104",
+          "port": 6000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8518553444058636,
+      "relativeStake": 0.0008240253895024095,
       "relays": [
         {
           "domain": "relay1.powerstakepool.com",
@@ -6177,8 +6223,18 @@
       ]
     },
     {
-      "accumulatedStake": 0.8488871219285604,
-      "relativeStake": 0.0008294992587157064,
+      "accumulatedStake": 0.8526708878858625,
+      "relativeStake": 0.00081554347999893,
+      "relays": [
+        {
+          "address": "3.125.129.213",
+          "port": 6000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8534841471685721,
+      "relativeStake": 0.0008132592827095906,
       "relays": [
         {
           "domain": "cardano-relays-1.nu.fi",
@@ -6191,18 +6247,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.8497128254454127,
-      "relativeStake": 0.0008257035168522032,
-      "relays": [
-        {
-          "domain": "relays.wavepool.digital",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8505354821269534,
-      "relativeStake": 0.0008226566815407227,
+      "accumulatedStake": 0.8542900309599096,
+      "relativeStake": 0.0008058837913374425,
       "relays": [
         {
           "domain": "europe1-relay.jpn-sp.net",
@@ -6211,22 +6257,26 @@
       ]
     },
     {
-      "accumulatedStake": 0.8513563120283454,
-      "relativeStake": 0.0008208299013919363,
+      "accumulatedStake": 0.8550827464398036,
+      "relativeStake": 0.0007927154798940823,
       "relays": [
         {
-          "domain": "adaboy-mainnet-2a.gleeze.com",
-          "port": 6000
+          "domain": "relay0.crimsonpool.com",
+          "port": 5100
         },
         {
-          "domain": "adaboy-mainnet-3a.gleeze.com",
-          "port": 6000
+          "domain": "relay1.crimsonpool.com",
+          "port": 5101
+        },
+        {
+          "domain": "relay2.crimsonpool.com",
+          "port": 5102
         }
       ]
     },
     {
-      "accumulatedStake": 0.8521719661260134,
-      "relativeStake": 0.0008156540976680863,
+      "accumulatedStake": 0.8558745445152843,
+      "relativeStake": 0.0007917980754806384,
       "relays": [
         {
           "domain": "LANDrelay1.cardanoland.com",
@@ -6255,208 +6305,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.8529868981358467,
-      "relativeStake": 0.0008149320098332732,
-      "relays": [
-        {
-          "domain": "relay1.thevikingpool.com",
-          "port": 6000
-        },
-        {
-          "domain": "relay2.thevikingpool.com",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8537987771793041,
-      "relativeStake": 0.0008118790434574147,
-      "relays": [
-        {
-          "domain": "a-r1.elitestakepool.com",
-          "port": 7011
-        },
-        {
-          "domain": "a-r2.elitestakepool.com",
-          "port": 7012
-        },
-        {
-          "domain": "b-r3.elitestakepool.com",
-          "port": 7013
-        },
-        {
-          "domain": "b-r4.elitestakepool.com",
-          "port": 7014
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8546024879695424,
-      "relativeStake": 0.0008037107902383115,
-      "relays": [
-        {
-          "domain": "relay0.crimsonpool.com",
-          "port": 5100
-        },
-        {
-          "domain": "relay1.crimsonpool.com",
-          "port": 5101
-        },
-        {
-          "domain": "relay2.crimsonpool.com",
-          "port": 5102
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8554055301384595,
-      "relativeStake": 0.0008030421689171822,
-      "relays": [
-        {
-          "domain": "relay1.astra-pool.com",
-          "port": 6000
-        },
-        {
-          "domain": "relay2.astra-pool.com",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8562062442913827,
-      "relativeStake": 0.0008007141529231231,
-      "relays": [
-        {
-          "domain": "relay.armadastakepool.com",
-          "port": 5100
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8570058045224738,
-      "relativeStake": 0.000799560231091046,
-      "relays": [
-        {
-          "domain": "rnode1.cardano-ada-staking-pool.com",
-          "port": 6000
-        },
-        {
-          "domain": "rnode2.cardano-ada-staking-pool.com",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8577987093953464,
-      "relativeStake": 0.0007929048728726548,
-      "relays": [
-        {
-          "domain": "relay1.cashflowpool.com",
-          "port": 3001
-        },
-        {
-          "domain": "relay2.cashflowpool.com",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8585785274595784,
-      "relativeStake": 0.0007798180642319423,
-      "relays": [
-        {
-          "domain": "51.195.18.14",
-          "port": 6000
-        },
-        {
-          "domain": "87.98.245.66",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8593460910101629,
-      "relativeStake": 0.0007675635505845452,
-      "relays": [
-        {
-          "address": "13.215.210.113",
-          "port": 6000
-        },
-        {
-          "address": "13.211.72.184",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8601113403502373,
-      "relativeStake": 0.0007652493400744282,
-      "relays": [
-        {
-          "address": "185.64.140.115",
-          "port": 6001
-        },
-        {
-          "address": "185.64.140.115",
-          "port": 6002
-        },
-        {
-          "address": "185.64.140.115",
-          "port": 6003
-        },
-        {
-          "address": "185.64.140.115",
-          "port": 6004
-        },
-        {
-          "address": "162.156.186.249",
-          "port": 6001
-        },
-        {
-          "address": "162.156.186.249",
-          "port": 6002
-        },
-        {
-          "address": "162.156.186.249",
-          "port": 6003
-        },
-        {
-          "address": "162.156.186.249",
-          "port": 6004
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8608707710101435,
-      "relativeStake": 0.0007594306599061685,
-      "relays": [
-        {
-          "address": "143.110.217.207",
-          "port": 6000
-        },
-        {
-          "address": "167.99.88.198",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8616254883457644,
-      "relativeStake": 0.0007547173356208588,
-      "relays": [
-        {
-          "address": "202.61.207.98",
-          "port": 6000
-        },
-        {
-          "address": "86.106.182.81",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8623761502537958,
-      "relativeStake": 0.0007506619080313889,
+      "accumulatedStake": 0.8566659161329326,
+      "relativeStake": 0.0007913716176483451,
       "relays": [
         {
           "address": "157.245.228.134",
@@ -6477,8 +6327,72 @@
       ]
     },
     {
-      "accumulatedStake": 0.8631180433419355,
-      "relativeStake": 0.0007418930881397463,
+      "accumulatedStake": 0.8574539702779064,
+      "relativeStake": 0.0007880541449737325,
+      "relays": [
+        {
+          "domain": "a-r1.elitestakepool.com",
+          "port": 7011
+        },
+        {
+          "domain": "a-r2.elitestakepool.com",
+          "port": 7012
+        },
+        {
+          "domain": "b-r3.elitestakepool.com",
+          "port": 7013
+        },
+        {
+          "domain": "b-r4.elitestakepool.com",
+          "port": 7014
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8582334818493189,
+      "relativeStake": 0.0007795115714125366,
+      "relays": [
+        {
+          "domain": "relay1.thevikingpool.com",
+          "port": 6000
+        },
+        {
+          "domain": "relay2.thevikingpool.com",
+          "port": 6000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.859010188062528,
+      "relativeStake": 0.0007767062132091535,
+      "relays": [
+        {
+          "domain": "relay1.cashflowpool.com",
+          "port": 3001
+        },
+        {
+          "domain": "relay2.cashflowpool.com",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8597845261802168,
+      "relativeStake": 0.0007743381176886807,
+      "relays": [
+        {
+          "domain": "relay1.astra-pool.com",
+          "port": 6000
+        },
+        {
+          "domain": "relay2.astra-pool.com",
+          "port": 6000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8605537455747452,
+      "relativeStake": 0.0007692193945284307,
       "relays": [
         {
           "address": "20.61.229.103",
@@ -6499,8 +6413,46 @@
       ]
     },
     {
-      "accumulatedStake": 0.8638593297425666,
-      "relativeStake": 0.0007412864006310899,
+      "accumulatedStake": 0.8613121747881659,
+      "relativeStake": 0.0007584292134207005,
+      "relays": [
+        {
+          "domain": "cardano-relays-1.nu.fi",
+          "port": 3003
+        },
+        {
+          "domain": "cardano-relays-2.nu.fi",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8620524742315958,
+      "relativeStake": 0.0007402994434299162,
+      "relays": [
+        {
+          "domain": "cardano-relays-1.nu.fi",
+          "port": 3003
+        },
+        {
+          "domain": "cardano-relays-2.nu.fi",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8627923532347561,
+      "relativeStake": 0.0007398790031602439,
+      "relays": [
+        {
+          "domain": "relay.armadastakepool.com",
+          "port": 5100
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8635184405934573,
+      "relativeStake": 0.0007260873587012633,
       "relays": [
         {
           "domain": "relay1.adaocean.com",
@@ -6525,22 +6477,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.8645903980385468,
-      "relativeStake": 0.0007310682959801873,
-      "relays": [
-        {
-          "domain": "cardano-relays-1.nu.fi",
-          "port": 3003
-        },
-        {
-          "domain": "cardano-relays-2.nu.fi",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8653171406828711,
-      "relativeStake": 0.000726742644324331,
+      "accumulatedStake": 0.8642434093864588,
+      "relativeStake": 0.0007249687930015001,
       "relays": [
         {
           "domain": "r1.1percentpool.eu",
@@ -6553,8 +6491,32 @@
       ]
     },
     {
-      "accumulatedStake": 0.866041821493569,
-      "relativeStake": 0.0007246808106978852,
+      "accumulatedStake": 0.8649626313059087,
+      "relativeStake": 0.0007192219194498781,
+      "relays": [
+        {
+          "domain": "r1.1percentpool.eu",
+          "port": 19001
+        },
+        {
+          "domain": "r2.1percentpool.eu",
+          "port": 19002
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8656768613536043,
+      "relativeStake": 0.000714230047695654,
+      "relays": [
+        {
+          "domain": "asia-pacific-japan.popsp.net",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8663905530456631,
+      "relativeStake": 0.0007136916920588315,
       "relays": [
         {
           "domain": "otg-relay-1.adamantium.online",
@@ -6567,82 +6529,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.866766348215762,
-      "relativeStake": 0.000724526722193026,
-      "relays": [
-        {
-          "domain": "asia-pacific-japan.popsp.net",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8674894525363228,
-      "relativeStake": 0.0007231043205608126,
-      "relays": [
-        {
-          "address": "194.163.168.97",
-          "port": 6001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8682104442914625,
-      "relativeStake": 0.0007209917551397,
-      "relays": [
-        {
-          "address": "223.25.73.249",
-          "port": 6452
-        },
-        {
-          "address": "128.199.147.30",
-          "port": 6001
-        },
-        {
-          "address": "158.140.141.199",
-          "port": 8082
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8689292763279554,
-      "relativeStake": 0.0007188320364928426,
-      "relays": [
-        {
-          "address": "104.236.24.187",
-          "port": 5281
-        },
-        {
-          "address": "50.185.24.9",
-          "port": 5282
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8696478784515829,
-      "relativeStake": 0.000718602123627448,
-      "relays": [
-        {
-          "address": "51.195.91.118",
-          "port": 3001
-        },
-        {
-          "address": "51.161.35.246",
-          "port": 3001
-        },
-        {
-          "address": "49.12.123.178",
-          "port": 3001
-        },
-        {
-          "address": "95.217.58.124",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8703613549775575,
-      "relativeStake": 0.0007134765259747245,
+      "accumulatedStake": 0.8670953704894139,
+      "relativeStake": 0.000704817443750716,
       "relays": [
         {
           "domain": "cardano1.vampyre.fund",
@@ -6663,8 +6551,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.8710707410690638,
-      "relativeStake": 0.0007093860915062932,
+      "accumulatedStake": 0.8677945169843283,
+      "relativeStake": 0.0006991464949144251,
       "relays": [
         {
           "address": "78.47.119.91",
@@ -6673,26 +6561,54 @@
       ]
     },
     {
-      "accumulatedStake": 0.8717744489448729,
-      "relativeStake": 0.0007037078758090734,
+      "accumulatedStake": 0.8684918083337692,
+      "relativeStake": 0.0006972913494408191,
       "relays": [
         {
-          "address": "108.174.196.172",
+          "address": "13.215.210.113",
           "port": 6000
         },
         {
-          "address": "142.11.241.195",
-          "port": 6000
-        },
-        {
-          "address": "142.11.241.198",
+          "address": "13.211.72.184",
           "port": 6000
         }
       ]
     },
     {
-      "accumulatedStake": 0.8724754334201184,
-      "relativeStake": 0.0007009844752454024,
+      "accumulatedStake": 0.869187449842461,
+      "relativeStake": 0.0006956415086918615,
+      "relays": [
+        {
+          "address": "51.195.91.118",
+          "port": 3001
+        },
+        {
+          "address": "51.161.35.246",
+          "port": 3001
+        },
+        {
+          "address": "49.12.123.178",
+          "port": 3001
+        },
+        {
+          "address": "95.217.58.124",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8698804057415123,
+      "relativeStake": 0.0006929558990512391,
+      "relays": [
+        {
+          "domain": "relays.wavepool.digital",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.87057074194768,
+      "relativeStake": 0.0006903362061677495,
       "relays": [
         {
           "address": "20.61.229.103",
@@ -6713,8 +6629,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.8731703100577013,
-      "relativeStake": 0.0006948766375829767,
+      "accumulatedStake": 0.8712573287882726,
+      "relativeStake": 0.0006865868405925171,
       "relays": [
         {
           "domain": "relays.hypernerd.org",
@@ -6723,8 +6639,22 @@
       ]
     },
     {
-      "accumulatedStake": 0.8738626370166315,
-      "relativeStake": 0.0006923269589301447,
+      "accumulatedStake": 0.8719437934744556,
+      "relativeStake": 0.00068646468618307,
+      "relays": [
+        {
+          "domain": "re1.reservoir.network",
+          "port": 3001
+        },
+        {
+          "domain": "re2.reservoir.network",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8726274078707257,
+      "relativeStake": 0.0006836143962700765,
       "relays": [
         {
           "domain": "r1.1percentpool.eu",
@@ -6737,8 +6667,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.8745537626047309,
-      "relativeStake": 0.0006911255880994791,
+      "accumulatedStake": 0.8733107715750728,
+      "relativeStake": 0.0006833637043471012,
       "relays": [
         {
           "domain": "ram-relay1.irota.xyz",
@@ -6751,8 +6681,26 @@
       ]
     },
     {
-      "accumulatedStake": 0.8752387962857593,
-      "relativeStake": 0.0006850336810283667,
+      "accumulatedStake": 0.8739911712327748,
+      "relativeStake": 0.0006803996577019944,
+      "relays": [
+        {
+          "address": "223.25.73.249",
+          "port": 6452
+        },
+        {
+          "address": "128.199.147.30",
+          "port": 6001
+        },
+        {
+          "address": "158.140.141.199",
+          "port": 8082
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8746683358767957,
+      "relativeStake": 0.0006771646440209026,
       "relays": [
         {
           "domain": "ruby-cardano.rockx.com",
@@ -6761,54 +6709,46 @@
       ]
     },
     {
-      "accumulatedStake": 0.8759201202424343,
-      "relativeStake": 0.0006813239566749627,
+      "accumulatedStake": 0.8753332186262763,
+      "relativeStake": 0.0006648827494807062,
       "relays": [
         {
-          "domain": "r0.mn.sp.one-step-cardano.com",
-          "port": 6000
+          "address": "185.64.140.115",
+          "port": 6001
         },
         {
-          "domain": "r1.mn.sp.one-step-cardano.com",
-          "port": 6000
+          "address": "185.64.140.115",
+          "port": 6002
+        },
+        {
+          "address": "185.64.140.115",
+          "port": 6003
+        },
+        {
+          "address": "185.64.140.115",
+          "port": 6004
+        },
+        {
+          "address": "162.156.186.249",
+          "port": 6001
+        },
+        {
+          "address": "162.156.186.249",
+          "port": 6002
+        },
+        {
+          "address": "162.156.186.249",
+          "port": 6003
+        },
+        {
+          "address": "162.156.186.249",
+          "port": 6004
         }
       ]
     },
     {
-      "accumulatedStake": 0.8765973880425336,
-      "relativeStake": 0.0006772678000993743,
-      "relays": [
-        {
-          "domain": "mound.adastack.net",
-          "port": 3001
-        },
-        {
-          "domain": "pack.adastack.net",
-          "port": 3001
-        },
-        {
-          "domain": "heap.adastack.net",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8772724982839146,
-      "relativeStake": 0.000675110241380992,
-      "relays": [
-        {
-          "domain": "relay-de.masterstake.com",
-          "port": 6000
-        },
-        {
-          "domain": "relay-nl.masterstake.com",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.877941045000865,
-      "relativeStake": 0.0006685467169504299,
+      "accumulatedStake": 0.8759913485908082,
+      "relativeStake": 0.0006581299645318602,
       "relays": [
         {
           "address": "137.117.180.0",
@@ -6825,8 +6765,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.8786049665093709,
-      "relativeStake": 0.0006639215085058672,
+      "accumulatedStake": 0.8766449238071455,
+      "relativeStake": 0.0006535752163372619,
       "relays": [
         {
           "domain": "r1.isp-r1.wjg.jp",
@@ -6839,176 +6779,22 @@
       ]
     },
     {
-      "accumulatedStake": 0.8792636648655531,
-      "relativeStake": 0.0006586983561821168,
+      "accumulatedStake": 0.8772978598746446,
+      "relativeStake": 0.0006529360674990497,
       "relays": [
         {
-          "domain": "relays.onyxstakepool.com",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8799139889973798,
-      "relativeStake": 0.0006503241318268459,
-      "relays": [
-        {
-          "address": "34.192.61.190",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8805639251454743,
-      "relativeStake": 0.0006499361480944183,
-      "relays": [
-        {
-          "domain": "relays.xray.app",
-          "port": 3000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8812086753943413,
-      "relativeStake": 0.0006447502488670491,
-      "relays": [
-        {
-          "domain": "cardano-relays.atomicwallet.io",
-          "port": 6001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8818525381377232,
-      "relativeStake": 0.0006438627433818949,
-      "relays": [
-        {
-          "address": "54.150.197.196",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8824960641349716,
-      "relativeStake": 0.0006435259972483413,
-      "relays": [
-        {
-          "domain": "cardano-relays-1.nu.fi",
-          "port": 3003
+          "address": "104.236.24.187",
+          "port": 5281
         },
         {
-          "domain": "cardano-relays-2.nu.fi",
-          "port": 3001
+          "address": "50.185.24.9",
+          "port": 5282
         }
       ]
     },
     {
-      "accumulatedStake": 0.8831395382423536,
-      "relativeStake": 0.0006434741073819614,
-      "relays": [
-        {
-          "domain": "relays.ektrp.com",
-          "port": 5859
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8837765813149367,
-      "relativeStake": 0.0006370430725832378,
-      "relays": [
-        {
-          "domain": "15.237.92.158",
-          "port": 16661
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8844066481401032,
-      "relativeStake": 0.0006300668251664044,
-      "relays": [
-        {
-          "domain": "r1.relaypool.online",
-          "port": 3000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8850353985124445,
-      "relativeStake": 0.0006287503723413686,
-      "relays": [
-        {
-          "domain": "relay1.pudim.cat",
-          "port": 3002
-        },
-        {
-          "domain": "relay2.pudim.cat",
-          "port": 3002
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8856637716005575,
-      "relativeStake": 0.0006283730881129794,
-      "relays": [
-        {
-          "address": "161.97.168.58",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8862857136844255,
-      "relativeStake": 0.0006219420838680224,
-      "relays": [
-        {
-          "domain": "ipclub29-1.relay.my-ip.at",
-          "port": 3001
-        },
-        {
-          "domain": "ipclub29-1.relay.my-ip.at",
-          "port": 3002
-        },
-        {
-          "domain": "ipclub29-2.relay.my-ip.at",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8869023120378885,
-      "relativeStake": 0.0006165983534629844,
-      "relays": [
-        {
-          "domain": "relay1-ada.cex.io",
-          "port": 3001
-        },
-        {
-          "domain": "relay2-ada.cex.io",
-          "port": 3002
-        },
-        {
-          "domain": "relay3-ada.cex.io",
-          "port": 3003
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.887518319405435,
-      "relativeStake": 0.0006160073675465269,
-      "relays": [
-        {
-          "domain": "relay01.londonpool.co.uk",
-          "port": 3001
-        },
-        {
-          "domain": "relay02.londonpool.co.uk",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8881342858941621,
-      "relativeStake": 0.0006159664887270554,
+      "accumulatedStake": 0.8779460674905412,
+      "relativeStake": 0.0006482076158966129,
       "relays": [
         {
           "address": "135.181.194.233",
@@ -7025,188 +6811,114 @@
       ]
     },
     {
-      "accumulatedStake": 0.8887443429893314,
-      "relativeStake": 0.0006100570951692104,
+      "accumulatedStake": 0.8785923164016733,
+      "relativeStake": 0.0006462489111322217,
       "relays": [
         {
-          "domain": "r1.poolforlovelace.me",
-          "port": 6000
-        },
-        {
-          "domain": "r2.poolforlovelace.me",
-          "port": 6000
-        },
-        {
-          "domain": "r3.poolforlovelace.me",
-          "port": 7000
-        },
-        {
-          "domain": "r4.poolforlovelace.me",
-          "port": 8001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8893525034066132,
-      "relativeStake": 0.0006081604172818904,
-      "relays": [
-        {
-          "domain": "relay2.bluecheesestakehouse.com",
-          "port": 5002
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8899470546429966,
-      "relativeStake": 0.0005945512363833629,
-      "relays": [
-        {
-          "domain": "relays.wavepool.digital",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8905380707309163,
-      "relativeStake": 0.0005910160879196624,
-      "relays": [
-        {
-          "address": "202.61.225.111",
-          "port": 6000
-        },
-        {
-          "address": "46.38.241.110",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.891128649321292,
-      "relativeStake": 0.0005905785903757625,
-      "relays": [
-        {
-          "address": "116.80.93.53",
-          "port": 6000
-        },
-        {
-          "address": "5.104.85.79",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8917182490092799,
-      "relativeStake": 0.0005895996879878647,
-      "relays": [
-        {
-          "domain": "relays.wavepool.digital",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8923047589063743,
-      "relativeStake": 0.000586509897094391,
-      "relays": [
-        {
-          "address": "52.197.233.151",
-          "port": 6000
-        },
-        {
-          "address": "57.182.76.81",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8928900787606413,
-      "relativeStake": 0.0005853198542670094,
-      "relays": [
-        {
-          "domain": "europe2-zzz4relay.zzzpool.net",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8934718815802858,
-      "relativeStake": 0.0005818028196445018,
-      "relays": [
-        {
-          "address": "125.250.255.197",
-          "port": 8000
-        },
-        {
-          "address": "142.132.189.114",
-          "port": 6000
-        },
-        {
-          "address": "75.119.158.164",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.894052860121113,
-      "relativeStake": 0.0005809785408271666,
-      "relays": [
-        {
-          "domain": "relays.digi.pro",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8946334667895522,
-      "relativeStake": 0.0005806066684392916,
-      "relays": [
-        {
-          "domain": "r1.adaism.uk",
-          "port": 8081
-        },
-        {
-          "domain": "r2.adaism.uk",
-          "port": 8081
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8952127178099509,
-      "relativeStake": 0.000579251020398675,
-      "relays": [
-        {
-          "domain": "cardano-relays-1.nu.fi",
-          "port": 3003
-        },
-        {
-          "domain": "cardano-relays-2.nu.fi",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8957907906000667,
-      "relativeStake": 0.000578072790115849,
-      "relays": [
-        {
-          "address": "3.111.14.60",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8963520811627727,
-      "relativeStake": 0.0005612905627058996,
-      "relays": [
-        {
-          "address": "192.168.1.100",
+          "domain": "r1.relaypool.online",
           "port": 3000
         }
       ]
     },
     {
-      "accumulatedStake": 0.8969118749093761,
-      "relativeStake": 0.0005597937466034114,
+      "accumulatedStake": 0.8792383549603412,
+      "relativeStake": 0.0006460385586678034,
+      "relays": [
+        {
+          "address": "194.163.168.97",
+          "port": 6001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8798835389794393,
+      "relativeStake": 0.0006451840190981032,
+      "relays": [
+        {
+          "domain": "relays.onyxstakepool.com",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8805263472793343,
+      "relativeStake": 0.0006428082998949851,
+      "relays": [
+        {
+          "address": "34.192.61.190",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.881168488017354,
+      "relativeStake": 0.000642140738019716,
+      "relays": [
+        {
+          "domain": "51.195.18.14",
+          "port": 6000
+        },
+        {
+          "domain": "87.98.245.66",
+          "port": 6000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8818081327745767,
+      "relativeStake": 0.0006396447572227019,
+      "relays": [
+        {
+          "domain": "relay01.londonpool.co.uk",
+          "port": 3001
+        },
+        {
+          "domain": "relay02.londonpool.co.uk",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.882447392955379,
+      "relativeStake": 0.0006392601808022816,
+      "relays": [
+        {
+          "domain": "cardano-relays.atomicwallet.io",
+          "port": 6001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8830811711213601,
+      "relativeStake": 0.0006337781659810851,
+      "relays": [
+        {
+          "domain": "mound.adastack.net",
+          "port": 3001
+        },
+        {
+          "domain": "pack.adastack.net",
+          "port": 3001
+        },
+        {
+          "domain": "heap.adastack.net",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8837130109416911,
+      "relativeStake": 0.0006318398203310563,
+      "relays": [
+        {
+          "domain": "relays.ektrp.com",
+          "port": 5859
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8843438871245509,
+      "relativeStake": 0.00063087618285981,
       "relays": [
         {
           "domain": "cardano-relays-1.nu.fi",
@@ -7219,40 +6931,112 @@
       ]
     },
     {
-      "accumulatedStake": 0.8974697105974887,
-      "relativeStake": 0.000557835688112676,
+      "accumulatedStake": 0.8849734388304827,
+      "relativeStake": 0.0006295517059317741,
       "relays": [
         {
-          "address": "194.163.185.176",
-          "port": 6000
-        },
-        {
-          "address": "161.97.129.78",
+          "address": "173.212.249.217",
           "port": 6000
         }
       ]
     },
     {
-      "accumulatedStake": 0.8980248672119276,
-      "relativeStake": 0.0005551566144389454,
+      "accumulatedStake": 0.8855988919191993,
+      "relativeStake": 0.0006254530887165583,
       "relays": [
         {
-          "domain": "157.173.120.233",
-          "port": 3001
+          "domain": "relay1.adaverse.com",
+          "port": 5000
         },
         {
-          "domain": "157.173.120.233",
+          "domain": "relay2.adaverse.com",
+          "port": 4000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8862202791151437,
+      "relativeStake": 0.0006213871959444289,
+      "relays": [
+        {
+          "domain": "relay1.pudim.cat",
           "port": 3002
         },
         {
-          "domain": "144.126.157.40",
-          "port": 3001
+          "domain": "relay2.pudim.cat",
+          "port": 3002
         }
       ]
     },
     {
-      "accumulatedStake": 0.8985734671531671,
-      "relativeStake": 0.0005485999412394726,
+      "accumulatedStake": 0.8868400462733118,
+      "relativeStake": 0.0006197671581681228,
+      "relays": [
+        {
+          "domain": "15.237.92.158",
+          "port": 16661
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8874539445519589,
+      "relativeStake": 0.0006138982786470579,
+      "relays": [
+        {
+          "domain": "relays.xray.app",
+          "port": 3000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8880630396152076,
+      "relativeStake": 0.0006090950632487601,
+      "relays": [
+        {
+          "domain": "relay1-ada.cex.io",
+          "port": 3001
+        },
+        {
+          "domain": "relay2-ada.cex.io",
+          "port": 3002
+        },
+        {
+          "domain": "relay3-ada.cex.io",
+          "port": 3003
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8886710912683784,
+      "relativeStake": 0.0006080516531707335,
+      "relays": [
+        {
+          "address": "108.174.196.172",
+          "port": 6000
+        },
+        {
+          "address": "142.11.241.195",
+          "port": 6000
+        },
+        {
+          "address": "142.11.241.198",
+          "port": 6000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8892726329879111,
+      "relativeStake": 0.000601541719532842,
+      "relays": [
+        {
+          "address": "54.150.197.196",
+          "port": 6000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8898708188505672,
+      "relativeStake": 0.0005981858626559767,
       "relays": [
         {
           "domain": "rho.relay.easy1staking.com",
@@ -7273,36 +7057,56 @@
       ]
     },
     {
-      "accumulatedStake": 0.8991214124485862,
-      "relativeStake": 0.0005479452954190343,
+      "accumulatedStake": 0.8904635013575529,
+      "relativeStake": 0.0005926825069857039,
       "relays": [
         {
-          "address": "143.198.206.176",
+          "address": "202.61.225.111",
           "port": 6000
         },
         {
-          "address": "207.154.201.62",
+          "address": "46.38.241.110",
           "port": 6000
         }
       ]
     },
     {
-      "accumulatedStake": 0.8996646514529945,
-      "relativeStake": 0.0005432390044082222,
+      "accumulatedStake": 0.8910537076210486,
+      "relativeStake": 0.0005902062634957275,
       "relays": [
         {
-          "address": "80.24.134.251",
-          "port": 6000
-        },
-        {
-          "domain": "relay2.quixote.network",
-          "port": 6001
+          "domain": "relays.wavepool.digital",
+          "port": 3001
         }
       ]
     },
     {
-      "accumulatedStake": 0.9002061771846069,
-      "relativeStake": 0.0005415257316124711,
+      "accumulatedStake": 0.8916429815813713,
+      "relativeStake": 0.0005892739603227259,
+      "relays": [
+        {
+          "domain": "relay2.bluecheesestakehouse.com",
+          "port": 5002
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8922260993867104,
+      "relativeStake": 0.0005831178053390079,
+      "relays": [
+        {
+          "address": "34.175.101.127",
+          "port": 6000
+        },
+        {
+          "address": "34.175.85.49",
+          "port": 6000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8928089588014793,
+      "relativeStake": 0.0005828594147689456,
       "relays": [
         {
           "domain": "relaynode1.bravostakepool.nl",
@@ -7317,8 +7121,174 @@
           "port": 3001
         }
       ]
+    },
+    {
+      "accumulatedStake": 0.8933874926830169,
+      "relativeStake": 0.0005785338815375874,
+      "relays": [
+        {
+          "domain": "europe2-zzz4relay.zzzpool.net",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8939647537074464,
+      "relativeStake": 0.0005772610244295296,
+      "relays": [
+        {
+          "domain": "1.node.bedrockstaking.com",
+          "port": 6000
+        },
+        {
+          "domain": "2.node.bedrockstaking.com",
+          "port": 6001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8945393130411824,
+      "relativeStake": 0.0005745593337360335,
+      "relays": [
+        {
+          "address": "125.250.255.197",
+          "port": 8000
+        },
+        {
+          "address": "142.132.189.114",
+          "port": 6000
+        },
+        {
+          "address": "75.119.158.164",
+          "port": 6000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8951092165456382,
+      "relativeStake": 0.0005699035044557793,
+      "relays": [
+        {
+          "domain": "r1.adaism.uk",
+          "port": 8081
+        },
+        {
+          "domain": "r2.adaism.uk",
+          "port": 8081
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8956783541535878,
+      "relativeStake": 0.0005691376079495611,
+      "relays": [
+        {
+          "domain": "relays.wavepool.digital",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8962380248706179,
+      "relativeStake": 0.0005596707170301063,
+      "relays": [
+        {
+          "address": "3.111.14.60",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8967963879668749,
+      "relativeStake": 0.0005583630962570003,
+      "relays": [
+        {
+          "domain": "relays.digi.pro",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8973531267534952,
+      "relativeStake": 0.000556738786620309,
+      "relays": [
+        {
+          "address": "133.167.33.31",
+          "port": 6000
+        },
+        {
+          "address": "162.43.71.205",
+          "port": 6000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8979080641264462,
+      "relativeStake": 0.0005549373729510449,
+      "relays": [
+        {
+          "address": "192.168.1.100",
+          "port": 3000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8984622382232288,
+      "relativeStake": 0.0005541740967825542,
+      "relays": [
+        {
+          "domain": "cardano-relays-1.nu.fi",
+          "port": 3003
+        },
+        {
+          "domain": "cardano-relays-2.nu.fi",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8990070594866418,
+      "relativeStake": 0.0005448212634130604,
+      "relays": [
+        {
+          "domain": "cardano-relays-1.nu.fi",
+          "port": 3003
+        },
+        {
+          "domain": "cardano-relays-2.nu.fi",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.899550013882525,
+      "relativeStake": 0.00054295439588307,
+      "relays": [
+        {
+          "address": "116.80.93.53",
+          "port": 6000
+        },
+        {
+          "address": "5.104.85.79",
+          "port": 6000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.9000903790914464,
+      "relativeStake": 0.0005403652089215045,
+      "relays": [
+        {
+          "address": "202.61.207.98",
+          "port": 6000
+        },
+        {
+          "address": "86.106.182.81",
+          "port": 6000
+        }
+      ]
     }
   ],
-  "slotNo": 152078944,
+  "slotNo": 156187557,
   "version": 1
 }

--- a/cardano-lib/preprod-config.nix
+++ b/cardano-lib/preprod-config.nix
@@ -36,7 +36,7 @@ with builtins; {
   # file will need to be declared in the p2p topology file under key
   # `peerSnapshotFile`.  A `CheckpointsFile` and corresponding
   # `CheckpointsFileHash` is not required for preprod.
-  ConsensusMode = "PraosMode";
+  ConsensusMode = "GenesisMode";
 
   # Default parameter values for "GenesisMode"
   SyncTargetNumberOfActivePeers = 0;

--- a/cardano-lib/preprod-config.nix
+++ b/cardano-lib/preprod-config.nix
@@ -28,7 +28,7 @@ with builtins; {
   EnableP2P = true;
   PeerSharing = true;
   TargetNumberOfActivePeers = 20;
-  TargetNumberOfEstablishedPeers = 40;
+  TargetNumberOfEstablishedPeers = 30;
   TargetNumberOfKnownPeers = 150;
   TargetNumberOfRootPeers = 60;
 
@@ -41,7 +41,7 @@ with builtins; {
   # Default parameter values for "GenesisMode"
   SyncTargetNumberOfActivePeers = 0;
   SyncTargetNumberOfActiveBigLedgerPeers = 30;
-  SyncTargetNumberOfEstablishedBigLedgerPeers = 50;
+  SyncTargetNumberOfEstablishedBigLedgerPeers = 40;
   SyncTargetNumberOfKnownBigLedgerPeers = 100;
   MinBigLedgerPeersForTrustedState = 5;
 

--- a/cardano-lib/preprod/peer-snapshot.json
+++ b/cardano-lib/preprod/peer-snapshot.json
@@ -1,8 +1,8 @@
 {
   "bigLedgerPools": [
     {
-      "accumulatedStake": 0.1638884356806454,
-      "relativeStake": 0.1638884356806454,
+      "accumulatedStake": 0.1618880216945963,
+      "relativeStake": 0.1618880216945963,
       "relays": [
         {
           "domain": "relay.preprod.staging.wingriders.com",
@@ -15,8 +15,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.25667700544529265,
-      "relativeStake": 0.09278856976464725,
+      "accumulatedStake": 0.25184241361052795,
+      "relativeStake": 0.08995439191593166,
       "relays": [
         {
           "domain": "preprod-node.pool.milkomeda.com",
@@ -25,8 +25,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.34426593845276593,
-      "relativeStake": 0.0875889330074733,
+      "accumulatedStake": 0.338435303045104,
+      "relativeStake": 0.08659288943457606,
       "relays": [
         {
           "address": "132.226.203.38",
@@ -35,8 +35,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.4091801430104222,
-      "relativeStake": 0.06491420455765627,
+      "accumulatedStake": 0.404434034472554,
+      "relativeStake": 0.06599873142745002,
       "relays": [
         {
           "address": "144.24.168.10",
@@ -49,8 +49,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.4531356077762043,
-      "relativeStake": 0.043955464765782104,
+      "accumulatedStake": 0.4486267935029092,
+      "relativeStake": 0.04419275903035518,
       "relays": [
         {
           "domain": "node1.cardano.gratis",
@@ -67,8 +67,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.4910634977829315,
-      "relativeStake": 0.037927890006727215,
+      "accumulatedStake": 0.48851659057253166,
+      "relativeStake": 0.03988979706962247,
       "relays": [
         {
           "domain": "logicalmechanism.asuscomm.com",
@@ -81,8 +81,18 @@
       ]
     },
     {
-      "accumulatedStake": 0.5215033405302082,
-      "relativeStake": 0.030439842747276655,
+      "accumulatedStake": 0.52584177276626,
+      "relativeStake": 0.0373251821937283,
+      "relays": [
+        {
+          "address": "73.222.122.247",
+          "port": 13001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.5556160144274127,
+      "relativeStake": 0.02977424166115275,
       "relays": [
         {
           "domain": "relay-kiln-0-0.cardano.testnet.kiln.fi",
@@ -91,8 +101,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.5500999839165874,
-      "relativeStake": 0.02859664338637923,
+      "accumulatedStake": 0.5844568738352693,
+      "relativeStake": 0.028840859407856613,
       "relays": [
         {
           "address": "140.238.91.50",
@@ -105,18 +115,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.5778688378317423,
-      "relativeStake": 0.027768853915154868,
-      "relays": [
-        {
-          "address": "73.222.122.247",
-          "port": 13001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.6047271292639204,
-      "relativeStake": 0.026858291432178067,
+      "accumulatedStake": 0.6112514134483173,
+      "relativeStake": 0.02679453961304801,
       "relays": [
         {
           "domain": "tn-preprod.psilobyte.io",
@@ -125,8 +125,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.6258384474729043,
-      "relativeStake": 0.021111318208983945,
+      "accumulatedStake": 0.6318318319582055,
+      "relativeStake": 0.020580418509888086,
       "relays": [
         {
           "address": "161.97.136.104",
@@ -135,8 +135,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.646430116415415,
-      "relativeStake": 0.02059166894251074,
+      "accumulatedStake": 0.6519918669309092,
+      "relativeStake": 0.020160034972703772,
       "relays": [
         {
           "domain": "adaboy-preprod-2b.gleeze.com",
@@ -149,8 +149,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.6656196006494456,
-      "relativeStake": 0.019189484234030593,
+      "accumulatedStake": 0.6702925851067342,
+      "relativeStake": 0.01830071817582501,
       "relays": [
         {
           "domain": "pp-relay1.apexpool.info",
@@ -159,8 +159,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.678507763392829,
-      "relativeStake": 0.012888162743383438,
+      "accumulatedStake": 0.682957867160957,
+      "relativeStake": 0.01266528205422279,
       "relays": [
         {
           "domain": "preprod1.volcyada.com",
@@ -177,8 +177,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.6902992979070546,
-      "relativeStake": 0.011791534514225516,
+      "accumulatedStake": 0.6942847313865597,
+      "relativeStake": 0.011326864225602664,
       "relays": [
         {
           "domain": "preprod.bladepool.com",
@@ -187,8 +187,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.7012403096117535,
-      "relativeStake": 0.010941011704698963,
+      "accumulatedStake": 0.7048909874819258,
+      "relativeStake": 0.010606256095366147,
       "relays": [
         {
           "address": "18.222.164.102",
@@ -197,8 +197,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.7101619749930198,
-      "relativeStake": 0.008921665381266273,
+      "accumulatedStake": 0.7135371887115215,
+      "relativeStake": 0.008646201229595694,
       "relays": [
         {
           "address": "66.42.94.80",
@@ -211,8 +211,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.7171279508231271,
-      "relativeStake": 0.006965975830107215,
+      "accumulatedStake": 0.7206273881535874,
+      "relativeStake": 0.007090199442065925,
       "relays": [
         {
           "domain": "preprod.canadastakes.ca",
@@ -221,8 +221,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.7234781629609087,
-      "relativeStake": 0.00635021213778168,
+      "accumulatedStake": 0.726808055743964,
+      "relativeStake": 0.006180667590376553,
       "relays": [
         {
           "domain": "dyn.derksen-it.nl",
@@ -231,8 +231,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.7293539630833031,
-      "relativeStake": 0.005875800122394464,
+      "accumulatedStake": 0.7325434186563786,
+      "relativeStake": 0.0057353629124146125,
       "relays": [
         {
           "address": "152.53.81.245",
@@ -245,18 +245,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.7350754686819322,
-      "relativeStake": 0.005721505598628982,
-      "relays": [
-        {
-          "domain": "r1.pp.mrbee.io",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.7407218526359054,
-      "relativeStake": 0.005646383953973195,
+      "accumulatedStake": 0.7380513417480142,
+      "relativeStake": 0.005507923091635681,
       "relays": [
         {
           "domain": "preprod-r1.panl.org",
@@ -265,8 +255,18 @@
       ]
     },
     {
-      "accumulatedStake": 0.7459144201140454,
-      "relativeStake": 0.005192567478140013,
+      "accumulatedStake": 0.7433914366756427,
+      "relativeStake": 0.005340094927628378,
+      "relays": [
+        {
+          "domain": "r1.pp.mrbee.io",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.7484239116819531,
+      "relativeStake": 0.0050324750063104814,
       "relays": [
         {
           "domain": "ppe-testnet-relay.cardanistas.io",
@@ -275,8 +275,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.7509738875486759,
-      "relativeStake": 0.005059467434630552,
+      "accumulatedStake": 0.753345726796064,
+      "relativeStake": 0.004921815114110899,
       "relays": [
         {
           "domain": "relay.preprod.cardanostakehouse.com",
@@ -285,8 +285,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.7559400219270189,
-      "relativeStake": 0.004966134378342979,
+      "accumulatedStake": 0.7581532223390403,
+      "relativeStake": 0.00480749554297618,
       "relays": [
         {
           "domain": "relay.preprod.cardanostakehouse.com",
@@ -295,8 +295,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.760831667422596,
-      "relativeStake": 0.004891645495577051,
+      "accumulatedStake": 0.7629186664855405,
+      "relativeStake": 0.004765444146500333,
       "relays": [
         {
           "domain": "relay.preprod.cardanostakehouse.com",
@@ -305,8 +305,18 @@
       ]
     },
     {
-      "accumulatedStake": 0.7654042367502121,
-      "relativeStake": 0.004572569327616108,
+      "accumulatedStake": 0.7676542151074482,
+      "relativeStake": 0.004735548621907704,
+      "relays": [
+        {
+          "domain": "preprod-relay1.angelstakepool.net",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.7721282117169683,
+      "relativeStake": 0.004473996609520027,
       "relays": [
         {
           "domain": "relay1.hunadapool.com",
@@ -315,8 +325,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.7699658182532771,
-      "relativeStake": 0.004561581503065034,
+      "accumulatedStake": 0.7766019986105356,
+      "relativeStake": 0.004473786893567261,
       "relays": [
         {
           "domain": "relay.preprod.cardanostakehouse.com",
@@ -325,8 +335,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.7743859767498054,
-      "relativeStake": 0.0044201584965282235,
+      "accumulatedStake": 0.7808856823533555,
+      "relativeStake": 0.004283683742820003,
       "relays": [
         {
           "domain": "relay.preprod.cardanostakehouse.com",
@@ -335,18 +345,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.7787555443485557,
-      "relativeStake": 0.004369567598750381,
-      "relays": [
-        {
-          "domain": "preprod-relay1.angelstakepool.net",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.7830821612331534,
-      "relativeStake": 0.00432661688459775,
+      "accumulatedStake": 0.785109591481584,
+      "relativeStake": 0.00422390912822841,
       "relays": [
         {
           "domain": "relay0-preprod.adanet.io",
@@ -355,48 +355,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.7871514532690176,
-      "relativeStake": 0.004069292035864096,
-      "relays": [
-        {
-          "domain": "d.fluxpool.cc",
-          "port": 3010
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.791143631524117,
-      "relativeStake": 0.003992178255099476,
-      "relays": [
-        {
-          "address": "168.138.37.117",
-          "port": 6003
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.7951124519058843,
-      "relativeStake": 0.003968820381767271,
-      "relays": [
-        {
-          "domain": "flightrelay1.intertreecryptoconsultants.com",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.7990266720258874,
-      "relativeStake": 0.003914220120003076,
-      "relays": [
-        {
-          "address": "204.216.213.96",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8028770464751227,
-      "relativeStake": 0.0038503744492353453,
+      "accumulatedStake": 0.7891840517703718,
+      "relativeStake": 0.004074460288787748,
       "relays": [
         {
           "domain": "test.smaug.pool.pm",
@@ -405,8 +365,58 @@
       ]
     },
     {
-      "accumulatedStake": 0.8064720985757856,
-      "relativeStake": 0.0035950521006629372,
+      "accumulatedStake": 0.7931546367694532,
+      "relativeStake": 0.003970584999081473,
+      "relays": [
+        {
+          "domain": "d.fluxpool.cc",
+          "port": 3010
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.7970531364683339,
+      "relativeStake": 0.003898499698880726,
+      "relays": [
+        {
+          "address": "168.138.37.117",
+          "port": 6003
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8009280284066148,
+      "relativeStake": 0.0038748919382808546,
+      "relays": [
+        {
+          "domain": "flightrelay1.intertreecryptoconsultants.com",
+          "port": 6000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8046404632818528,
+      "relativeStake": 0.0037124348752379855,
+      "relays": [
+        {
+          "address": "73.54.73.48",
+          "port": 7000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8083283748852769,
+      "relativeStake": 0.0036879116034240905,
+      "relays": [
+        {
+          "address": "204.216.213.96",
+          "port": 6000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8118206163985316,
+      "relativeStake": 0.003492241513254769,
       "relays": [
         {
           "domain": "pre-prod1.xstakepool.com",
@@ -415,8 +425,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.8100503941597809,
-      "relativeStake": 0.003578295583995228,
+      "accumulatedStake": 0.8153122485307568,
+      "relativeStake": 0.0034916321322252296,
       "relays": [
         {
           "domain": "relay1.preprod.stakepool.quebec",
@@ -425,38 +435,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.8135303677603413,
-      "relativeStake": 0.0034799736005604043,
-      "relays": [
-        {
-          "domain": "artemisrelay3.uk",
-          "port": 6001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8169669257456404,
-      "relativeStake": 0.003436557985299186,
-      "relays": [
-        {
-          "domain": "alpha.stake-cardano-pool.com",
-          "port": 7001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8203947913596863,
-      "relativeStake": 0.0034278656140458766,
-      "relays": [
-        {
-          "address": "62.169.19.81",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.823818217185264,
-      "relativeStake": 0.0034234258255776704,
+      "accumulatedStake": 0.81878636516623,
+      "relativeStake": 0.0034741166354732393,
       "relays": [
         {
           "domain": "preprod.altzpool.com",
@@ -465,8 +445,38 @@
       ]
     },
     {
-      "accumulatedStake": 0.8271984082901036,
-      "relativeStake": 0.003380191104839555,
+      "accumulatedStake": 0.8222340891696764,
+      "relativeStake": 0.0034477240034463882,
+      "relays": [
+        {
+          "domain": "preprod.frcan.com",
+          "port": 6011
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8256529625412552,
+      "relativeStake": 0.0034188733715787185,
+      "relays": [
+        {
+          "domain": "preprod.happystaking.io",
+          "port": 3002
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8290518427228897,
+      "relativeStake": 0.0033988801816345377,
+      "relays": [
+        {
+          "domain": "artemisrelay3.uk",
+          "port": 6001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8324379010760258,
+      "relativeStake": 0.00338605835313605,
       "relays": [
         {
           "domain": "gateway.adavault.com",
@@ -475,8 +485,28 @@
       ]
     },
     {
-      "accumulatedStake": 0.8305573808589437,
-      "relativeStake": 0.0033589725688401217,
+      "accumulatedStake": 0.8357923751638205,
+      "relativeStake": 0.00335447408779472,
+      "relays": [
+        {
+          "domain": "alpha.stake-cardano-pool.com",
+          "port": 7001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8391384584373763,
+      "relativeStake": 0.0033460832735558083,
+      "relays": [
+        {
+          "address": "62.169.19.81",
+          "port": 6000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8424195792360989,
+      "relativeStake": 0.003281120798722629,
       "relays": [
         {
           "domain": "preprod-relay1.angelstakepool.net",
@@ -485,8 +515,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.8339162017888296,
-      "relativeStake": 0.003358820929885991,
+      "accumulatedStake": 0.8456987142097943,
+      "relativeStake": 0.003279134973695313,
       "relays": [
         {
           "domain": "c-pp-rn01.liv.io",
@@ -499,28 +529,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.8372691664952203,
-      "relativeStake": 0.0033529647063905805,
-      "relays": [
-        {
-          "domain": "preprod.frcan.com",
-          "port": 6011
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8406201632560819,
-      "relativeStake": 0.003350996760861692,
-      "relays": [
-        {
-          "domain": "dear-colt-ada-lb-7b5456ef061920ec.elb.eu-west-2.amazonaws.com",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8439496968752879,
-      "relativeStake": 0.0033295336192059252,
+      "accumulatedStake": 0.8489473266875648,
+      "relativeStake": 0.00324861247777058,
       "relays": [
         {
           "address": "74.122.122.121",
@@ -529,8 +539,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.8472694189590014,
-      "relativeStake": 0.0033197220837135597,
+      "accumulatedStake": 0.8521884224549531,
+      "relativeStake": 0.003241095767388248,
       "relays": [
         {
           "domain": "preprod-relays.onyxstakepool.com",
@@ -539,8 +549,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.8505866925357513,
-      "relativeStake": 0.003317273576749818,
+      "accumulatedStake": 0.8554256679179087,
+      "relativeStake": 0.003237245462955633,
       "relays": [
         {
           "domain": "testicles.kiwipool.org",
@@ -549,8 +559,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.8538973491249633,
-      "relativeStake": 0.003310656589212031,
+      "accumulatedStake": 0.8586455523387605,
+      "relativeStake": 0.0032198844208518236,
       "relays": [
         {
           "domain": "preprod.leadstakepool.com",
@@ -563,28 +573,18 @@
       ]
     },
     {
-      "accumulatedStake": 0.8572044904448508,
-      "relativeStake": 0.003307141319887467,
+      "accumulatedStake": 0.8618642927370884,
+      "relativeStake": 0.003218740398327838,
       "relays": [
         {
-          "domain": "pprelay.adaocean.com",
+          "domain": "pp-relays.digitalfortress.online",
           "port": 6001
         }
       ]
     },
     {
-      "accumulatedStake": 0.8605077405111891,
-      "relativeStake": 0.0033032500663383395,
-      "relays": [
-        {
-          "domain": "preprod.happystaking.io",
-          "port": 3002
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.863805339568335,
-      "relativeStake": 0.0032975990571459564,
+      "accumulatedStake": 0.8650821837880777,
+      "relativeStake": 0.0032178910509893023,
       "relays": [
         {
           "domain": "preprod.weebl.me",
@@ -597,18 +597,18 @@
       ]
     },
     {
-      "accumulatedStake": 0.8671025289767259,
-      "relativeStake": 0.0032971894083908214,
+      "accumulatedStake": 0.8682975802951003,
+      "relativeStake": 0.003215396507022597,
       "relays": [
         {
-          "domain": "pp-relays.digitalfortress.online",
+          "domain": "pprelay.adaocean.com",
           "port": 6001
         }
       ]
     },
     {
-      "accumulatedStake": 0.8703844679212638,
-      "relativeStake": 0.0032819389445379295,
+      "accumulatedStake": 0.8714904649325429,
+      "relativeStake": 0.0031928846374425757,
       "relays": [
         {
           "domain": "031e6928.cardano-relay.bison.run",
@@ -617,8 +617,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.8735836163274464,
-      "relativeStake": 0.0031991484061825565,
+      "accumulatedStake": 0.8745908201673843,
+      "relativeStake": 0.00310035523484146,
       "relays": [
         {
           "address": "18.130.49.180",
@@ -627,8 +627,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.8767540287162557,
-      "relativeStake": 0.0031704123888093632,
+      "accumulatedStake": 0.8776865017342381,
+      "relativeStake": 0.00309568156685387,
       "relays": [
         {
           "domain": "cntr-1.services.evolute.software",
@@ -637,8 +637,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.8799225807510979,
-      "relativeStake": 0.003168552034842124,
+      "accumulatedStake": 0.8807484855731729,
+      "relativeStake": 0.003061983838934729,
       "relays": [
         {
           "address": "149.102.137.115",
@@ -647,18 +647,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.8830715740314964,
-      "relativeStake": 0.003148993280398576,
-      "relays": [
-        {
-          "address": "73.54.73.48",
-          "port": 7000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8862102383496224,
-      "relativeStake": 0.0031386643181260114,
+      "accumulatedStake": 0.883806743169464,
+      "relativeStake": 0.0030582575962910174,
       "relays": [
         {
           "domain": "r1.pp.cpoker.io",
@@ -667,18 +657,18 @@
       ]
     },
     {
-      "accumulatedStake": 0.8893459694144159,
-      "relativeStake": 0.003135731064793478,
+      "accumulatedStake": 0.8868586663088028,
+      "relativeStake": 0.003051923139338968,
       "relays": [
         {
-          "domain": "relay.preprod.crimsonpool.com",
-          "port": 3100
+          "domain": "dear-colt-ada-lb-7b5456ef061920ec.elb.eu-west-2.amazonaws.com",
+          "port": 3001
         }
       ]
     },
     {
-      "accumulatedStake": 0.8924449101082067,
-      "relativeStake": 0.0030989406937907585,
+      "accumulatedStake": 0.8899093884077273,
+      "relativeStake": 0.0030507220989243458,
       "relays": [
         {
           "domain": "adar-monitor.freeddns.org",
@@ -687,36 +677,46 @@
       ]
     },
     {
-      "accumulatedStake": 0.8954267822313788,
-      "relativeStake": 0.0029818721231721305,
+      "accumulatedStake": 0.8929448746060666,
+      "relativeStake": 0.00303548619833946,
       "relays": [
         {
-          "domain": "preprod.vampyre.fund",
-          "port": 3101
+          "domain": "relay.preprod.crimsonpool.com",
+          "port": 3100
         }
       ]
     },
     {
-      "accumulatedStake": 0.8984077403203513,
-      "relativeStake": 0.002980958088972508,
+      "accumulatedStake": 0.8959570703189368,
+      "relativeStake": 0.0030121957128700716,
       "relays": [
         {
-          "domain": "preprod1-node.play.dev.cardano.org",
+          "domain": "preprod.junglestakepool.com",
           "port": 3001
         }
       ]
     },
     {
-      "accumulatedStake": 0.9013874228299609,
-      "relativeStake": 0.00297968250960957,
+      "accumulatedStake": 0.898926583327013,
+      "relativeStake": 0.002969513008076275,
       "relays": [
         {
-          "domain": "preprod2-node.play.dev.cardano.org",
-          "port": 3001
+          "domain": "relay1.amapools.ir",
+          "port": 3002
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.9018427370371769,
+      "relativeStake": 0.002916153710163887,
+      "relays": [
+        {
+          "address": "0.0.0.0",
+          "port": 6000
         }
       ]
     }
   ],
-  "slotNo": 87963642,
+  "slotNo": 92095985,
   "version": 1
 }

--- a/cardano-lib/preview-config.nix
+++ b/cardano-lib/preview-config.nix
@@ -36,7 +36,7 @@ with builtins; {
   # file will need to be declared in the p2p topology file under key
   # `peerSnapshotFile`.  A `CheckpointsFile` and corresponding
   # `CheckpointsFileHash` is not required for preview.
-  ConsensusMode = "PraosMode";
+  ConsensusMode = "GenesisMode";
 
   # Default parameter values for "GenesisMode"
   SyncTargetNumberOfActivePeers = 0;

--- a/cardano-lib/preview-config.nix
+++ b/cardano-lib/preview-config.nix
@@ -22,7 +22,7 @@ with builtins; {
   EnableP2P = true;
   PeerSharing = true;
   TargetNumberOfActivePeers = 20;
-  TargetNumberOfEstablishedPeers = 40;
+  TargetNumberOfEstablishedPeers = 30;
   TargetNumberOfKnownPeers = 150;
   TargetNumberOfRootPeers = 60;
   ExperimentalHardForksEnabled = false;
@@ -41,7 +41,7 @@ with builtins; {
   # Default parameter values for "GenesisMode"
   SyncTargetNumberOfActivePeers = 0;
   SyncTargetNumberOfActiveBigLedgerPeers = 30;
-  SyncTargetNumberOfEstablishedBigLedgerPeers = 50;
+  SyncTargetNumberOfEstablishedBigLedgerPeers = 40;
   SyncTargetNumberOfKnownBigLedgerPeers = 100;
   MinBigLedgerPeersForTrustedState = 5;
 

--- a/cardano-lib/preview/peer-snapshot.json
+++ b/cardano-lib/preview/peer-snapshot.json
@@ -1,8 +1,8 @@
 {
   "bigLedgerPools": [
     {
-      "accumulatedStake": 0.0820701633060363,
-      "relativeStake": 0.0820701633060363,
+      "accumulatedStake": 0.07492932456992851,
+      "relativeStake": 0.07492932456992851,
       "relays": [
         {
           "domain": "node1.cardano.gratis",
@@ -19,8 +19,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.12989060678573627,
-      "relativeStake": 0.04782044347969997,
+      "accumulatedStake": 0.1208522016459698,
+      "relativeStake": 0.045922877076041285,
       "relays": [
         {
           "domain": "tn-preview.psilobyte.io",
@@ -33,8 +33,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.17531495868249733,
-      "relativeStake": 0.04542435189676106,
+      "accumulatedStake": 0.15688725295849512,
+      "relativeStake": 0.036035051312525324,
       "relays": [
         {
           "address": "132.145.71.219",
@@ -43,8 +43,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.210210120665389,
-      "relativeStake": 0.03489516198289166,
+      "accumulatedStake": 0.18894724786432468,
+      "relativeStake": 0.03205999490582955,
       "relays": [
         {
           "domain": "adaboy-preview-1c.gleeze.com",
@@ -57,8 +57,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.23382167971879314,
-      "relativeStake": 0.023611559053404167,
+      "accumulatedStake": 0.2139055377336676,
+      "relativeStake": 0.024958289869342926,
       "relays": [
         {
           "domain": "preview.world.bbhmm.net",
@@ -67,8 +67,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.2545382114821117,
-      "relativeStake": 0.020716531763318526,
+      "accumulatedStake": 0.23695586832364748,
+      "relativeStake": 0.02305033058997988,
       "relays": [
         {
           "domain": "preview1.volcyada.com",
@@ -85,8 +85,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.27305736059038704,
-      "relativeStake": 0.01851914910827539,
+      "accumulatedStake": 0.25887486973528806,
+      "relativeStake": 0.021919001411640573,
       "relays": [
         {
           "address": "73.222.122.247",
@@ -95,8 +95,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.29142886247582445,
-      "relativeStake": 0.018371501885437354,
+      "accumulatedStake": 0.279813719704277,
+      "relativeStake": 0.020938849968988916,
       "relays": [
         {
           "domain": "relay-m.fluxpool.cc",
@@ -105,18 +105,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.30973013133174093,
-      "relativeStake": 0.01830126885591652,
-      "relays": [
-        {
-          "address": "204.216.214.226",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.32790992848456146,
-      "relativeStake": 0.018179797152820504,
+      "accumulatedStake": 0.2995575638191148,
+      "relativeStake": 0.019743844114837837,
       "relays": [
         {
           "domain": "sully.crabdance.com",
@@ -125,8 +115,18 @@
       ]
     },
     {
-      "accumulatedStake": 0.3445901119435669,
-      "relativeStake": 0.016680183459005484,
+      "accumulatedStake": 0.3186323578767154,
+      "relativeStake": 0.019074794057600573,
+      "relays": [
+        {
+          "address": "204.216.214.226",
+          "port": 6000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.33494653669861274,
+      "relativeStake": 0.01631417882189736,
       "relays": [
         {
           "address": "161.97.167.41",
@@ -135,8 +135,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.35978898822952,
-      "relativeStake": 0.015198876285953034,
+      "accumulatedStake": 0.350630836983988,
+      "relativeStake": 0.015684300285375256,
       "relays": [
         {
           "address": "75.119.130.108",
@@ -145,8 +145,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.3741300980988669,
-      "relativeStake": 0.014341109869346901,
+      "accumulatedStake": 0.36612957142492975,
+      "relativeStake": 0.015498734440941752,
       "relays": [
         {
           "domain": "preview.leadstakepool.com",
@@ -159,18 +159,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.38811561299373687,
-      "relativeStake": 0.013985514894869981,
-      "relays": [
-        {
-          "domain": "1.tcp.au.ngrok.io",
-          "port": 25432
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.40195886956041216,
-      "relativeStake": 0.01384325656667532,
+      "accumulatedStake": 0.38119150244174455,
+      "relativeStake": 0.015061931016814793,
       "relays": [
         {
           "domain": "129.213.55.211",
@@ -179,28 +169,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.4150515473123398,
-      "relativeStake": 0.013092677751927613,
-      "relays": [
-        {
-          "address": "90.251.253.249",
-          "port": 3000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.4272027926110439,
-      "relativeStake": 0.012151245298704117,
-      "relays": [
-        {
-          "address": "82.208.22.91",
-          "port": 6003
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.4392972100702174,
-      "relativeStake": 0.012094417459173485,
+      "accumulatedStake": 0.3938627192166735,
+      "relativeStake": 0.012671216774928936,
       "relays": [
         {
           "domain": "relay1.preview.stakepool.quebec",
@@ -209,18 +179,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.45106603036634835,
-      "relativeStake": 0.011768820296130982,
-      "relays": [
-        {
-          "domain": "previewrelay.stakepoolcentral.com",
-          "port": 15654
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.4626359604880269,
-      "relativeStake": 0.01156993012167856,
+      "accumulatedStake": 0.4061490077106836,
+      "relativeStake": 0.012286288494010093,
       "relays": [
         {
           "domain": "relay.test.lidonation.com",
@@ -229,8 +189,38 @@
       ]
     },
     {
-      "accumulatedStake": 0.4737601992646555,
-      "relativeStake": 0.011124238776628563,
+      "accumulatedStake": 0.41813172377484736,
+      "relativeStake": 0.011982716064163809,
+      "relays": [
+        {
+          "address": "82.208.22.91",
+          "port": 6003
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.43001810991920003,
+      "relativeStake": 0.011886386144352667,
+      "relays": [
+        {
+          "domain": "previewrelay.stakepoolcentral.com",
+          "port": 15654
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.44176160099998774,
+      "relativeStake": 0.011743491080787666,
+      "relays": [
+        {
+          "domain": "preview-r1.panl.org",
+          "port": 3015
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.453462753304623,
+      "relativeStake": 0.011701152304635273,
       "relays": [
         {
           "domain": "preview.frcan.com",
@@ -239,8 +229,38 @@
       ]
     },
     {
-      "accumulatedStake": 0.48477762551833975,
-      "relativeStake": 0.01101742625368424,
+      "accumulatedStake": 0.4651111130565143,
+      "relativeStake": 0.011648359751891353,
+      "relays": [
+        {
+          "domain": "1.tcp.au.ngrok.io",
+          "port": 25432
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.4767416932396813,
+      "relativeStake": 0.011630580183166967,
+      "relays": [
+        {
+          "domain": "r1.pv.mrbee.io",
+          "port": 3101
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.48824857406801925,
+      "relativeStake": 0.01150688082833792,
+      "relays": [
+        {
+          "address": "90.251.253.249",
+          "port": 3000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.49956719035760133,
+      "relativeStake": 0.011318616289582096,
       "relays": [
         {
           "domain": "test.smaug.pool.pm",
@@ -249,22 +269,38 @@
       ]
     },
     {
-      "accumulatedStake": 0.4954954075946499,
-      "relativeStake": 0.01071778207631013,
+      "accumulatedStake": 0.5108845991894692,
+      "relativeStake": 0.011317408831867845,
       "relays": [
         {
-          "domain": "144.126.157.40",
-          "port": 3005
-        },
-        {
-          "domain": "144.126.157.40",
-          "port": 3006
+          "domain": "adar-monitor.freeddns.org",
+          "port": 3010
         }
       ]
     },
     {
-      "accumulatedStake": 0.5061011090972145,
-      "relativeStake": 0.010605701502564692,
+      "accumulatedStake": 0.5219747774918911,
+      "relativeStake": 0.011090178302421991,
+      "relays": [
+        {
+          "domain": "testnet.valhallapool.net",
+          "port": 3000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.5330605585563831,
+      "relativeStake": 0.011085781064491942,
+      "relays": [
+        {
+          "domain": "relay01.preview.junglestakepool.com",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.5440409432027381,
+      "relativeStake": 0.010980384646355049,
       "relays": [
         {
           "address": "73.54.73.48",
@@ -277,8 +313,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.5166094920564,
-      "relativeStake": 0.010508382959185504,
+      "accumulatedStake": 0.5546844318556722,
+      "relativeStake": 0.010643488652934055,
       "relays": [
         {
           "address": "207.180.211.199",
@@ -287,18 +323,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.5269805029596154,
-      "relativeStake": 0.010371010903215374,
-      "relays": [
-        {
-          "domain": "adar-monitor.freeddns.org",
-          "port": 3010
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.5371541088095884,
-      "relativeStake": 0.010173605849972957,
+      "accumulatedStake": 0.5650202742274457,
+      "relativeStake": 0.010335842371773532,
       "relays": [
         {
           "address": "142.132.229.15",
@@ -307,88 +333,22 @@
       ]
     },
     {
-      "accumulatedStake": 0.5472617317361752,
-      "relativeStake": 0.010107622926586858,
+      "accumulatedStake": 0.5751592434084407,
+      "relativeStake": 0.010138969180994991,
       "relays": [
         {
-          "domain": "preview.adastack.net",
-          "port": 3001
+          "domain": "144.126.157.40",
+          "port": 3005
+        },
+        {
+          "domain": "144.126.157.40",
+          "port": 3006
         }
       ]
     },
     {
-      "accumulatedStake": 0.5573411644763102,
-      "relativeStake": 0.010079432740135013,
-      "relays": [
-        {
-          "domain": "preview-r1.panl.org",
-          "port": 3015
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.5672348751025477,
-      "relativeStake": 0.009893710626237373,
-      "relays": [
-        {
-          "domain": "preview-testnet-relay.cardanistas.io",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.5771071974373011,
-      "relativeStake": 0.009872322334753452,
-      "relays": [
-        {
-          "domain": "testnet.valhallapool.net",
-          "port": 3000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.5867357380392444,
-      "relativeStake": 0.009628540601943255,
-      "relays": [
-        {
-          "domain": "relay01.preview.junglestakepool.com",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.596361390006102,
-      "relativeStake": 0.009625651966857624,
-      "relays": [
-        {
-          "address": "88.198.86.62",
-          "port": 4444
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.605876392470633,
-      "relativeStake": 0.009515002464531023,
-      "relays": [
-        {
-          "domain": "beta.stake-cardano-pool.com",
-          "port": 7002
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.6151980415303474,
-      "relativeStake": 0.009321649059714422,
-      "relays": [
-        {
-          "domain": "preview-node.world.dev.cardano.org",
-          "port": 30002
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.6245008714547821,
-      "relativeStake": 0.009302829924434602,
+      "accumulatedStake": 0.5852400905510023,
+      "relativeStake": 0.010080847142561643,
       "relays": [
         {
           "domain": "beadapool.ddns.net",
@@ -397,8 +357,38 @@
       ]
     },
     {
-      "accumulatedStake": 0.6337716727903856,
-      "relativeStake": 0.009270801335603611,
+      "accumulatedStake": 0.5953187478479806,
+      "relativeStake": 0.010078657296978143,
+      "relays": [
+        {
+          "domain": "preview-testnet-relay.cardanistas.io",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.6051898491665538,
+      "relativeStake": 0.009871101318573322,
+      "relays": [
+        {
+          "address": "88.198.86.62",
+          "port": 4444
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.6150003357630587,
+      "relativeStake": 0.009810486596504827,
+      "relays": [
+        {
+          "domain": "beta.stake-cardano-pool.com",
+          "port": 7002
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.6246770273218766,
+      "relativeStake": 0.009676691558817955,
       "relays": [
         {
           "domain": "relay1.afica.io",
@@ -407,8 +397,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.6429512245480681,
-      "relativeStake": 0.00917955175768248,
+      "accumulatedStake": 0.6342440198803942,
+      "relativeStake": 0.009566992558517645,
       "relays": [
         {
           "domain": "8.tcp.eu.ngrok.io",
@@ -417,8 +407,28 @@
       ]
     },
     {
-      "accumulatedStake": 0.6518578585805095,
-      "relativeStake": 0.008906634032441407,
+      "accumulatedStake": 0.6437970338724757,
+      "relativeStake": 0.009553013992081404,
+      "relays": [
+        {
+          "domain": "preview-node.world.dev.cardano.org",
+          "port": 30002
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.6531442264133044,
+      "relativeStake": 0.009347192540828698,
+      "relays": [
+        {
+          "address": "52.166.113.150",
+          "port": 6000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.6623298626917907,
+      "relativeStake": 0.009185636278486333,
       "relays": [
         {
           "domain": "preview.testnet.cryptobounty.org",
@@ -427,8 +437,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.660735094730109,
-      "relativeStake": 0.008877236149599527,
+      "accumulatedStake": 0.6714859618018869,
+      "relativeStake": 0.009156099110096247,
       "relays": [
         {
           "domain": "bbotest.duckdns.org",
@@ -441,8 +451,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.6695959881682709,
-      "relativeStake": 0.008860893438161897,
+      "accumulatedStake": 0.680615602669717,
+      "relativeStake": 0.009129640867830033,
       "relays": [
         {
           "domain": "adrelay.hawak.cloud",
@@ -451,28 +461,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.6784430192443144,
-      "relativeStake": 0.008847031076043427,
-      "relays": [
-        {
-          "address": "194.163.149.210",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.6872847449331583,
-      "relativeStake": 0.008841725688843964,
-      "relays": [
-        {
-          "address": "52.166.113.150",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.6960505533902002,
-      "relativeStake": 0.00876580845704188,
+      "accumulatedStake": 0.6896841589116366,
+      "relativeStake": 0.00906855624191961,
       "relays": [
         {
           "domain": "preview-testnet-relay.junostakepool.com",
@@ -485,8 +475,28 @@
       ]
     },
     {
-      "accumulatedStake": 0.7046470484380947,
-      "relativeStake": 0.00859649504789447,
+      "accumulatedStake": 0.6987082267420294,
+      "relativeStake": 0.009024067830392737,
+      "relays": [
+        {
+          "address": "194.163.149.210",
+          "port": 6000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.7077288587677396,
+      "relativeStake": 0.009020632025710277,
+      "relays": [
+        {
+          "domain": "preview.adastack.net",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.7166155563208372,
+      "relativeStake": 0.008886697553097522,
       "relays": [
         {
           "address": "128.140.96.209",
@@ -495,8 +505,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.7132138616695561,
-      "relativeStake": 0.008566813231461454,
+      "accumulatedStake": 0.7254909490777558,
+      "relativeStake": 0.00887539275691867,
       "relays": [
         {
           "domain": "esq.ddns.net",
@@ -509,8 +519,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.7217758278027888,
-      "relativeStake": 0.008561966133232722,
+      "accumulatedStake": 0.7343459170152995,
+      "relativeStake": 0.008854967937543728,
       "relays": [
         {
           "domain": "scarborough1.ddns.net",
@@ -527,8 +537,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.7303183807162953,
-      "relativeStake": 0.008542552913506482,
+      "accumulatedStake": 0.743183046883652,
+      "relativeStake": 0.00883712986835242,
       "relays": [
         {
           "domain": "alpha.relays.preview.mochipool.com",
@@ -537,8 +547,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.7388548202512225,
-      "relativeStake": 0.00853643953492719,
+      "accumulatedStake": 0.7520145594009607,
+      "relativeStake": 0.008831512517308753,
       "relays": [
         {
           "address": "5.161.75.212",
@@ -555,8 +565,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.7473552726553497,
-      "relativeStake": 0.008500452404127185,
+      "accumulatedStake": 0.7608130047126096,
+      "relativeStake": 0.008798445311648917,
       "relays": [
         {
           "address": "184.174.32.106",
@@ -565,8 +575,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.7558148357053845,
-      "relativeStake": 0.008459563050034834,
+      "accumulatedStake": 0.7695738783520798,
+      "relativeStake": 0.008760873639470219,
       "relays": [
         {
           "address": "194.60.201.143",
@@ -575,18 +585,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.7637965701199549,
-      "relativeStake": 0.00798173441457038,
-      "relays": [
-        {
-          "domain": "r1.pv.mrbee.io",
-          "port": 3101
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.7704680015578758,
-      "relativeStake": 0.006671431437920798,
+      "accumulatedStake": 0.7759782839694169,
+      "relativeStake": 0.006404405617337078,
       "relays": [
         {
           "address": "130.162.231.122",
@@ -595,18 +595,8 @@
       ]
     },
     {
-      "accumulatedStake": 0.7768608544056234,
-      "relativeStake": 0.006392852847747649,
-      "relays": [
-        {
-          "domain": "relay.preview.cardanostakehouse.com",
-          "port": 11000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.7830058055257566,
-      "relativeStake": 0.006144951120133221,
+      "accumulatedStake": 0.7819020942948828,
+      "relativeStake": 0.005923810325465886,
       "relays": [
         {
           "domain": "prv-relay1.apexpool.info",
@@ -615,38 +605,18 @@
       ]
     },
     {
-      "accumulatedStake": 0.7887943187564469,
-      "relativeStake": 0.005788513230690299,
+      "accumulatedStake": 0.7877762460324174,
+      "relativeStake": 0.005874151737534605,
       "relays": [
         {
-          "domain": "midnight-testnet.digitalfortress.online",
-          "port": 8001
+          "domain": "relay.preview.cardanostakehouse.com",
+          "port": 11000
         }
       ]
     },
     {
-      "accumulatedStake": 0.7937074027647479,
-      "relativeStake": 0.004913084008301075,
-      "relays": [
-        {
-          "domain": "preview.canadastakes.ca",
-          "port": 5002
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.7980714496079345,
-      "relativeStake": 0.004364046843186578,
-      "relays": [
-        {
-          "address": "194.60.201.143",
-          "port": 6001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8019901728269014,
-      "relativeStake": 0.003918723218966864,
+      "accumulatedStake": 0.7935772025276986,
+      "relativeStake": 0.0058009564952811845,
       "relays": [
         {
           "address": "198.13.63.94",
@@ -659,438 +629,28 @@
       ]
     },
     {
-      "accumulatedStake": 0.8057196010214365,
-      "relativeStake": 0.003729428194535047,
+      "accumulatedStake": 0.7986243718851926,
+      "relativeStake": 0.0050471693574940385,
       "relays": [
         {
-          "address": "18.219.254.123",
-          "port": 3001
+          "domain": "preview.canadastakes.ca",
+          "port": 5002
         }
       ]
     },
     {
-      "accumulatedStake": 0.8092948174576886,
-      "relativeStake": 0.0035752164362521524,
+      "accumulatedStake": 0.8029757679468225,
+      "relativeStake": 0.004351396061629847,
       "relays": [
         {
-          "domain": "testnet-relay.xstakepool.com",
-          "port": 3001
+          "address": "194.60.201.143",
+          "port": 6001
         }
       ]
     },
     {
-      "accumulatedStake": 0.8126366980777924,
-      "relativeStake": 0.0033418806201037745,
-      "relays": [
-        {
-          "domain": "topo-test.topopool.com",
-          "port": 3010
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8157806684732062,
-      "relativeStake": 0.0031439703954138547,
-      "relays": [
-        {
-          "domain": "preview-relays.onyxstakepool.com",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8188985818047745,
-      "relativeStake": 0.003117913331568277,
-      "relays": [
-        {
-          "domain": "preview.bladepool.com",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8219440956341025,
-      "relativeStake": 0.003045513829327968,
-      "relays": [
-        {
-          "domain": "test.stakepool.at",
-          "port": 9001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8248943891527739,
-      "relativeStake": 0.0029502935186714696,
-      "relays": [
-        {
-          "address": "69.128.162.203",
-          "port": 3000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8278267964886092,
-      "relativeStake": 0.0029324073358352356,
-      "relays": [
-        {
-          "domain": "ava1.sytes.net",
-          "port": 6010
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8306646909116712,
-      "relativeStake": 0.0028378944230619515,
-      "relays": [
-        {
-          "address": "0.0.0.0",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8334061057774829,
-      "relativeStake": 0.0027414148658117163,
-      "relays": [
-        {
-          "domain": "pn1.powerfulpools.com",
-          "port": 6030
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8360172272601899,
-      "relativeStake": 0.0026111214827070537,
-      "relays": [
-        {
-          "domain": "157.173.103.26",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8385754996455976,
-      "relativeStake": 0.002558272385407773,
-      "relays": [
-        {
-          "domain": "d8bdbfbe.cardano-relay.bison.run",
-          "port": 1338
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8411018147108861,
-      "relativeStake": 0.0025263150652883653,
-      "relays": [
-        {
-          "domain": "preview-test.ahlnet.nu",
-          "port": 2102
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8434604966632334,
-      "relativeStake": 0.0023586819523473235,
-      "relays": [
-        {
-          "domain": "previewrelay1.intertreecryptoconsultants.com",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8458152052897612,
-      "relativeStake": 0.0023547086265277833,
-      "relays": [
-        {
-          "domain": "1.tcp.ap.ngrok.io",
-          "port": 25317
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.848073622809319,
-      "relativeStake": 0.0022584175195578455,
-      "relays": [
-        {
-          "address": "2001:861:4000:2b80:216:3eff:fe05:9009",
-          "port": 6006
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8503288092029117,
-      "relativeStake": 0.0022551863935926083,
-      "relays": [
-        {
-          "domain": "pv-relays.digitalfortress.online",
-          "port": 8001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8523771788804605,
-      "relativeStake": 0.002048369677548913,
-      "relays": [
-        {
-          "domain": "spec2-staging.spirestaking2.com",
-          "port": 3006
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8543573699058132,
-      "relativeStake": 0.0019801910253527356,
-      "relays": [
-        {
-          "address": "95.216.173.194",
-          "port": 16000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.85631067163027,
-      "relativeStake": 0.0019533017244567448,
-      "relays": [
-        {
-          "address": "2001:861:4000:2b80:216:3eff:feb6:d700",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8582342230887304,
-      "relativeStake": 0.001923551458460416,
-      "relays": [
-        {
-          "address": "168.138.37.117",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8601477871460929,
-      "relativeStake": 0.0019135640573624433,
-      "relays": [
-        {
-          "address": "88.198.86.61",
-          "port": 8888
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8620520876850574,
-      "relativeStake": 0.001904300538964514,
-      "relays": [
-        {
-          "domain": "preview.ada.chicando.net",
-          "port": 3002
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8639182650933709,
-      "relativeStake": 0.001866177408313493,
-      "relays": [
-        {
-          "domain": "hcm07xw90vx.sn.mynetname.net",
-          "port": 7000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8657815912026829,
-      "relativeStake": 0.0018633261093120661,
-      "relays": [
-        {
-          "address": "65.21.198.152",
-          "port": 3003
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8676382367319643,
-      "relativeStake": 0.001856645529281337,
-      "relays": [
-        {
-          "domain": "spec1-staging.spirestaking2.com",
-          "port": 3005
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.869490253507229,
-      "relativeStake": 0.0018520167752646623,
-      "relays": [
-        {
-          "domain": "f7ca89d1.cardano-relay.stagebison.net",
-          "port": 1338
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8713202989875742,
-      "relativeStake": 0.001830045480345298,
-      "relays": [
-        {
-          "domain": "relay.preview.crimsonpool.com",
-          "port": 3000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8731400016855072,
-      "relativeStake": 0.0018197026979329554,
-      "relays": [
-        {
-          "domain": "preview1-node.play.dev.cardano.org",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8749328282582854,
-      "relativeStake": 0.001792826572778303,
-      "relays": [
-        {
-          "domain": "testicles.kiwipool.org",
-          "port": 9720
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8767113289240224,
-      "relativeStake": 0.0017785006657368705,
-      "relays": [
-        {
-          "address": "185.43.205.110",
-          "port": 3003
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8784877255230046,
-      "relativeStake": 0.0017763965989822344,
-      "relays": [
-        {
-          "address": "51.77.24.220",
-          "port": 4003
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8802635706420974,
-      "relativeStake": 0.0017758451190927628,
-      "relays": [
-        {
-          "address": "152.53.108.208",
-          "port": 8081
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.882026211684637,
-      "relativeStake": 0.0017626410425396774,
-      "relays": [
-        {
-          "domain": "pv-relays.digitalfortress.online",
-          "port": 8001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8837802651122221,
-      "relativeStake": 0.0017540534275850338,
-      "relays": [
-        {
-          "domain": "pv-relays.digitalfortress.online",
-          "port": 8001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8855212558932251,
-      "relativeStake": 0.0017409907810030378,
-      "relays": [
-        {
-          "domain": "preview.happystaking.io",
-          "port": 3003
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8872529948528243,
-      "relativeStake": 0.0017317389595991233,
-      "relays": [
-        {
-          "domain": "preview2-node.play.dev.cardano.org",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.888976768899246,
-      "relativeStake": 0.001723774046421786,
-      "relays": [
-        {
-          "domain": "test.paradoxicalsphere.com",
-          "port": 6080
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8906980587790464,
-      "relativeStake": 0.001721289879800416,
-      "relays": [
-        {
-          "domain": "preview3-node.play.dev.cardano.org",
-          "port": 3001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8923845114262364,
-      "relativeStake": 0.0016864526471900435,
-      "relays": [
-        {
-          "address": "217.180.194.220",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8940073128288271,
-      "relativeStake": 0.0016228014025906146,
-      "relays": [
-        {
-          "domain": "pr.adaloop.org",
-          "port": 4001
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8955925080436528,
-      "relativeStake": 0.0015851952148256303,
-      "relays": [
-        {
-          "domain": "preview.cr0ss0ver.com",
-          "port": 5000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8971590229387262,
-      "relativeStake": 0.0015665148950734667,
-      "relays": [
-        {
-          "address": "67.250.33.227",
-          "port": 6000
-        }
-      ]
-    },
-    {
-      "accumulatedStake": 0.8987096352720919,
-      "relativeStake": 0.001550612333365714,
+      "accumulatedStake": 0.8069822453953475,
+      "relativeStake": 0.004006477448524997,
       "relays": [
         {
           "address": "152.53.38.172",
@@ -1099,16 +659,456 @@
       ]
     },
     {
-      "accumulatedStake": 0.9002491762452564,
-      "relativeStake": 0.0015395409731644807,
+      "accumulatedStake": 0.8104090449238213,
+      "relativeStake": 0.003426799528473807,
       "relays": [
         {
-          "address": "173.67.34.66",
+          "address": "18.219.254.123",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8136855458249613,
+      "relativeStake": 0.0032765009011400826,
+      "relays": [
+        {
+          "address": "0.0.0.0",
+          "port": 6000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8169449258680095,
+      "relativeStake": 0.003259380043048116,
+      "relays": [
+        {
+          "domain": "testnet-relay.xstakepool.com",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8200901707245438,
+      "relativeStake": 0.00314524485653437,
+      "relays": [
+        {
+          "domain": "topo-test.topopool.com",
+          "port": 3010
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8230415225591622,
+      "relativeStake": 0.0029513518346183545,
+      "relays": [
+        {
+          "domain": "preview-relays.onyxstakepool.com",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8259077097820545,
+      "relativeStake": 0.002866187222892296,
+      "relays": [
+        {
+          "domain": "preview1-node.play.dev.cardano.org",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8287712571737214,
+      "relativeStake": 0.002863547391666878,
+      "relays": [
+        {
+          "domain": "preview.bladepool.com",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.831621464793674,
+      "relativeStake": 0.0028502076199526543,
+      "relays": [
+        {
+          "domain": "test.stakepool.at",
+          "port": 9001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8343965224822566,
+      "relativeStake": 0.002775057688582618,
+      "relays": [
+        {
+          "address": "69.128.162.203",
+          "port": 3000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8371293038490271,
+      "relativeStake": 0.0027327813667703837,
+      "relays": [
+        {
+          "domain": "ava1.sytes.net",
+          "port": 6010
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8396838110067741,
+      "relativeStake": 0.0025545071577470903,
+      "relays": [
+        {
+          "domain": "pn1.powerfulpools.com",
+          "port": 6030
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8421062463768475,
+      "relativeStake": 0.0024224353700733753,
+      "relays": [
+        {
+          "domain": "157.173.103.26",
+          "port": 6000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8445074920465109,
+      "relativeStake": 0.002401245669663414,
+      "relays": [
+        {
+          "domain": "d8bdbfbe.cardano-relay.bison.run",
+          "port": 1338
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8468284520228323,
+      "relativeStake": 0.0023209599763213845,
+      "relays": [
+        {
+          "domain": "preview-test.ahlnet.nu",
+          "port": 2102
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8490528613567806,
+      "relativeStake": 0.002224409333948284,
+      "relays": [
+        {
+          "domain": "previewrelay1.intertreecryptoconsultants.com",
+          "port": 6000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8512165135483128,
+      "relativeStake": 0.002163652191532217,
+      "relays": [
+        {
+          "domain": "1.tcp.ap.ngrok.io",
+          "port": 25317
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8533793128994388,
+      "relativeStake": 0.0021627993511260163,
+      "relays": [
+        {
+          "address": "2001:861:4000:2b80:216:3eff:feb6:d700",
+          "port": 6000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8555077656452508,
+      "relativeStake": 0.002128452745811908,
+      "relays": [
+        {
+          "address": "2001:861:4000:2b80:216:3eff:fe05:9009",
+          "port": 6006
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8575869423816379,
+      "relativeStake": 0.002079176736387211,
+      "relays": [
+        {
+          "domain": "pv-relays.digitalfortress.online",
+          "port": 8001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8595479913610198,
+      "relativeStake": 0.0019610489793818937,
+      "relays": [
+        {
+          "domain": "relay0-testnet.zeropercentstaking.com",
+          "port": 6000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8614747414292194,
+      "relativeStake": 0.0019267500681996567,
+      "relays": [
+        {
+          "domain": "spec2-staging.spirestaking2.com",
+          "port": 3006
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8633494101801545,
+      "relativeStake": 0.0018746687509350452,
+      "relays": [
+        {
+          "address": "95.216.173.194",
+          "port": 16000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8651608932725234,
+      "relativeStake": 0.0018114830923688836,
+      "relays": [
+        {
+          "address": "88.198.86.61",
+          "port": 8888
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8669606166774921,
+      "relativeStake": 0.001799723404968765,
+      "relays": [
+        {
+          "address": "168.138.37.117",
+          "port": 6000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8687125701175084,
+      "relativeStake": 0.0017519534400161603,
+      "relays": [
+        {
+          "address": "65.21.198.152",
+          "port": 3003
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8704588152571907,
+      "relativeStake": 0.0017462451396823857,
+      "relays": [
+        {
+          "domain": "spec1-staging.spirestaking2.com",
+          "port": 3005
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8721983074638494,
+      "relativeStake": 0.0017394922066586449,
+      "relays": [
+        {
+          "domain": "f7ca89d1.cardano-relay.stagebison.net",
+          "port": 1338
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8739203448121099,
+      "relativeStake": 0.0017220373482605066,
+      "relays": [
+        {
+          "domain": "relay.preview.crimsonpool.com",
+          "port": 3000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8756061003072625,
+      "relativeStake": 0.0016857554951525912,
+      "relays": [
+        {
+          "domain": "testicles.kiwipool.org",
+          "port": 9720
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.877277701725191,
+      "relativeStake": 0.0016716014179285316,
+      "relays": [
+        {
+          "address": "152.53.108.208",
+          "port": 8081
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8789475866048305,
+      "relativeStake": 0.001669884879639547,
+      "relays": [
+        {
+          "domain": "preview.ada.chicando.net",
+          "port": 3002
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8806114119511061,
+      "relativeStake": 0.0016638253462755539,
+      "relays": [
+        {
+          "address": "51.77.24.220",
+          "port": 4003
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8822666226558188,
+      "relativeStake": 0.0016552107047127177,
+      "relays": [
+        {
+          "domain": "pv-relays.digitalfortress.online",
+          "port": 8001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8839189824975974,
+      "relativeStake": 0.0016523598417785281,
+      "relays": [
+        {
+          "address": "185.43.205.110",
+          "port": 3003
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8855650825423037,
+      "relativeStake": 0.0016461000447063152,
+      "relays": [
+        {
+          "domain": "pv-relays.digitalfortress.online",
+          "port": 8001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8871991853263814,
+      "relativeStake": 0.0016341027840777863,
+      "relays": [
+        {
+          "domain": "preview.happystaking.io",
+          "port": 3003
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.888827468799047,
+      "relativeStake": 0.0016282834726654958,
+      "relays": [
+        {
+          "domain": "preview2-node.play.dev.cardano.org",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8904466258087084,
+      "relativeStake": 0.0016191570096614337,
+      "relays": [
+        {
+          "domain": "preview3-node.play.dev.cardano.org",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8920297528765653,
+      "relativeStake": 0.0015831270678569557,
+      "relays": [
+        {
+          "address": "217.180.194.220",
+          "port": 6000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8935831835041603,
+      "relativeStake": 0.0015534306275949645,
+      "relays": [
+        {
+          "domain": "preview.relays.liqwid.finance",
+          "port": 3001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8951129383834835,
+      "relativeStake": 0.0015297548793231995,
+      "relays": [
+        {
+          "domain": "pr.adaloop.org",
+          "port": 4001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8966190633410985,
+      "relativeStake": 0.0015061249576150688,
+      "relays": [
+        {
+          "domain": "hcm07xw90vx.sn.mynetname.net",
+          "port": 7000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.8981043106575523,
+      "relativeStake": 0.0014852473164537272,
+      "relays": [
+        {
+          "domain": "midnight-testnet.digitalfortress.online",
+          "port": 8001
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.899580599892866,
+      "relativeStake": 0.0014762892353137368,
+      "relays": [
+        {
+          "domain": "preview.cr0ss0ver.com",
+          "port": 5000
+        }
+      ]
+    },
+    {
+      "accumulatedStake": 0.9010249706209849,
+      "relativeStake": 0.0014443707281188234,
+      "relays": [
+        {
+          "address": "67.250.33.227",
           "port": 6000
         }
       ]
     }
   ],
-  "slotNo": 76990859,
+  "slotNo": 81122692,
   "version": 1
 }


### PR DESCRIPTION
* Set `GenesisMode` for `ConsensusMode` as default on preview and preprod
* Tune `TargetNumberOfEstablishedPeers`, `SyncTargetNumberOfEstablishedBigLedgerPeers`  per network team request
* Update peer-snapshots per environment
* Update useLedgerAfterSlot per environment