### PR TITLE
Update PraosMode bootstrap peer list for mainnet

### DIFF
--- a/cardano-lib/default.nix
+++ b/cardano-lib/default.nix
@@ -147,10 +147,6 @@ let
           addr = "backbone.mainnet.cardanofoundation.org";
           port = 3001;
         }
-        {
-          addr = "backbone.mainnet.emurgornd.com";
-          port = 3001;
-        }
       ];
       edgePort = 3001;
       confKey = "mainnet_full";


### PR DESCRIPTION
Removes the Emurgo bootstrap entry from the PraosMode bootstrap peer list for mainnet environment. 