### PR TITLE
Tune the QueryBatchSize LedgerDB param

### DIFF
--- a/cardano-lib/mainnet-config.nix
+++ b/cardano-lib/mainnet-config.nix
@@ -62,7 +62,7 @@ with builtins; {
 
     # When querying the store for a big range of UTxOs (such as with
     # QueryUTxOByAddress), the store will be read in batches of this size.
-    QueryBatchSize = 100;
+    QueryBatchSize = 100000;
 
     # The backend can either be in memory with `V2InMemory` or on disk with
     # `V1LMDB`.

--- a/cardano-lib/preprod-config.nix
+++ b/cardano-lib/preprod-config.nix
@@ -57,7 +57,7 @@ with builtins; {
 
     # When querying the store for a big range of UTxOs (such as with
     # QueryUTxOByAddress), the store will be read in batches of this size.
-    QueryBatchSize = 100;
+    QueryBatchSize = 100000;
 
     # The backend can either be in memory with `V2InMemory` or on disk with
     # `V1LMDB`.

--- a/cardano-lib/preview-config.nix
+++ b/cardano-lib/preview-config.nix
@@ -57,7 +57,7 @@ with builtins; {
 
     # When querying the store for a big range of UTxOs (such as with
     # QueryUTxOByAddress), the store will be read in batches of this size.
-    QueryBatchSize = 100;
+    QueryBatchSize = 100000;
 
     # The backend can either be in memory with `V2InMemory` or on disk with
     # `V1LMDB`.

--- a/cardano-lib/testnet-template/config.json
+++ b/cardano-lib/testnet-template/config.json
@@ -11,7 +11,7 @@
   "LedgerDB": {
     "Backend": "V2InMemory",
     "NumOfDiskSnapshots": 2,
-    "QueryBatchSize": 100,
+    "QueryBatchSize": 100000,
     "SnapshotInterval": 216
   },
   "MaxConcurrencyDeadline": 4,


### PR DESCRIPTION
* Adjust `QueryBatchSize` declared default from 100 to 100000 to match the [Consensus UTXO HD Migration Guide](https://ouroboros-consensus.cardano.intersectmbo.org/docs/for-developers/utxo-hd/migrating/#populate-the-new-configuration-options)