### PR TITLE
Fix darwin code signatures in setGitRev using darwin.signingUtils

### DIFF
--- a/overlays/haskell-nix-extra/default.nix
+++ b/overlays/haskell-nix-extra/default.nix
@@ -55,7 +55,8 @@ in final: prev: with final; with lib; {
         passthru = drv.passthru // (optionalAttrs (drv.passthru ? exeName) {
           exePath = newdrv + "/bin/${drv.passthru.exeName}";
         });
-      } ''
+        nativeBuildInputs = optionals stdenv.hostPlatform.isDarwin [ darwin.signingUtils ];
+      } (''
           mkdir -p $out
           # We link rather than copy from original, to save some space/time:
           ln -s ${drv}/* $out/
@@ -66,7 +67,11 @@ in final: prev: with final; with lib; {
           cp --no-preserve=timestamps --recursive ${drv}/bin/*${stdenv.hostPlatform.extensions.executable} $out/bin/
           chmod -R +w $out/bin/*${stdenv.hostPlatform.extensions.executable}
           ${pkgsBuildBuild.haskellBuildUtils}/bin/set-git-rev "${gitrev}" $out/bin/*${stdenv.hostPlatform.extensions.executable}
-        '';
+        '' + optionalString stdenv.hostPlatform.isDarwin ''
+          for exe in $out/bin/*${stdenv.hostPlatform.extensions.executable}; do
+            signIfRequired "$exe"
+          done
+        '');
       in drv // newdrv;
 
   # Stamp executables from multiple derivations, identified by path in the attribute set

--- a/overlays/haskell-nix-extra/default.nix
+++ b/overlays/haskell-nix-extra/default.nix
@@ -55,7 +55,7 @@ in final: prev: with final; with lib; {
         passthru = drv.passthru // (optionalAttrs (drv.passthru ? exeName) {
           exePath = newdrv + "/bin/${drv.passthru.exeName}";
         });
-        nativeBuildInputs = optionals stdenv.hostPlatform.isDarwin [ darwin.signingUtils ];
+        nativeBuildInputs = optionals stdenv.hostPlatform.isDarwin [ buildPackages.darwin.signingUtils ];
       } (''
           mkdir -p $out
           # We link rather than copy from original, to save some space/time:


### PR DESCRIPTION
## Summary

- The `setGitRev` function uses `set-git-rev` to patch binary content in Haskell executables, embedding git revision hashes.
- On aarch64-darwin (Apple Silicon), this binary patching invalidates the ad-hoc code signature that the linker originally created. Apple Silicon requires all executables to have valid code signatures -- without re-signing, the patched binary is killed on launch.
- This PR uses `darwin.signingUtils` and its `signIfRequired` wrapper (matching the pattern from cardano-node's `nix/set-git-rev.nix`) to properly re-sign executables after patching on darwin platforms.

## Changes

In `overlays/haskell-nix-extra/default.nix`:

1. Added `nativeBuildInputs = optionals stdenv.hostPlatform.isDarwin [ buildPackages.darwin.signingUtils ];` to bring `signIfRequired` into scope (sourced from `buildPackages` to match the `buildPackages.runCommand` context and support cross-compilation).
2. Added a post-patching loop that calls `signIfRequired` on each executable to re-sign after `set-git-rev` invalidates the original code signature.

This is preferable to a raw `/usr/bin/codesign` call because `darwin.signingUtils` handles signing correctly within the Nix sandbox and supports both ad-hoc and identity-based signing as needed by the nixpkgs infrastructure.

## Test plan

- [ ] Build a Haskell package that uses `setGitRev` on aarch64-darwin and verify the resulting executable runs without code signature errors
- [ ] Verify the fix is a no-op on linux (no codesign invocation, no `darwin.signingUtils` in `nativeBuildInputs`)