### PR TITLE
Set experimental HF networks false until PV11 for node `11.0.0`

### DIFF
--- a/cardano-lib/dijkstra-config.nix
+++ b/cardano-lib/dijkstra-config.nix
@@ -22,7 +22,9 @@ with builtins; {
 
   RequiresNetworkMagic = "RequiresMagic";
 
-  ExperimentalHardForksEnabled = true;
+  # For node 11.0.0, set false until the network is forked to PV11
+  ExperimentalHardForksEnabled = false;
+
   ExperimentalProtocolsEnabled = true;
   TestShelleyHardForkAtEpoch = 0;
   TestAllegraHardForkAtEpoch = 0;

--- a/cardano-lib/sanchonet-config.nix
+++ b/cardano-lib/sanchonet-config.nix
@@ -22,7 +22,9 @@ with builtins; {
 
   RequiresNetworkMagic = "RequiresMagic";
 
-  ExperimentalHardForksEnabled = true;
+  # For node 11.0.0, set false until the network is forked to PV11
+  ExperimentalHardForksEnabled = false;
+
   ExperimentalProtocolsEnabled = true;
   TestShelleyHardForkAtEpoch = 0;
   TestAllegraHardForkAtEpoch = 0;

--- a/cardano-lib/testnet-template/config-legacy.json
+++ b/cardano-lib/testnet-template/config-legacy.json
@@ -5,7 +5,7 @@
   "ByronGenesisFile": "byron-genesis.json",
   "ConwayGenesisFile": "conway-genesis.json",
   "DijkstraGenesisFile": "dijkstra-genesis.json",
-  "ExperimentalHardForksEnabled": true,
+  "ExperimentalHardForksEnabled": false,
   "ExperimentalProtocolsEnabled": true,
   "LastKnownBlockVersion-Alt": 0,
   "LastKnownBlockVersion-Major": 3,

--- a/cardano-lib/testnet-template/config.json
+++ b/cardano-lib/testnet-template/config.json
@@ -6,7 +6,7 @@
   "ConsensusMode": "PraosMode",
   "ConwayGenesisFile": "conway-genesis.json",
   "DijkstraGenesisFile": "dijkstra-genesis.json",
-  "ExperimentalHardForksEnabled": true,
+  "ExperimentalHardForksEnabled": false,
   "ExperimentalProtocolsEnabled": true,
   "LastKnownBlockVersion-Alt": 0,
   "LastKnownBlockVersion-Major": 3,


### PR DESCRIPTION
* For networks using `ExperimentalHardFork` `true`, set this to `false` for node `11.0.0` until forked to `PV11` for compatibility with older node versions.