### PR TITLE
Make libsodium-vrf and secp256k1 .version match .pc file

### DIFF
--- a/overlays/crypto/libsecp256k1.nix
+++ b/overlays/crypto/libsecp256k1.nix
@@ -3,7 +3,7 @@
 
 stdenv.mkDerivation rec {
   pname = "secp256k1";
-  version = src.shortRev;
+  version = "0.3.2";
 
   inherit src;
 
@@ -17,6 +17,20 @@ stdenv.mkDerivation rec {
   ];
 
   doCheck = true;
+
+  # Verify .pc version matches derivation version
+  preCheck = ''
+    pc_file="libsecp256k1.pc"
+    if [ ! -f "$pc_file" ]; then
+      echo "ERROR: pkg-config file not found: $pc_file"
+      exit 1
+    fi
+    pc_version=$(sed -n 's/^Version: *//p' "$pc_file")
+    if [ "$pc_version" != "${version}" ]; then
+      echo "ERROR: Version mismatch: derivation has ${version}, but .pc file has $pc_version"
+      exit 1
+    fi
+  '';
 
   meta = with lib; {
     description = "Optimized C library for EC operations on curve secp256k1";

--- a/overlays/crypto/libsodium.nix
+++ b/overlays/crypto/libsodium.nix
@@ -2,7 +2,7 @@
 
 stdenv.mkDerivation rec {
   pname = "libsodium-vrf";
-  version = src.shortRev;
+  version = "1.0.18";
 
   inherit src;
 
@@ -20,6 +20,20 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   doCheck = true;
+
+  # Verify .pc version matches derivation version
+  preCheck = ''
+    pc_file="libsodium.pc"
+    if [ ! -f "$pc_file" ]; then
+      echo "ERROR: pkg-config file not found: $pc_file"
+      exit 1
+    fi
+    pc_version=$(sed -n 's/^Version: *//p' "$pc_file")
+    if [ "$pc_version" != "${version}" ]; then
+      echo "ERROR: Version mismatch: derivation has ${version}, but .pc file has $pc_version"
+      exit 1
+    fi
+  '';
 
   meta = with lib; {
     description = "A modern and easy-to-use crypto library - VRF fork";


### PR DESCRIPTION
Haskell.nix expects the derivations `.version` and the version in the `.pc` file to match.

This is a follow up to #603